### PR TITLE
Replace mapbox geolocate API with custom geolocation service

### DIFF
--- a/web/src/components/map/Map.vue
+++ b/web/src/components/map/Map.vue
@@ -224,11 +224,6 @@ watch(
   display: none !important;
 }
 
-.mapboxgl-ctrl-geolocate,
-.mapboxgl-ctrl:has(.mapboxgl-ctrl-geolocate) {
-  display: none !important;
-}
-
 .mapboxgl-ctrl-attrib,
 .maplibregl-ctrl-attrib {
   display: none !important;

--- a/web/src/components/map/UserLocationMarker.vue
+++ b/web/src/components/map/UserLocationMarker.vue
@@ -1,0 +1,105 @@
+<script setup lang="ts">
+interface Props {
+  accuracy: number | null
+  heading: number | null
+  mode?: 'dot' | 'navigation'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  mode: 'dot',
+})
+</script>
+
+<template>
+  <div
+    class="user-location-marker"
+    :class="{ 'navigation-mode': props.mode === 'navigation' }"
+  >
+    <!-- Accuracy pulse ring (dot mode only) -->
+    <div v-if="props.mode === 'dot'" class="accuracy-ring" />
+
+    <!-- Blue dot (dot mode) -->
+    <div v-if="props.mode === 'dot'" class="location-dot" />
+
+    <!-- Navigation arrow (navigation mode) -->
+    <div
+      v-if="props.mode === 'navigation'"
+      class="navigation-arrow"
+      :style="{ transform: `rotate(${props.heading ?? 0}deg)` }"
+    >
+      <svg
+        width="40"
+        height="40"
+        viewBox="0 0 40 40"
+        fill="none"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <!-- Directional chevron / arrow -->
+        <path
+          d="M20 4L32 28L20 22L8 28L20 4Z"
+          fill="hsl(var(--primary))"
+          stroke="white"
+          stroke-width="2"
+          stroke-linejoin="round"
+        />
+      </svg>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.user-location-marker {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+}
+
+.location-dot {
+  position: relative;
+  z-index: 2;
+  width: 14px;
+  height: 14px;
+  border-radius: 50%;
+  background: hsl(var(--primary));
+  border: 2.5px solid white;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
+  transition: transform 0.3s ease;
+}
+
+.accuracy-ring {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: hsl(var(--primary) / 0.2);
+  animation: pulse 2.5s ease-out infinite;
+  z-index: 1;
+}
+
+.navigation-arrow {
+  z-index: 2;
+  transition: transform 0.3s ease;
+  filter: drop-shadow(0 1px 3px rgba(0, 0, 0, 0.3));
+}
+
+@keyframes pulse {
+  0% {
+    transform: translate(-50%, -50%) scale(0.8);
+    opacity: 0.6;
+  }
+  70% {
+    transform: translate(-50%, -50%) scale(1.6);
+    opacity: 0;
+  }
+  100% {
+    transform: translate(-50%, -50%) scale(1.6);
+    opacity: 0;
+  }
+}
+</style>

--- a/web/src/components/map/controls/LocateControl.vue
+++ b/web/src/components/map/controls/LocateControl.vue
@@ -2,17 +2,24 @@
 import { computed } from 'vue'
 import { storeToRefs } from 'pinia'
 import { Button } from '@/components/ui/button'
-import { Locate } from 'lucide-vue-next'
+import { Locate, LocateOff, Loader2 } from 'lucide-vue-next'
 import { useMapService } from '@/services/map.service'
 import { useMapStore } from '@/stores/map.store'
+import { useGeolocationService } from '@/services/geolocation.service'
 import { ControlVisibility } from '@/types/map.types'
 
 const mapService = useMapService()
 const mapStore = useMapStore()
+const geolocation = useGeolocationService()
 const { controlSettings } = storeToRefs(mapStore)
 
 const isVisible = computed(() => {
   return controlSettings.value.locate === ControlVisibility.ALWAYS
+})
+
+const isDenied = computed(() => geolocation.permissionState.value === 'denied')
+const isWaiting = computed(() => {
+  return geolocation.permissionState.value === 'prompt' && !geolocation.hasLocation.value
 })
 </script>
 
@@ -22,9 +29,12 @@ const isVisible = computed(() => {
       variant="default"
       size="icon-sm"
       class="rounded-md size-11"
+      :disabled="isDenied"
       @click="mapService.locate()"
     >
-      <Locate class="size-5" strokeWidth="2" />
+      <LocateOff v-if="isDenied" class="size-5" strokeWidth="2" />
+      <Loader2 v-else-if="isWaiting" class="size-5 animate-spin" strokeWidth="2" />
+      <Locate v-else class="size-5" strokeWidth="2" />
     </Button>
   </div>
 </template>

--- a/web/src/components/map/layers/user-location-layer.ts
+++ b/web/src/components/map/layers/user-location-layer.ts
@@ -1,0 +1,39 @@
+/**
+ * User Location Marker Layer
+ *
+ * Displays the current user's location on the map using the centralized
+ * geolocation service. Automatically syncs with geolocation state.
+ */
+
+import { BaseMarkerLayer, type MarkerData } from './base-marker-layer'
+import { useGeolocationService } from '@/services/geolocation.service'
+import UserLocationMarker from '@/components/map/UserLocationMarker.vue'
+
+export class UserLocationLayer extends BaseMarkerLayer {
+  private geolocation = useGeolocationService()
+
+  constructor() {
+    super({
+      idPrefix: 'user-location-',
+      component: UserLocationMarker,
+      zIndex: 0, // Below friend markers
+    })
+  }
+
+  protected getData(): MarkerData[] {
+    const lngLat = this.geolocation.lngLat.value
+    if (!lngLat) return []
+
+    return [
+      {
+        id: 'self',
+        lngLat,
+        props: {
+          accuracy: this.geolocation.accuracy.value,
+          heading: this.geolocation.heading.value,
+          mode: 'dot',
+        },
+      },
+    ]
+  }
+}

--- a/web/src/components/map/map-providers/map.strategy.ts
+++ b/web/src/components/map/map-providers/map.strategy.ts
@@ -152,25 +152,8 @@ export class MapStrategy {
   ) {}
   destroy() {}
   locate() {
-    if (!navigator.geolocation) {
-      console.error('Geolocation is not supported by your browser')
-      return
-    }
-
-    navigator.geolocation.getCurrentPosition(
-      position => {
-        this.flyTo({
-          center: [position.coords.longitude, position.coords.latitude],
-          zoom: 16,
-        })
-      },
-      error => {
-        console.error('Error getting location:', error)
-      },
-      {
-        enableHighAccuracy: true,
-      },
-    )
+    // Geolocation is now handled by the centralized geolocation service.
+    // See map.service.ts locate() which uses useGeolocationService().
   }
 
   zoomIn() {}

--- a/web/src/components/map/map-providers/mapbox.strategy.ts
+++ b/web/src/components/map/map-providers/mapbox.strategy.ts
@@ -2,7 +2,6 @@ import { MapStrategy } from './map.strategy'
 import {
   Map as MapboxMap,
   NavigationControl,
-  GeolocateControl,
   AttributionControl,
   ScaleControl,
   Projection,
@@ -117,7 +116,6 @@ export class MapboxStrategy extends MapStrategy {
   private streetViewLayerIds: Set<string> = new Set()
   private unwatchTheme?: () => void
   private clickDebounceTimer: number | null = null
-  geolocateControl: GeolocateControl
   layerGroups: Map<string, MapLayerGroup> = new Map()
   private currentLanguage?: string
   private hdRoadsEnabled: boolean = false
@@ -160,16 +158,6 @@ export class MapboxStrategy extends MapStrategy {
       testMode: isTestEnvironment,
     })
 
-    // Add geolocate control but hide it off-screen
-    this.geolocateControl = new GeolocateControl({
-      positionOptions: {
-        enableHighAccuracy: true,
-      },
-      trackUserLocation: true,
-      showUserLocation: true,
-      showAccuracyCircle: true,
-    })
-
     this.addControls()
     this.configureEventListeners()
 
@@ -190,7 +178,6 @@ export class MapboxStrategy extends MapStrategy {
       }),
       'bottom-left',
     )
-    this.mapInstance.addControl(this.geolocateControl, 'top-left')
   }
 
   configureEventListeners() {
@@ -745,7 +732,8 @@ export class MapboxStrategy extends MapStrategy {
   }
 
   locate() {
-    this.geolocateControl.trigger()
+    // Geolocation is now handled by the centralized geolocation service.
+    // See map.service.ts locate() which uses useGeolocationService().
   }
 
   destroy() {

--- a/web/src/composables/useE2eeLocationBroadcast.ts
+++ b/web/src/composables/useE2eeLocationBroadcast.ts
@@ -1,8 +1,9 @@
-import { ref, onUnmounted } from 'vue'
+import { ref, onUnmounted, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useIdentityStore } from '@/stores/identity.store'
 import { useFriendsStore } from '@/stores/friends.store'
 import { useLocationService } from '@/services/location.service'
+import { useGeolocationService } from '@/services/geolocation.service'
 import {
   encryptLocationForFriend,
   encryptLocation,
@@ -26,6 +27,7 @@ export function useE2eeLocationBroadcast() {
   const identityStore = useIdentityStore()
   const friendsStore = useFriendsStore()
   const locationService = useLocationService()
+  const geolocation = useGeolocationService()
 
   const { isSetupComplete, encryptionPrivateKey } = storeToRefs(identityStore)
   const { friends } = storeToRefs(friendsStore)
@@ -40,7 +42,7 @@ export function useE2eeLocationBroadcast() {
 
   // Internal state
   let broadcastIntervalId: ReturnType<typeof setInterval> | null = null
-  let watchPositionId: number | null = null
+  let stopLocationWatch: (() => void) | null = null
   let currentLocation: GeolocationPosition | null = null
   let batteryManager: BatteryManager | null = null
 
@@ -88,38 +90,36 @@ export function useE2eeLocationBroadcast() {
   >([])
 
   /**
-   * Start watching device location
+   * Start watching device location via centralized geolocation service
    */
   function startLocationWatch() {
-    if (!navigator.geolocation) {
+    if (!geolocation.isSupported.value) {
       broadcastError.value = 'Geolocation not supported'
       return
     }
 
-    watchPositionId = navigator.geolocation.watchPosition(
-      position => {
-        currentLocation = position
-      },
-      error => {
-        console.error('Geolocation error:', error)
-        broadcastError.value = `Location error: ${error.message}`
-      },
-      {
-        enableHighAccuracy: true,
-        maximumAge: 30000,
-        timeout: 10000,
-      },
-    )
-  }
+    geolocation.resume()
 
-  /**
-   * Stop watching device location
-   */
-  function stopLocationWatch() {
-    if (watchPositionId !== null) {
-      navigator.geolocation.clearWatch(watchPositionId)
-      watchPositionId = null
-    }
+    stopLocationWatch = watch(
+      geolocation.coords,
+      (coords) => {
+        if (coords.latitude !== Infinity) {
+          currentLocation = {
+            coords: {
+              latitude: coords.latitude,
+              longitude: coords.longitude,
+              accuracy: coords.accuracy,
+              altitude: coords.altitude,
+              altitudeAccuracy: coords.altitudeAccuracy,
+              heading: coords.heading,
+              speed: coords.speed,
+            },
+            timestamp: Date.now(),
+          } as GeolocationPosition
+        }
+      },
+      { immediate: true },
+    )
   }
 
   /**
@@ -275,7 +275,8 @@ export function useE2eeLocationBroadcast() {
    * Stop broadcasting
    */
   function stop() {
-    stopLocationWatch()
+    stopLocationWatch?.()
+    stopLocationWatch = null
 
     if (broadcastIntervalId) {
       clearInterval(broadcastIntervalId)

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -776,6 +776,18 @@
           "whileActive": "While active"
         }
       },
+      "location": {
+        "title": "Location",
+        "locateOnStartup": "Locate me on startup",
+        "locateOnStartupDescription": "Fly to your location when the map loads",
+        "locateFlySpeed": "Locate animation speed",
+        "speed": {
+          "instant": "Instant",
+          "fast": "Fast",
+          "normal": "Normal",
+          "slow": "Slow"
+        }
+      },
       "basemaps": {
         "title": "Basemaps",
         "new": "New basemap",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -739,6 +739,18 @@
           "whileActive": "Mientras está activo"
         }
       },
+      "location": {
+        "title": "Ubicación",
+        "locateOnStartup": "Ubicarme al iniciar",
+        "locateOnStartupDescription": "Volar a tu ubicación cuando se carga el mapa",
+        "locateFlySpeed": "Velocidad de animación de ubicación",
+        "speed": {
+          "instant": "Instantáneo",
+          "fast": "Rápido",
+          "normal": "Normal",
+          "slow": "Lento"
+        }
+      },
       "basemaps": {
         "title": "Mapas base",
         "new": "Nuevo mapa base",

--- a/web/src/main.ts
+++ b/web/src/main.ts
@@ -1,5 +1,6 @@
-import { createApp } from 'vue'
+import { createApp, effectScope } from 'vue'
 import { createPinia } from 'pinia'
+import { useGeolocationService } from '@/services/geolocation.service'
 import { i18n } from '@/lib/i18n'
 import './style.css'
 import App from './App.vue'
@@ -27,5 +28,8 @@ app.use(MotionPlugin)
 app.use(VueVirtualScroller)
 
 initVaulChromeWorkaround()
+
+// Start geolocation as early as possible — before any component mounts
+effectScope().run(() => useGeolocationService())
 
 app.mount('#app')

--- a/web/src/services/directions.service.ts
+++ b/web/src/services/directions.service.ts
@@ -1,7 +1,8 @@
 import { watch, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { api } from '@/lib/api'
-import { createSharedComposable, useGeolocation } from '@vueuse/core'
+import { createSharedComposable } from '@vueuse/core'
+import { useGeolocationService } from '@/services/geolocation.service'
 import { useDirectionsStore } from '@/stores/directions.store'
 import { Waypoint } from '@/types/map.types'
 import { TripsResponse, WaypointType } from '@/types/directions.types'
@@ -28,7 +29,7 @@ function directionsService() {
     coords,
     isSupported: isGeolocationSupported,
     resume,
-  } = useGeolocation()
+  } = useGeolocationService()
 
   /**
    * Generate unique key for request deduplication

--- a/web/src/services/geolocation.service.ts
+++ b/web/src/services/geolocation.service.ts
@@ -1,0 +1,99 @@
+/**
+ * Geolocation Service
+ *
+ * Centralized geolocation service that provides reactive user location data
+ * to all parts of the application. Uses VueUse's useGeolocation under the hood.
+ *
+ * Starts tracking immediately on initialization — the browser will silently
+ * succeed if permission is already granted, or prompt the user if not yet decided.
+ * Call resume() explicitly to trigger a permission prompt when the user clicks locate.
+ */
+
+import { computed, ref, watch } from 'vue'
+import { createSharedComposable, useGeolocation } from '@vueuse/core'
+import type { LngLat } from '@/types/map.types'
+
+export type GeolocationPermissionState = 'granted' | 'denied' | 'prompt' | 'unknown'
+
+function geolocationService() {
+  const {
+    coords,
+    error,
+    isSupported,
+    resume,
+    pause,
+  } = useGeolocation({
+    immediate: true, // Start watchPosition immediately — no async permission gate
+    enableHighAccuracy: true,
+  })
+
+  const permissionState = ref<GeolocationPermissionState>('unknown')
+
+  // Track permission state changes via Permissions API (non-blocking)
+  if (typeof navigator !== 'undefined' && navigator.permissions) {
+    navigator.permissions.query({ name: 'geolocation' }).then(status => {
+      permissionState.value = status.state as GeolocationPermissionState
+      status.addEventListener('change', () => {
+        permissionState.value = status.state as GeolocationPermissionState
+      })
+    })
+  }
+
+  // Update permission state when we get coordinates or errors
+  watch(coords, (c) => {
+    if (c.latitude !== Infinity) {
+      permissionState.value = 'granted'
+    }
+  })
+
+  watch(error, (e) => {
+    if (e?.code === GeolocationPositionError.PERMISSION_DENIED) {
+      permissionState.value = 'denied'
+    }
+  })
+
+  const hasLocation = computed(() => {
+    return coords.value.latitude !== Infinity && coords.value.longitude !== Infinity
+  })
+
+  const lngLat = computed<LngLat | null>(() => {
+    if (!hasLocation.value) return null
+    return {
+      lng: coords.value.longitude,
+      lat: coords.value.latitude,
+    }
+  })
+
+  const accuracy = computed<number | null>(() => {
+    if (!hasLocation.value) return null
+    return coords.value.accuracy
+  })
+
+  const heading = computed<number | null>(() => {
+    if (!hasLocation.value || coords.value.heading === null) return null
+    return coords.value.heading
+  })
+
+  /**
+   * Request geolocation permission and start tracking.
+   * If already tracking, this is a no-op.
+   */
+  function startTracking() {
+    resume()
+  }
+
+  return {
+    coords,
+    error,
+    isSupported,
+    permissionState,
+    hasLocation,
+    lngLat,
+    accuracy,
+    heading,
+    resume: startTracking,
+    pause,
+  }
+}
+
+export const useGeolocationService = createSharedComposable(geolocationService)

--- a/web/src/services/layers/markers/marker-layers.service.ts
+++ b/web/src/services/layers/markers/marker-layers.service.ts
@@ -10,6 +10,7 @@ import { MapStrategy } from '@/components/map/map-providers/map.strategy'
 import { WaypointsLayer } from '@/components/map/layers/waypoints-layer'
 import { FriendLocationsLayer } from '@/components/map/layers/friend-locations-layer'
 import { TripInstructionsLayer } from '@/components/map/layers/trip-instructions-layer'
+import { UserLocationLayer } from '@/components/map/layers/user-location-layer'
 import { useDirectionsStore } from '@/stores/directions.store'
 import { watch, Component } from 'vue'
 
@@ -20,6 +21,7 @@ export function useMarkerLayersService() {
   let waypointsLayer: WaypointsLayer | null = null
   let friendLocationsLayer: FriendLocationsLayer | null = null
   let tripInstructionsLayer: TripInstructionsLayer | null = null
+  let userLocationLayer: UserLocationLayer | null = null
 
   // ============================================================================
   // INITIALIZATION
@@ -34,6 +36,7 @@ export function useMarkerLayersService() {
     waypointsLayer = new WaypointsLayer()
     friendLocationsLayer = new FriendLocationsLayer()
     tripInstructionsLayer = new TripInstructionsLayer()
+    userLocationLayer = new UserLocationLayer()
 
     // Initialize with map API
     const markerAPI = {
@@ -51,6 +54,7 @@ export function useMarkerLayersService() {
     waypointsLayer.initialize(markerAPI)
     friendLocationsLayer.initialize(markerAPI)
     tripInstructionsLayer.initialize(markerAPI)
+    userLocationLayer.initialize(markerAPI)
 
     // Set up watchers for reactive updates
     setupMarkerLayerWatchers()
@@ -111,10 +115,12 @@ export function useMarkerLayersService() {
     waypointsLayer?.destroy()
     friendLocationsLayer?.destroy()
     tripInstructionsLayer?.destroy()
+    userLocationLayer?.destroy()
 
     waypointsLayer = null
     friendLocationsLayer = null
     tripInstructionsLayer = null
+    userLocationLayer = null
   }
 
   // ============================================================================

--- a/web/src/services/map.service.ts
+++ b/web/src/services/map.service.ts
@@ -12,6 +12,7 @@ import {
   type LngLat,
   LayerType,
   MapSettings,
+  LocateFlySpeed,
 } from '@/types/map.types'
 import type { Place } from '@/types/place.types'
 import { useMapStore } from '../stores/map.store'
@@ -35,6 +36,7 @@ import { AppRoute } from '@/router'
 import { useRouter } from 'vue-router'
 import { ref, toRaw, watch, Component } from 'vue'
 import { storedLocale } from '@/lib/i18n'
+import { useGeolocationService } from '@/services/geolocation.service'
 
 const dark = useDark()
 
@@ -282,6 +284,43 @@ function mapService() {
     return mapStrategy
   }
 
+  // null = jumpTo (instant), undefined = Mapbox default flyTo (distance-based, no cap), number = fixed ms
+  const LOCATE_FLY_DURATIONS: Record<LocateFlySpeed, number | null | undefined> = {
+    [LocateFlySpeed.INSTANT]: null,
+    [LocateFlySpeed.FAST]: 500,
+    [LocateFlySpeed.NORMAL]: 1500,
+    [LocateFlySpeed.SLOW]: undefined,
+  }
+
+  function locateUser() {
+    const geo = useGeolocationService()
+    const speed = mapStore.settings.locateFlySpeed ?? LocateFlySpeed.NORMAL
+    const duration = LOCATE_FLY_DURATIONS[speed]
+
+    function goToLocation() {
+      const center: [number, number] = [geo.lngLat.value!.lng, geo.lngLat.value!.lat]
+      if (duration === null) {
+        jumpTo({ center, zoom: 16 })
+      } else if (duration === undefined) {
+        flyTo({ center, zoom: 16 }) // Mapbox default: distance-based speed, no fixed cap
+      } else {
+        flyTo({ center, zoom: 16, duration })
+      }
+    }
+
+    if (geo.hasLocation.value) {
+      goToLocation()
+    } else {
+      geo.resume()
+      const stopWatch = watch(geo.hasLocation, (has) => {
+        if (has) {
+          goToLocation()
+          stopWatch()
+        }
+      })
+    }
+  }
+
   function onMapLoad() {
     // NOTE: Layer initialization happens in onStyleLoad() after style is fully loaded
     // This function only handles map-level setup that doesn't require the style to be loaded
@@ -290,6 +329,11 @@ function mapService() {
 
     // Ensure map container is properly sized after load
     resize()
+
+    // Locate user on startup if enabled
+    if (mapStore.settings.locateOnStartup) {
+      locateUser()
+    }
   }
 
   function onStyleLoad() {
@@ -1065,7 +1109,7 @@ function mapService() {
     zoomIn,
     zoomOut,
     resetNorth,
-    locate: () => mapStrategy?.locate(),
+    locate: () => locateUser(),
     setMapContainer,
     setVisibleTrips,
     showAllTrips,

--- a/web/src/stores/map.store.ts
+++ b/web/src/stores/map.store.ts
@@ -12,6 +12,7 @@ import {
   MapProjection,
   MapControlSettings,
   ControlVisibility,
+  LocateFlySpeed,
 } from '@/types/map.types'
 import { MapStrategy } from '@/components/map/map-providers/map.strategy'
 import { useStorage } from '@vueuse/core'
@@ -30,6 +31,8 @@ const defaultSettings: MapSettings = {
   transitLabels: true,
   placeLabels: true,
   hdRoads: false,
+  locateFlySpeed: LocateFlySpeed.NORMAL,
+  locateOnStartup: false,
 }
 
 // Compute default control settings based on screen size (mobile vs desktop)

--- a/web/src/types/map.types.ts
+++ b/web/src/types/map.types.ts
@@ -35,6 +35,13 @@ export enum MapColorTheme {
   MONOCHROME = 'monochrome',
 }
 
+export enum LocateFlySpeed {
+  INSTANT = 'instant',
+  FAST = 'fast',
+  NORMAL = 'normal',
+  SLOW = 'slow',
+}
+
 export interface MapSettings {
   theme: MapTheme
   engine: MapEngine
@@ -48,6 +55,8 @@ export interface MapSettings {
   transitLabels: boolean
   placeLabels: boolean
   hdRoads: boolean
+  locateFlySpeed: LocateFlySpeed
+  locateOnStartup: boolean
 }
 
 export type MapCamera = {
@@ -61,6 +70,7 @@ export type MapCamera = {
     left?: number
     right?: number
   } // Padding around the viewport edges when considering visible content
+  duration?: number // Animation duration in ms (passed through to flyTo)
 }
 
 export type MapInstance = MapboxMap | MaplibreMap

--- a/web/src/views/directions/WaypointInput.vue
+++ b/web/src/views/directions/WaypointInput.vue
@@ -24,14 +24,14 @@ import { cn } from '@/lib/utils'
 import { useDebounceFn } from '@vueuse/core'
 import { Spinner } from '@/components/ui/spinner'
 import { getSearchResultName } from '@/lib/search.utils'
-import { useGeolocation } from '@vueuse/core'
+import { useGeolocationService } from '@/services/geolocation.service'
 import { useI18n } from 'vue-i18n'
 import { ItemIcon } from '@/components/ui/item-icon'
 import { type ThemeColor, fuzzyFilter } from '@/lib/utils'
 
 const searchService = useSearchService()
 const mapCamera = useMapCamera()
-const { coords, isSupported: isGeolocationSupported, resume } = useGeolocation()
+const { coords, isSupported: isGeolocationSupported, resume } = useGeolocationService()
 const { t } = useI18n()
 
 const directionsService = useDirectionsService()

--- a/web/src/views/settings/pages/Behavior.vue
+++ b/web/src/views/settings/pages/Behavior.vue
@@ -6,9 +6,10 @@ import { useAppStore } from '@/stores/app.store'
 import { useAuthStore } from '@/stores/auth.store'
 import { useCommandStore } from '@/stores/command.store'
 import { CommandName } from '@/stores/command.store'
-import { UnitSystem } from '@/types/map.types'
+import { UnitSystem, LocateFlySpeed } from '@/types/map.types'
 import type { Locale } from '@/lib/i18n'
 import { updatePreferences } from '@/services/preferences.service'
+import { useMapStore } from '@/stores/map.store'
 import { SettingsSection, SettingsItem } from '@/components/settings'
 import {
   Select,
@@ -18,12 +19,15 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Gauge, LanguagesIcon } from 'lucide-vue-next'
+import { Switch } from '@/components/ui/switch'
+import { Gauge, GaugeIcon, LanguagesIcon, Navigation2Icon } from 'lucide-vue-next'
 
 const appStore = useAppStore()
 const authStore = useAuthStore()
 const commandStore = useCommandStore()
+const mapStore = useMapStore()
 const { unitSystem } = storeToRefs(appStore)
+const { settings } = storeToRefs(mapStore)
 const { locale } = useI18n()
 
 const languageCommand = commandStore.useCommand(CommandName.UPDATE_LANGUAGE)
@@ -68,6 +72,50 @@ watch(
             >
               {{ language.name }}
             </SelectItem>
+          </SelectContent>
+        </Select>
+      </SettingsItem>
+    </SettingsSection>
+
+    <!-- Location behavior -->
+    <SettingsSection :title="$t('settings.mapSettings.location.title')">
+      <SettingsItem
+        :title="$t('settings.mapSettings.location.locateOnStartup')"
+        :description="$t('settings.mapSettings.location.locateOnStartupDescription')"
+        :icon="Navigation2Icon"
+      >
+        <Switch
+          :model-value="settings.locateOnStartup"
+          @update:model-value="settings.locateOnStartup = !!$event"
+        />
+      </SettingsItem>
+
+      <SettingsItem
+        :title="$t('settings.mapSettings.location.locateFlySpeed')"
+        :icon="GaugeIcon"
+      >
+        <Select
+          :model-value="settings.locateFlySpeed ?? LocateFlySpeed.NORMAL"
+          @update:model-value="settings.locateFlySpeed = $event as LocateFlySpeed"
+        >
+          <SelectTrigger class="w-fit">
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectGroup>
+              <SelectItem :value="LocateFlySpeed.INSTANT">
+                {{ $t('settings.mapSettings.location.speed.instant') }}
+              </SelectItem>
+              <SelectItem :value="LocateFlySpeed.FAST">
+                {{ $t('settings.mapSettings.location.speed.fast') }}
+              </SelectItem>
+              <SelectItem :value="LocateFlySpeed.NORMAL">
+                {{ $t('settings.mapSettings.location.speed.normal') }}
+              </SelectItem>
+              <SelectItem :value="LocateFlySpeed.SLOW">
+                {{ $t('settings.mapSettings.location.speed.slow') }}
+              </SelectItem>
+            </SelectGroup>
           </SelectContent>
         </Select>
       </SettingsItem>

--- a/web/src/views/settings/pages/MapSettings.vue
+++ b/web/src/views/settings/pages/MapSettings.vue
@@ -25,7 +25,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from '@/components/ui/select'
-import { Switch } from '@/components/ui/switch'
 import {
   MountainSnowIcon,
   PlusIcon,


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Geolocation handling is refactored across map controls, map camera behavior, and location broadcasting; regressions could affect permission prompting and locate UX. MapLibre still includes its built-in `GeolocateControl` while Mapbox’s is removed, which may cause inconsistent behavior between engines.
> 
> **Overview**
> Replaces per-strategy and ad-hoc browser geolocation usage with a new shared `useGeolocationService()` that tracks coordinates, accuracy/heading, and permission state via the Permissions API.
> 
> `map.service` now owns “locate me” behavior (including optional locate-on-startup) and supports configurable fly/jump animation speed via new `MapSettings` fields (`locateOnStartup`, `locateFlySpeed`). The locate control UI updates to reflect denied/waiting states, and a new Vue marker layer renders the user’s current location on the map.
> 
> Updates other consumers (directions and E2EE location broadcasting) to read location from the centralized service, and adds i18n strings plus settings UI to configure the new location behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 40394d21b899164a1b129bd3eb243f2a691e3c49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->