### PR TITLE
OSM integration

### DIFF
--- a/RELEASE_TITLE
+++ b/RELEASE_TITLE
@@ -1,1 +1,1 @@
-OSM Account integration
+OSM integration

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.1.2-6",
+  "version": "0.1.3",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build": "bun build ./src/index.ts ./src/migrate.ts ./src/seed/seed.ts --outdir ./dist --target bun",

--- a/server/src/config/osm.config.ts
+++ b/server/src/config/osm.config.ts
@@ -1,17 +1,60 @@
-export type OsmServer = 'production' | 'sandbox'
+import { integrationManager } from '../services/integrations'
+import { IntegrationId } from '../types/integration.enums'
+import type { OpenStreetMapSystemConfig, OsmServerOption } from '../services/integrations/openstreetmap-system-integration'
 
-const OSM_SERVERS = {
+const OSM_SERVERS: Record<string, string> = {
   production: 'https://www.openstreetmap.org',
   sandbox: 'https://master.apis.dev.openstreetmap.org',
-} as const
+}
 
-const server: OsmServer = (process.env.OSM_SERVER as OsmServer) || 'production'
+export interface OsmConfig {
+  server: OsmServerOption
+  serverUrl: string
+  apiBase: string
+  authEndpoint: string
+  tokenEndpoint: string
+  redirectUri?: string
+  clientId: string
+  clientSecret?: string
+}
 
-const osmBase = OSM_SERVERS[server]
+/**
+ * Resolve the full OSM configuration from the system integration.
+ * Throws if the system integration is not configured.
+ */
+export function getOsmConfig(): OsmConfig {
+  const systemIntegrations = integrationManager.getConfiguredIntegrations()
+  const osmSystem = systemIntegrations.find(
+    (i) => i.integrationId === IntegrationId.OPENSTREETMAP,
+  )
 
-export const osmConfig = {
-  server,
-  apiBase: `${osmBase}/api/0.6`,
-  authEndpoint: `${osmBase}/oauth2/authorize`,
-  tokenEndpoint: `${osmBase}/oauth2/token`,
+  if (!osmSystem) {
+    throw new Error(
+      'OSM system integration not configured. An admin must configure OpenStreetMap OAuth application credentials.',
+    )
+  }
+
+  const config = osmSystem.config as OpenStreetMapSystemConfig
+  const server: OsmServerOption = config.server || 'production'
+
+  let serverUrl: string
+  if (server === 'custom') {
+    if (!config.customServerUrl) {
+      throw new Error('Custom OSM server URL is required when server is set to "custom".')
+    }
+    serverUrl = config.customServerUrl.replace(/\/+$/, '')
+  } else {
+    serverUrl = OSM_SERVERS[server]
+  }
+
+  return {
+    server,
+    serverUrl,
+    apiBase: `${serverUrl}/api/0.6`,
+    authEndpoint: `${serverUrl}/oauth2/authorize`,
+    tokenEndpoint: `${serverUrl}/oauth2/token`,
+    redirectUri: config.redirectUri || undefined,
+    clientId: config.clientId,
+    clientSecret: config.clientSecret,
+  }
 }

--- a/server/src/controllers/integration.controller.ts
+++ b/server/src/controllers/integration.controller.ts
@@ -7,66 +7,142 @@ import {
   testIntegrationConfig,
   getConfiguredIntegrations,
   getAvailableIntegrations,
-  getPublicIntegrations,
   getIntegrationDefinition,
+  extractPublicConfig,
+  getDependentIntegrations,
 } from '../services/integration.service'
 import {
   IntegrationId,
   IntegrationCapabilityId,
   IntegrationCapability,
   IntegrationScope,
-  IntegrationRecord,
 } from '../types/integration.types'
-import { requireAuth } from '../middleware/auth.middleware'
+import { requireAuth, getSession } from '../middleware/auth.middleware'
 import { PermissionId } from '../types/auth.types'
 import { hasPermission, getPermissions } from '../services/auth.service'
 
-// Helper function to sanitize integration configs by removing sensitive data
-function sanitizeIntegrationConfig(
-  integration: IntegrationRecord,
-): IntegrationRecord {
-  return {
-    ...integration,
-    config: {} as any, // Remove all config data for users without system read permissions
-  }
-}
-
 const app = new Elysia({ prefix: '/integrations' })
 
-// All endpoints require auth
-app.use(requireAuth)
+/**
+ * GET /integrations/configured
+ *
+ * Public endpoint (no auth required).
+ * Returns configured integrations the caller has permission to see,
+ * with only publicly-marked config fields.
+ *
+ * - Unauthenticated: system integrations with public config fields only
+ * - Authenticated: system integrations (always) + user integrations,
+ *   all with public config fields only. Filtered by read permissions.
+ */
+app.use(getSession).get(
+  '/configured',
+  async ({ user }) => {
+    const { integrationManager } = await import('../services/integrations')
 
-// New: Public integrations for client (safe subset)
-app.get(
-  '/public',
-  async () => {
-    const list = await getPublicIntegrations()
-    return list
+    // Always include system integrations with public fields
+    const systemIntegrations = await getConfiguredIntegrations()
+
+    const result: any[] = systemIntegrations.map((integration) => {
+      const definition = getIntegrationDefinition(integration.integrationId)
+      const publicConfig = extractPublicConfig(
+        (integration.config || {}) as Record<string, any>,
+        definition,
+      )
+
+      // Get the integration instance to access capability metadata
+      const instance =
+        integrationManager.getCachedIntegrationInstance(integration)
+      const enhancedCapabilities = integration.capabilities.map((cap) => {
+        const capabilityMetadata = instance?.capabilities[cap.id]?.metadata
+        return { ...cap, metadata: capabilityMetadata || null }
+      })
+
+      return {
+        id: integration.id,
+        integrationId: integration.integrationId,
+        config: publicConfig,
+        capabilities: enhancedCapabilities,
+        name: definition?.name,
+      }
+    })
+
+    // If authenticated, also include user integrations
+    if (user) {
+      const userPermissions = await getPermissions(user.id)
+      const canReadUser = hasPermission(
+        userPermissions,
+        PermissionId.INTEGRATIONS_READ_USER,
+      )
+
+      if (canReadUser) {
+        const userIntegrations = await getConfiguredIntegrations(user.id)
+        for (const integration of userIntegrations) {
+          const definition = getIntegrationDefinition(
+            integration.integrationId,
+          )
+          const publicConfig = extractPublicConfig(
+            (integration.config || {}) as Record<string, any>,
+            definition,
+          )
+
+          const instance =
+            integrationManager.getCachedIntegrationInstance(integration)
+          const enhancedCapabilities = integration.capabilities.map((cap) => {
+            const capabilityMetadata = instance?.capabilities[cap.id]?.metadata
+            return { ...cap, metadata: capabilityMetadata || null }
+          })
+
+          result.push({
+            id: integration.id,
+            userId: integration.userId,
+            integrationId: integration.integrationId,
+            config: publicConfig,
+            capabilities: enhancedCapabilities,
+            name: definition?.name,
+          })
+        }
+      }
+    }
+
+    return result
   },
   {
     detail: {
       tags: ['Integrations'],
-      summary: 'Get public integrations (safe subset)',
+      summary:
+        'Get configured integrations with public config fields only',
     },
   },
 )
 
-// Get all available integrations (metadata only)
-app.use(requireAuth).get(
+// All remaining endpoints require auth
+app.use(requireAuth)
+
+/**
+ * GET /integrations/available
+ *
+ * Returns integration definitions the user has permission to see in the
+ * settings UI. User integrations require INTEGRATIONS_READ_USER,
+ * system integrations require INTEGRATIONS_READ_SYSTEM.
+ */
+app.get(
   '/available',
   async ({ user, status, t }) => {
-    // Check if user has basic read permission for integrations
     const userPermissions = await getPermissions(user.id)
-    const canRead = hasPermission(
+    const canReadUser = hasPermission(
       userPermissions,
-      PermissionId.INTEGRATIONS_READ,
+      PermissionId.INTEGRATIONS_READ_USER,
+    )
+    const canReadSystem = hasPermission(
+      userPermissions,
+      PermissionId.INTEGRATIONS_READ_SYSTEM,
     )
     const canWriteSystem = hasPermission(
       userPermissions,
       PermissionId.INTEGRATIONS_WRITE_SYSTEM,
     )
 
-    if (!canRead) {
+    if (!canReadUser && !canReadSystem) {
       return status(403, {
         message: t('errors.auth.insufficientPermissions'),
       })
@@ -95,15 +171,15 @@ app.use(requireAuth).get(
         if (integration.scope.includes(IntegrationScope.SYSTEM)) {
           // If it's already configured, show to users with read permissions
           if (configuredIntegrationIds.has(integration.id)) {
-            return canRead
+            return canReadSystem
           }
           // If not configured, only show to users with write permissions
           return canWriteSystem
         }
 
-        // If integration has USER scope, user just needs read permissions
+        // If integration has USER scope, user needs read user permissions
         if (integration.scope.includes(IntegrationScope.USER)) {
-          return canRead
+          return canReadUser
         }
 
         return false
@@ -120,97 +196,16 @@ app.use(requireAuth).get(
   },
 )
 
-// TODO: Don't require auth, we should be able to get public integrations
-// Get user's configured integrations (user-specific ones plus system-wide ones)
-// Configs are sanitized unless user has appropriate write permissions
-app.use(requireAuth).get(
-  '/configured',
-  async ({ user, status, t }) => {
-    // Check if user has basic read permission for integrations
-    const userPermissions = await getPermissions(user.id)
-    const canRead = hasPermission(
-      userPermissions,
-      PermissionId.INTEGRATIONS_READ,
-    )
-    const canWriteUser = hasPermission(
-      userPermissions,
-      PermissionId.INTEGRATIONS_WRITE_USER,
-    )
-    const canWriteSystem = hasPermission(
-      userPermissions,
-      PermissionId.INTEGRATIONS_WRITE_SYSTEM,
-    )
-
-    if (!canRead) {
-      return status(403, {
-        message: t('errors.auth.insufficientPermissions'),
-      })
-    }
-
-    // Get user-specific integrations
-    const userIntegrations = await getConfiguredIntegrations(user.id)
-
-    // Get system-wide integrations
-    const systemIntegrations = await getConfiguredIntegrations()
-
-    // Combine all integrations
-    const allIntegrations = [...userIntegrations, ...systemIntegrations]
-
-    // Import integration manager to get capability metadata
-    const { integrationManager } = await import('../services/integrations')
-
-    // Sanitize configs based on user permissions and integration scope
-    // and add capability metadata
-    return allIntegrations.map((integration) => {
-      const definition = getIntegrationDefinition(integration.integrationId)
-      if (!definition) return sanitizeIntegrationConfig(integration)
-
-      // Check if user can see full config based on integration scope
-      const canSeeFullConfig =
-        (definition.scope.includes(IntegrationScope.USER) && canWriteUser) ||
-        (definition.scope.includes(IntegrationScope.SYSTEM) && canWriteSystem)
-
-      const baseIntegration = canSeeFullConfig
-        ? integration
-        : sanitizeIntegrationConfig(integration)
-
-      // Get the integration instance to access capability metadata
-      const instance =
-        integrationManager.getCachedIntegrationInstance(integration)
-
-      // Enhance capabilities with metadata
-      const enhancedCapabilities = integration.capabilities.map((cap) => {
-        const capabilityMetadata = instance?.capabilities[cap.id]?.metadata
-        return {
-          ...cap,
-          metadata: capabilityMetadata || null,
-        }
-      })
-
-      return {
-        ...baseIntegration,
-        name: definition.name, // Add human-friendly name from definition
-        capabilities: enhancedCapabilities,
-      }
-    })
-  },
-  {
-    detail: {
-      tags: ['Integrations'],
-      summary: 'Get configured integrations for user with capability metadata',
-    },
-  },
-)
-
-// Get a specific integration
-app.use(requireAuth).get(
+/**
+ * GET /integrations/:id
+ *
+ * Returns full config for a single integration. Requires the appropriate
+ * write permission (write:user for user-scoped, write:system for system-scoped).
+ */
+app.get(
   '/:id',
   async ({ params: { id }, user, status, t }) => {
     const userPermissions = await getPermissions(user.id)
-    const canRead = hasPermission(
-      userPermissions,
-      PermissionId.INTEGRATIONS_READ,
-    )
     const canWriteUser = hasPermission(
       userPermissions,
       PermissionId.INTEGRATIONS_WRITE_USER,
@@ -219,12 +214,6 @@ app.use(requireAuth).get(
       userPermissions,
       PermissionId.INTEGRATIONS_WRITE_SYSTEM,
     )
-
-    if (!canRead) {
-      return status(403, {
-        message: t('errors.auth.insufficientPermissions'),
-      })
-    }
 
     // First try user-specific integration
     let integration = await getIntegration(id, user.id)
@@ -238,17 +227,24 @@ app.use(requireAuth).get(
       return status(404, { message: t('errors.notFound.integration') })
     }
 
-    // Check if user can see full config based on integration scope
+    // Check if user has write permission for this integration's scope
     const definition = getIntegrationDefinition(integration.integrationId)
-    if (!definition) return sanitizeIntegrationConfig(integration)
+    if (!definition) {
+      return status(404, { message: t('errors.notFound.integrationDefinition') })
+    }
 
-    const canSeeFullConfig =
+    const hasWriteAccess =
       (definition.scope.includes(IntegrationScope.USER) && canWriteUser) ||
       (definition.scope.includes(IntegrationScope.SYSTEM) && canWriteSystem)
 
-    return canSeeFullConfig
-      ? integration
-      : sanitizeIntegrationConfig(integration)
+    if (!hasWriteAccess) {
+      return status(403, {
+        message: t('errors.auth.insufficientPermissions'),
+      })
+    }
+
+    // Return full config
+    return integration
   },
   {
     params: t.Object({
@@ -256,13 +252,18 @@ app.use(requireAuth).get(
     }),
     detail: {
       tags: ['Integrations'],
-      summary: 'Get a specific integration',
+      summary: 'Get a specific integration with full config (requires write permission)',
     },
   },
 )
 
-// Create a new integration
-app.use(requireAuth).post(
+/**
+ * POST /integrations
+ *
+ * Create a new integration. Requires write permission for the
+ * integration's scope (write:user or write:system).
+ */
+app.post(
   '/',
   async ({ body, user, status, t }) => {
     const userPermissions = await getPermissions(user.id)
@@ -275,7 +276,7 @@ app.use(requireAuth).post(
       PermissionId.INTEGRATIONS_WRITE_SYSTEM,
     )
 
-    const { integrationId, config, capabilities, isSystemWide } = body
+    const { integrationId, config, capabilities } = body
 
     // Verify the integration ID is valid
     const validId = Object.values(IntegrationId).includes(
@@ -366,7 +367,6 @@ app.use(requireAuth).post(
           }),
         ),
       ),
-      isSystemWide: t.Optional(t.Boolean()),
     }),
     detail: {
       tags: ['Integrations'],
@@ -375,8 +375,13 @@ app.use(requireAuth).post(
   },
 )
 
-// Update an integration
-app.use(requireAuth).put(
+/**
+ * PUT /integrations/:id
+ *
+ * Update an integration. Requires write permission for the
+ * integration's scope.
+ */
+app.put(
   '/:id',
   async ({ params: { id }, body, user, status, t }) => {
     const userPermissions = await getPermissions(user.id)
@@ -470,10 +475,68 @@ app.use(requireAuth).put(
   },
 )
 
-// Delete an integration
-app.use(requireAuth).delete(
+/**
+ * GET /integrations/:id/dependents
+ *
+ * Returns a list of configured integrations that depend on this one
+ * (via requiresSystemIntegration). Used by the frontend to warn users
+ * before deleting a system integration that other integrations rely on.
+ */
+app.get(
+  '/:id/dependents',
+  async ({ params: { id }, user, status, t }) => {
+    const userPermissions = await getPermissions(user.id)
+    const canWriteSystem = hasPermission(
+      userPermissions,
+      PermissionId.INTEGRATIONS_WRITE_SYSTEM,
+    )
+
+    if (!canWriteSystem) {
+      return status(403, {
+        message: t('errors.auth.insufficientPermissions'),
+      })
+    }
+
+    // Find the integration record
+    let integration = await getIntegration(id)
+    if (!integration) {
+      return status(404, { message: t('errors.notFound.integration') })
+    }
+
+    const dependents = await getDependentIntegrations(
+      integration.integrationId as any,
+    )
+
+    return dependents.map((dep) => {
+      const definition = getIntegrationDefinition(dep.integrationId)
+      return {
+        id: dep.id,
+        integrationId: dep.integrationId,
+        userId: dep.userId,
+        name: definition?.name ?? dep.integrationId,
+      }
+    })
+  },
+  {
+    params: t.Object({
+      id: t.String(),
+    }),
+    detail: {
+      tags: ['Integrations'],
+      summary: 'Get integrations that depend on this one',
+    },
+  },
+)
+
+/**
+ * DELETE /integrations/:id
+ *
+ * Delete an integration. Requires write permission for the
+ * integration's scope. Cascade-deletes dependent integrations.
+ */
+app.delete(
   '/:id',
-  async ({ params: { id }, user, set, status }) => {
+  async ({ params: { id }, user, set, status, t }) => {
     const userPermissions = await getPermissions(user.id)
     const canWriteUser = hasPermission(
       userPermissions,
@@ -540,10 +603,15 @@ app.use(requireAuth).delete(
   },
 )
 
-// Test an integration configuration
-app.use(requireAuth).post(
+/**
+ * POST /integrations/test
+ *
+ * Test an integration configuration. Requires write permission for the
+ * integration's scope.
+ */
+app.post(
   '/test',
-  async ({ body, user, status }) => {
+  async ({ body, user, status, t }) => {
     const userPermissions = await getPermissions(user.id)
     const canWriteUser = hasPermission(
       userPermissions,

--- a/server/src/controllers/notes.controller.ts
+++ b/server/src/controllers/notes.controller.ts
@@ -7,9 +7,7 @@ import {
   OsmNote,
   OsmNoteComment,
 } from '../types/integration.types'
-import { osmConfig } from '../config/osm.config'
-
-const { apiBase: OSM_API_BASE } = osmConfig
+import { getOsmConfig } from '../config/osm.config'
 
 /**
  * Look up the user's OSM access token from their configured integrations.
@@ -47,6 +45,11 @@ function adaptNoteFeature(feature: any): OsmNote {
   }
 }
 
+function notesErrorStatus(error: any): number {
+  if (!error.response && error.message?.includes('not configured')) return 503
+  return error.response?.status ?? 500
+}
+
 const app = new Elysia({ prefix: '/notes' })
 
 /**
@@ -57,14 +60,14 @@ app.get(
   async ({ query, status }) => {
     try {
       const { bbox, limit = 100, closed = 7 } = query
-      const response = await axios.get(`${OSM_API_BASE}/notes.json`, {
+      const response = await axios.get(`${getOsmConfig().apiBase}/notes.json`, {
         params: { bbox, limit, closed },
         headers: { Accept: 'application/json' },
       })
       const features = response.data?.features || []
       return features.map((feature: any) => adaptNoteFeature(feature))
     } catch (error: any) {
-      const errorStatus = error.response?.status ?? 500
+      const errorStatus = notesErrorStatus(error)
       return status(errorStatus, {
         message: error.response?.data || error.message || 'Failed to fetch notes',
       })
@@ -91,12 +94,12 @@ app.get(
   async ({ params, status }) => {
     try {
       const response = await axios.get(
-        `${OSM_API_BASE}/notes/${params.id}.json`,
+        `${getOsmConfig().apiBase}/notes/${params.id}.json`,
         { headers: { Accept: 'application/json' } },
       )
       return adaptNoteFeature(response.data)
     } catch (error: any) {
-      const errorStatus = error.response?.status ?? 500
+      const errorStatus = notesErrorStatus(error)
       return status(errorStatus, {
         message: error.response?.data || error.message || 'Failed to fetch note',
       })
@@ -104,7 +107,7 @@ app.get(
   },
   {
     params: t.Object({
-      id: t.String(),
+      id: t.String({ pattern: '^[0-9]+$' }),
     }),
     detail: {
       tags: ['Notes'],
@@ -127,7 +130,7 @@ app.use(requireAuth).post(
 
     try {
       const response = await axios.post(
-        `${OSM_API_BASE}/notes.json`,
+        `${getOsmConfig().apiBase}/notes.json`,
         null,
         {
           params: { lat: body.lat, lon: body.lng, text: body.text },
@@ -139,7 +142,7 @@ app.use(requireAuth).post(
       )
       return adaptNoteFeature(response.data)
     } catch (error: any) {
-      const errorStatus = error.response?.status ?? 500
+      const errorStatus = notesErrorStatus(error)
       return status(errorStatus, {
         message: error.response?.data || error.message || 'Failed to create note',
       })
@@ -171,7 +174,7 @@ app.use(requireAuth).post(
 
     try {
       const response = await axios.post(
-        `${OSM_API_BASE}/notes/${params.id}/comment.json`,
+        `${getOsmConfig().apiBase}/notes/${params.id}/comment.json`,
         null,
         {
           params: { text: body.text },
@@ -183,7 +186,7 @@ app.use(requireAuth).post(
       )
       return adaptNoteFeature(response.data)
     } catch (error: any) {
-      const errorStatus = error.response?.status ?? 500
+      const errorStatus = notesErrorStatus(error)
       return status(errorStatus, {
         message: error.response?.data || error.message || 'Failed to comment on note',
       })
@@ -191,7 +194,7 @@ app.use(requireAuth).post(
   },
   {
     params: t.Object({
-      id: t.String(),
+      id: t.String({ pattern: '^[0-9]+$' }),
     }),
     body: t.Object({
       text: t.String(),
@@ -216,7 +219,7 @@ app.use(requireAuth).post(
 
     try {
       const response = await axios.post(
-        `${OSM_API_BASE}/notes/${params.id}/close.json`,
+        `${getOsmConfig().apiBase}/notes/${params.id}/close.json`,
         null,
         {
           params: body.text ? { text: body.text } : undefined,
@@ -228,7 +231,7 @@ app.use(requireAuth).post(
       )
       return adaptNoteFeature(response.data)
     } catch (error: any) {
-      const errorStatus = error.response?.status ?? 500
+      const errorStatus = notesErrorStatus(error)
       return status(errorStatus, {
         message: error.response?.data || error.message || 'Failed to close note',
       })
@@ -236,7 +239,7 @@ app.use(requireAuth).post(
   },
   {
     params: t.Object({
-      id: t.String(),
+      id: t.String({ pattern: '^[0-9]+$' }),
     }),
     body: t.Object({
       text: t.Optional(t.String()),
@@ -261,7 +264,7 @@ app.use(requireAuth).post(
 
     try {
       const response = await axios.post(
-        `${OSM_API_BASE}/notes/${params.id}/reopen.json`,
+        `${getOsmConfig().apiBase}/notes/${params.id}/reopen.json`,
         null,
         {
           params: body.text ? { text: body.text } : undefined,
@@ -273,7 +276,7 @@ app.use(requireAuth).post(
       )
       return adaptNoteFeature(response.data)
     } catch (error: any) {
-      const errorStatus = error.response?.status ?? 500
+      const errorStatus = notesErrorStatus(error)
       return status(errorStatus, {
         message: error.response?.data || error.message || 'Failed to reopen note',
       })
@@ -281,7 +284,7 @@ app.use(requireAuth).post(
   },
   {
     params: t.Object({
-      id: t.String(),
+      id: t.String({ pattern: '^[0-9]+$' }),
     }),
     body: t.Object({
       text: t.Optional(t.String()),

--- a/server/src/controllers/osm-oauth.controller.ts
+++ b/server/src/controllers/osm-oauth.controller.ts
@@ -1,48 +1,62 @@
 import { Elysia, t } from 'elysia'
 import * as arctic from 'arctic'
 import axios from 'axios'
-import { getSession, requireAuth } from '../middleware/auth.middleware'
+import { eq, and } from 'drizzle-orm'
+import { requireAuth } from '../middleware/auth.middleware'
 import { serverOrigin, clientOrigin } from '../config/origins.config'
+import { db } from '../db'
+import { tokens } from '../schema/tokens.schema'
 import {
   createIntegration,
   deleteIntegration,
   updateIntegration,
   getConfiguredIntegrations,
 } from '../services/integration.service'
-import { createServerToken, validateServerToken } from '../services/token.service'
-import { IntegrationId, IntegrationScope } from '../types/integration.types'
-import { integrationManager } from '../services/integrations'
+import { IntegrationId } from '../types/integration.types'
+import { getOsmConfig } from '../config/osm.config'
+import { generateId } from '../util'
 
-import { osmConfig } from '../config/osm.config'
-
-const OSM_AUTH_ENDPOINT = osmConfig.authEndpoint
-const OSM_TOKEN_ENDPOINT = osmConfig.tokenEndpoint
-const OSM_API_BASE = osmConfig.apiBase
 const OSM_SCOPES = ['read_prefs', 'write_notes', 'write_api'] // read_prefs needed to fetch display name during OAuth callback
 
 function getOsmClient() {
-  const systemIntegrations = integrationManager.getConfiguredIntegrations()
-  const osmSystem = systemIntegrations.find(
-    (i) => i.integrationId === IntegrationId.OPENSTREETMAP,
-  )
-
-  if (!osmSystem) {
-    throw new Error(
-      'OSM system integration not configured. An admin must configure OpenStreetMap OAuth application credentials.',
-    )
-  }
-
-  const { clientId, clientSecret } = osmSystem.config as any
-  if (!clientId || !clientSecret) {
-    throw new Error(
-      'OSM OAuth2 credentials incomplete in system integration config.',
-    )
-  }
+  const config = getOsmConfig()
+  const redirectUri = config.redirectUri || `${serverOrigin}/integrations/osm/callback`
 
   return new arctic.OAuth2Client(
-    clientId,
-    clientSecret,
-    `${serverOrigin}/integrations/osm/callback`,
+    config.clientId,
+    config.clientSecret || null,
+    redirectUri,
+  )
+}
+
+/**
+ * Render a minimal HTML page that posts a message to the opener window and closes itself.
+ * Used as the OAuth callback response so the SPA isn't disrupted by a redirect.
+ */
+function oauthCallbackPage(result: { status: 'connected' | 'error'; message?: string }) {
+  // Sanitize message for safe inline script embedding:
+  // - Escape </ to prevent </script> breakout
+  // - Use only the status enum for the fallback URL message to avoid injection
+  const safeMessage = JSON.stringify({ type: 'osm-oauth-callback', ...result })
+    .replace(/</g, '\\u003c')
+  const safeOrigin = clientOrigin.replace(/'/g, "\\'")
+  const fallbackUrl = `${clientOrigin}/settings/integrations?osm=${encodeURIComponent(result.status)}${result.message ? `&message=${encodeURIComponent(result.message)}` : ''}`
+  const safeFallbackUrl = fallbackUrl.replace(/'/g, "\\'")
+  return new Response(
+    `<!DOCTYPE html>
+<html><head><title>Connecting...</title></head>
+<body>
+<script>
+  if (window.opener) {
+    window.opener.postMessage(${safeMessage}, '${safeOrigin}');
+    window.close();
+  } else {
+    window.location.href = '${safeFallbackUrl}';
+  }
+</script>
+<noscript>You can close this window.</noscript>
+</body></html>`,
+    { headers: { 'Content-Type': 'text/html' } },
   )
 }
 
@@ -59,11 +73,25 @@ app.use(requireAuth).get(
       const client = getOsmClient()
       const state = arctic.generateState()
 
-      // Store state → userId mapping using existing token service
-      await createServerToken('token', user.id, state, false)
+      // Store state → userId mapping with a 1-hour expiry (longer than the default
+      // 15 minutes to accommodate the dev-mode manual callback workaround)
+      // Clean up any existing OAuth state tokens for this user
+      await db
+        .delete(tokens)
+        .where(and(eq(tokens.userId, user.id), eq(tokens.type, 'token')))
 
+      await db.insert(tokens).values({
+        id: generateId(),
+        userId: user.id,
+        type: 'token',
+        value: state,
+        ephemeral: true,
+        expires: new Date(Date.now() + 60 * 60 * 1000), // 1 hour
+      })
+
+      const osmCfg = getOsmConfig()
       const url = client.createAuthorizationURL(
-        OSM_AUTH_ENDPOINT,
+        osmCfg.authEndpoint,
         state,
         OSM_SCOPES,
       )
@@ -85,34 +113,27 @@ app.use(requireAuth).get(
 
 /**
  * OAuth2 callback from OpenStreetMap.
- * This is a browser redirect — no API auth, authenticates via state token.
+ * Opens in a popup/new tab — posts result back to opener via postMessage.
+ * Falls back to redirect if there's no opener (e.g. popup was blocked).
  */
 app.get(
   '/callback',
-  async ({ query, set }) => {
+  async ({ query }) => {
     const { code, state } = query
-    const redirectBase = `${clientOrigin}/settings/integrations`
 
     if (!code || !state) {
-      set.redirect = `${redirectBase}?osm=error&message=${encodeURIComponent('Missing authorization code or state')}`
-      return
+      return oauthCallbackPage({ status: 'error', message: 'Missing authorization code or state' })
     }
 
     try {
       // Look up the state token to find the associated user
-      // The token service stores tokens per-user, so we need to find which user owns this state
-      const { db } = await import('../db')
-      const { tokens } = await import('../schema/tokens.schema')
-      const { eq, and } = await import('drizzle-orm')
-
       const matchingTokens = await db
         .select()
         .from(tokens)
         .where(and(eq(tokens.type, 'token'), eq(tokens.value, state)))
 
       if (matchingTokens.length === 0) {
-        set.redirect = `${redirectBase}?osm=error&message=${encodeURIComponent('Invalid or expired state parameter')}`
-        return
+        return oauthCallbackPage({ status: 'error', message: 'Invalid or expired state parameter' })
       }
 
       const stateToken = matchingTokens[0]
@@ -121,8 +142,7 @@ app.get(
       // Check expiry
       if (stateToken.expires && new Date(stateToken.expires) < new Date()) {
         await db.delete(tokens).where(eq(tokens.id, stateToken.id))
-        set.redirect = `${redirectBase}?osm=error&message=${encodeURIComponent('Authorization request expired')}`
-        return
+        return oauthCallbackPage({ status: 'error', message: 'Authorization request expired' })
       }
 
       // Clean up the state token
@@ -130,8 +150,9 @@ app.get(
 
       // Exchange authorization code for tokens
       const client = getOsmClient()
+      const osmCfg = getOsmConfig()
       const oauthTokens = await client.validateAuthorizationCode(
-        OSM_TOKEN_ENDPOINT,
+        osmCfg.tokenEndpoint,
         code,
         null,
       )
@@ -139,7 +160,7 @@ app.get(
       const accessToken = oauthTokens.accessToken()
 
       // Fetch OSM user details
-      const userResponse = await axios.get(`${OSM_API_BASE}/user/details.json`, {
+      const userResponse = await axios.get(`${osmCfg.apiBase}/user/details.json`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           Accept: 'application/json',
@@ -148,8 +169,7 @@ app.get(
 
       const osmUser = userResponse.data?.user
       if (!osmUser) {
-        set.redirect = `${redirectBase}?osm=error&message=${encodeURIComponent('Failed to fetch OSM user details')}`
-        return
+        return oauthCallbackPage({ status: 'error', message: 'Failed to fetch OSM user details' })
       }
 
       // Check if user already has an OSM integration and remove it
@@ -174,14 +194,14 @@ app.get(
 
       await createIntegration(userId, IntegrationId.OPENSTREETMAP_ACCOUNT, config)
 
-      set.redirect = `${redirectBase}?osm=connected`
+      return oauthCallbackPage({ status: 'connected' })
     } catch (error: any) {
       console.error('OSM OAuth2 callback error:', error)
       const message =
         error instanceof arctic.OAuth2RequestError
           ? `OAuth2 error: ${error.code}`
           : error.message || 'OAuth2 callback failed'
-      set.redirect = `${redirectBase}?osm=error&message=${encodeURIComponent(message)}`
+      return oauthCallbackPage({ status: 'error', message })
     }
   },
   {
@@ -217,7 +237,8 @@ app.use(requireAuth).get(
         return status(400, { message: 'No access token found' })
       }
 
-      const userResponse = await axios.get(`${OSM_API_BASE}/user/details.json`, {
+      const osmCfg = getOsmConfig()
+      const userResponse = await axios.get(`${osmCfg.apiBase}/user/details.json`, {
         headers: {
           Authorization: `Bearer ${accessToken}`,
           Accept: 'application/json',

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -27,6 +27,7 @@ import {
   notes as notesController,
 } from './controllers'
 import { initializeIntegrations } from './services/integration.service'
+import { syncPermissionsAndRoles } from './seed/sync-permissions'
 import { getI18nInitOptions, detectLanguage } from './lib/i18n'
 import { initializeOsmPresets } from './lib/osm-presets'
 
@@ -102,6 +103,8 @@ async function main() {
 
   try {
     logger.debug('i18n configured')
+    await syncPermissionsAndRoles()
+    logger.info('Permissions and roles synced')
     initializeOsmPresets()
     await initializeIntegrations()
     logger.info('Integrations initialized')

--- a/server/src/seed/permissions.ts
+++ b/server/src/seed/permissions.ts
@@ -32,14 +32,20 @@ export const permissions: {
     name: 'Read system status data',
   },
   {
-    id: PermissionId.INTEGRATIONS_READ,
-    name: 'View integrations',
+    id: PermissionId.INTEGRATIONS_READ_USER,
+    name: 'Read User Integrations',
+    description: 'View user-scoped integration configurations',
   },
   {
     id: PermissionId.INTEGRATIONS_WRITE_USER,
     name: 'Write User Integrations',
     description:
       'Create, update, and delete user-scoped integration configurations',
+  },
+  {
+    id: PermissionId.INTEGRATIONS_READ_SYSTEM,
+    name: 'Read System Integrations',
+    description: 'View system-wide integration configurations in settings',
   },
   {
     id: PermissionId.INTEGRATIONS_WRITE_SYSTEM,

--- a/server/src/seed/roles.ts
+++ b/server/src/seed/roles.ts
@@ -19,7 +19,8 @@ const user: Role = {
   name: 'User',
   description: 'A user that can view and browse the map',
   permissions: [
-    PermissionId.INTEGRATIONS_READ,
+    PermissionId.INTEGRATIONS_READ_USER,
+    PermissionId.INTEGRATIONS_WRITE_USER,
     PermissionId.LAYERS_READ,
     PermissionId.LAYERS_WRITE,
   ],
@@ -31,8 +32,9 @@ const alpha: Role = {
   description:
     'A privileged user that is able to read all data in the app, but has limited write permissions',
   permissions: [
-    PermissionId.INTEGRATIONS_READ,
+    PermissionId.INTEGRATIONS_READ_USER,
     PermissionId.INTEGRATIONS_WRITE_USER,
+    PermissionId.INTEGRATIONS_READ_SYSTEM,
     PermissionId.SYSTEM_READ,
     PermissionId.LAYERS_READ,
     PermissionId.LAYERS_WRITE,

--- a/server/src/seed/seed.ts
+++ b/server/src/seed/seed.ts
@@ -1,11 +1,7 @@
 import { db, connection } from '../db'
-import { permissions as permissionsSchema } from '../schema/permissions.schema'
-import { roles as rolesSchema } from '../schema/roles.schema'
 import { users as usersSchema } from '../schema/users.schema'
-import { roleToPermissions } from '../schema/roles-permissions.schema'
 import { usersToRoles } from '../schema/users-roles.schema'
-import { permissions } from './permissions'
-import { roles } from './roles'
+import { syncPermissionsAndRoles } from './sync-permissions'
 
 /**
  * Populate the DB with initial data that is required for the app to work properly,
@@ -13,69 +9,8 @@ import { roles } from './roles'
  * Run this script whenever updating roles or permissions using `bun seed`
  */
 
-// Clean database
-const originalRoleAssignments = await db.select().from(usersToRoles)
-await db.delete(roleToPermissions)
-await db.delete(usersToRoles)
-await db.delete(rolesSchema)
-await db.delete(permissionsSchema)
-
-// Create permissions and roles
-const permissionsCount = (
-  await db.insert(permissionsSchema).values(permissions).returning()
-).length
-
-console.info(`✅ Inserted ${permissionsCount} permissions`)
-
-const rolesCount = (await db.insert(rolesSchema).values(roles).returning())
-  .length
-
-console.info(`✅ Inserted ${rolesCount} roles`)
-
-// Assign permissions to roles
-for (const role of roles) {
-  if (role.permissions === '*') {
-    for (const permission of permissions) {
-      await db.insert(roleToPermissions).values({
-        roleId: role.id,
-        permissionId: permission.id,
-      })
-    }
-    console.info(
-      `✅ Assigned all ${permissions.length} permissions to role ${role.id}`,
-    )
-  } else {
-    for (const permission of role.permissions) {
-      await db.insert(roleToPermissions).values({
-        roleId: role.id,
-        permissionId: permission,
-      })
-    }
-    console.info(
-      `✅ Assigned ${role.permissions.length} permissions to role ${role.id}`,
-    )
-  }
-}
-
-// Reassign roles to users
-// TODO: Instead of deleting all roles assignments and recreating, create a diffing algorithm and only update what has changed
-if (originalRoleAssignments.length) {
-  const insertedRoleAssignments = await db
-    .insert(usersToRoles)
-    .values(originalRoleAssignments)
-    .returning()
-
-  const uniqueUsersCount = new Set(
-    insertedRoleAssignments.map((role) => role.userId),
-  ).size
-  const uniqueRolesCount = new Set(
-    insertedRoleAssignments.map((role) => role.roleId),
-  ).size
-
-  console.info(
-    `✅ Assigned ${uniqueRolesCount} roles to ${uniqueUsersCount} users`,
-  )
-}
+await syncPermissionsAndRoles()
+console.info('✅ Permissions and roles synced')
 
 // Insert initial user if none exist
 const users = await db.select().from(usersSchema).limit(1)

--- a/server/src/seed/sync-permissions.ts
+++ b/server/src/seed/sync-permissions.ts
@@ -1,0 +1,49 @@
+import { db } from '../db'
+import { permissions as permissionsSchema } from '../schema/permissions.schema'
+import { roles as rolesSchema } from '../schema/roles.schema'
+import { roleToPermissions } from '../schema/roles-permissions.schema'
+import { usersToRoles } from '../schema/users-roles.schema'
+import { permissions } from './permissions'
+import { roles } from './roles'
+
+/**
+ * Synchronize permissions and roles from code definitions to the database.
+ * Safe to call on every server startup — it preserves existing user-role
+ * assignments while ensuring the permission and role tables match code.
+ * Wrapped in a transaction to prevent a window with no permissions.
+ */
+export async function syncPermissionsAndRoles() {
+  await db.transaction(async (tx) => {
+    // Snapshot existing user-role assignments so we can restore them
+    const originalRoleAssignments = await tx.select().from(usersToRoles)
+
+    // Recreate permissions and roles from code definitions
+    await tx.delete(roleToPermissions)
+    await tx.delete(usersToRoles)
+    await tx.delete(rolesSchema)
+    await tx.delete(permissionsSchema)
+
+    await tx.insert(permissionsSchema).values(permissions)
+    await tx.insert(rolesSchema).values(roles)
+
+    // Assign permissions to roles
+    for (const role of roles) {
+      const perms = role.permissions === '*' ? permissions.map(p => p.id) : role.permissions
+      for (const permissionId of perms) {
+        await tx.insert(roleToPermissions).values({
+          roleId: role.id,
+          permissionId,
+        })
+      }
+    }
+
+    // Restore user-role assignments, filtering out any that reference removed roles
+    const validRoleIds = new Set(roles.map(r => r.id))
+    const validAssignments = originalRoleAssignments.filter(
+      a => validRoleIds.has(a.roleId),
+    )
+    if (validAssignments.length) {
+      await tx.insert(usersToRoles).values(validAssignments)
+    }
+  })
+}

--- a/server/src/services/integration.service.test.ts
+++ b/server/src/services/integration.service.test.ts
@@ -1,0 +1,178 @@
+import { describe, test, expect } from 'bun:test'
+
+// Import the function directly — it's a pure function with no DB dependencies
+import { extractPublicConfig } from './integration.service'
+import { IntegrationScope } from '../types/integration.types'
+import type { IntegrationDefinition } from '../types/integration.types'
+
+function makeDefinition(
+  overrides: Partial<IntegrationDefinition> = {},
+): IntegrationDefinition {
+  return {
+    id: 'test' as any,
+    name: 'Test',
+    description: 'Test integration',
+    color: '#000',
+    capabilities: [],
+    paid: false,
+    cloud: true,
+    configSchema: 'testSchema',
+    scope: [IntegrationScope.SYSTEM],
+    ...overrides,
+  }
+}
+
+describe('extractPublicConfig', () => {
+  test('returns empty object when definition is undefined', () => {
+    const result = extractPublicConfig({ secret: 'abc', host: 'localhost' }, undefined)
+    expect(result).toEqual({})
+  })
+
+  test('returns empty object when definition has no publicFields or resolvePublicConfig', () => {
+    const def = makeDefinition()
+    const result = extractPublicConfig(
+      { apiKey: 'secret123', host: 'https://example.com' },
+      def,
+    )
+    expect(result).toEqual({})
+  })
+
+  test('returns empty object when publicFields is an empty array', () => {
+    const def = makeDefinition({ publicFields: [] })
+    const result = extractPublicConfig(
+      { apiKey: 'secret123', host: 'https://example.com' },
+      def,
+    )
+    expect(result).toEqual({})
+  })
+
+  test('returns only fields listed in publicFields', () => {
+    const def = makeDefinition({ publicFields: ['host'] })
+    const result = extractPublicConfig(
+      { apiKey: 'secret123', host: 'https://example.com', extra: 'data' },
+      def,
+    )
+    expect(result).toEqual({ host: 'https://example.com' })
+  })
+
+  test('does not include publicFields that are missing from config', () => {
+    const def = makeDefinition({ publicFields: ['host', 'missingField'] })
+    const result = extractPublicConfig({ host: 'https://example.com' }, def)
+    expect(result).toEqual({ host: 'https://example.com' })
+  })
+
+  test('never leaks fields not in publicFields', () => {
+    const def = makeDefinition({ publicFields: ['accessToken'] })
+    const config = {
+      accessToken: 'pk.abc123',
+      clientSecret: 'supersecret',
+      apiKey: 'key123',
+      password: 'hunter2',
+    }
+    const result = extractPublicConfig(config, def)
+    expect(result).toEqual({ accessToken: 'pk.abc123' })
+    expect(result).not.toHaveProperty('clientSecret')
+    expect(result).not.toHaveProperty('apiKey')
+    expect(result).not.toHaveProperty('password')
+  })
+
+  test('supports multiple publicFields', () => {
+    const def = makeDefinition({ publicFields: ['accessToken', 'host'] })
+    const config = {
+      accessToken: 'pk.abc123',
+      host: 'https://example.com',
+      clientSecret: 'supersecret',
+    }
+    const result = extractPublicConfig(config, def)
+    expect(result).toEqual({
+      accessToken: 'pk.abc123',
+      host: 'https://example.com',
+    })
+  })
+
+  test('resolvePublicConfig takes precedence over publicFields', () => {
+    const def = makeDefinition({
+      publicFields: ['raw'],
+      resolvePublicConfig: (config) => ({
+        derivedUrl: `https://${config.host}/api`,
+      }),
+    })
+    const result = extractPublicConfig(
+      { host: 'example.com', raw: 'value', secret: 'hidden' },
+      def,
+    )
+    expect(result).toEqual({ derivedUrl: 'https://example.com/api' })
+    expect(result).not.toHaveProperty('raw')
+    expect(result).not.toHaveProperty('secret')
+  })
+
+  test('resolvePublicConfig can return empty object', () => {
+    const def = makeDefinition({
+      resolvePublicConfig: () => ({}),
+    })
+    const result = extractPublicConfig({ secret: 'abc' }, def)
+    expect(result).toEqual({})
+  })
+
+  test('handles empty config object', () => {
+    const def = makeDefinition({ publicFields: ['accessToken'] })
+    const result = extractPublicConfig({}, def)
+    expect(result).toEqual({})
+  })
+
+  // OSM system integration specific test
+  test('OSM resolvePublicConfig resolves production server URL', () => {
+    const resolvePublicConfig = (config: Record<string, any>) => {
+      const server = config.server || 'production'
+      const OSM_SERVERS: Record<string, string> = {
+        production: 'https://www.openstreetmap.org',
+        sandbox: 'https://master.apis.dev.openstreetmap.org',
+      }
+      let serverUrl: string
+      if (server === 'custom' && config.customServerUrl) {
+        serverUrl = config.customServerUrl.replace(/\/+$/, '')
+      } else {
+        serverUrl = OSM_SERVERS[server] || OSM_SERVERS.production
+      }
+      return { serverUrl }
+    }
+
+    expect(
+      resolvePublicConfig({ server: 'production', clientId: 'id', clientSecret: 'secret' }),
+    ).toEqual({ serverUrl: 'https://www.openstreetmap.org' })
+
+    expect(
+      resolvePublicConfig({ server: 'sandbox', clientId: 'id', clientSecret: 'secret' }),
+    ).toEqual({ serverUrl: 'https://master.apis.dev.openstreetmap.org' })
+
+    expect(
+      resolvePublicConfig({
+        server: 'custom',
+        customServerUrl: 'https://osm.local/',
+        clientId: 'id',
+      }),
+    ).toEqual({ serverUrl: 'https://osm.local' })
+
+    // Falls back to production for unknown server values
+    expect(
+      resolvePublicConfig({ server: 'unknown' }),
+    ).toEqual({ serverUrl: 'https://www.openstreetmap.org' })
+
+    // Falls back to production when server is missing
+    expect(
+      resolvePublicConfig({}),
+    ).toEqual({ serverUrl: 'https://www.openstreetmap.org' })
+
+    // Never leaks secrets
+    const result = resolvePublicConfig({
+      server: 'sandbox',
+      clientId: 'my-client-id',
+      clientSecret: 'my-secret',
+      redirectUri: 'https://example.com/callback',
+    })
+    expect(result).toEqual({ serverUrl: 'https://master.apis.dev.openstreetmap.org' })
+    expect(result).not.toHaveProperty('clientId')
+    expect(result).not.toHaveProperty('clientSecret')
+    expect(result).not.toHaveProperty('redirectUri')
+  })
+})

--- a/server/src/services/integration.service.ts
+++ b/server/src/services/integration.service.ts
@@ -25,7 +25,7 @@ const availableIntegrations: IntegrationDefinition[] = [
     paid: true,
     cloud: true,
     configSchema: 'mapboxSchema',
-    public: true,
+    publicFields: ['accessToken'],
     scope: [IntegrationScope.SYSTEM],
   },
   {
@@ -144,7 +144,7 @@ const availableIntegrations: IntegrationDefinition[] = [
     paid: false,
     cloud: true,
     configSchema: 'mapillarySchema',
-    public: true,
+    publicFields: ['accessToken'],
     scope: [IntegrationScope.SYSTEM],
   },
   {
@@ -235,7 +235,7 @@ const availableIntegrations: IntegrationDefinition[] = [
     paid: true,
     cloud: true,
     configSchema: 'apiKeySchema',
-    public: true,
+    publicFields: ['apiKey'],
     scope: [IntegrationScope.SYSTEM],
   },
   {
@@ -261,7 +261,21 @@ const availableIntegrations: IntegrationDefinition[] = [
     capabilities: [],
     paid: false,
     cloud: true,
-    configSchema: 'oauthConfigSchema',
+    configSchema: 'openstreetmapSystemSchema',
+    resolvePublicConfig: (config) => {
+      const server = config.server || 'production'
+      const OSM_SERVERS: Record<string, string> = {
+        production: 'https://www.openstreetmap.org',
+        sandbox: 'https://master.apis.dev.openstreetmap.org',
+      }
+      let serverUrl: string
+      if (server === 'custom' && config.customServerUrl) {
+        serverUrl = config.customServerUrl.replace(/\/+$/, '')
+      } else {
+        serverUrl = OSM_SERVERS[server] || OSM_SERVERS.production
+      }
+      return { serverUrl }
+    },
     scope: [IntegrationScope.SYSTEM],
   },
   {
@@ -278,6 +292,7 @@ const availableIntegrations: IntegrationDefinition[] = [
     paid: false,
     cloud: true,
     configSchema: 'openstreetmapOAuthSchema',
+    publicFields: ['osmDisplayName', 'osmProfileImageUrl', 'osmAccountCreated', 'osmChangesetCount', 'osmTraceCount'],
     authType: 'oauth2',
     scope: [IntegrationScope.USER],
     requiresSystemIntegration: IntegrationId.OPENSTREETMAP,
@@ -448,25 +463,32 @@ export async function getAvailableIntegrations(): Promise<
   return availableIntegrations
 }
 
-export async function getPublicIntegrations(): Promise<any[]> {
-  // Get system-wide integrations only (public integrations are typically system-wide)
-  const systemIntegrations = await getConfiguredIntegrations()
+/**
+ * Extract only the public fields from an integration's config,
+ * based on the `publicFields` list in its definition.
+ * If the definition provides a `resolvePublicConfig` callback,
+ * it takes precedence over the raw field list.
+ * Returns an empty object when the definition has no public fields.
+ */
+export function extractPublicConfig(
+  config: Record<string, any>,
+  definition: IntegrationDefinition | undefined,
+): Record<string, any> {
+  if (!definition) return {}
 
-  // Filter to only include public integrations
-  const publicIntegrations = systemIntegrations.filter((integration) => {
-    const definition = availableIntegrations.find(
-      (def) => def.id === integration.integrationId,
-    )
-    return definition?.public === true
-  })
+  // Use custom resolver if provided
+  if (definition.resolvePublicConfig) {
+    return definition.resolvePublicConfig(config)
+  }
 
-  // Return integrations with their config exposed (since they're public)
-  return publicIntegrations.map((integration) => ({
-    id: integration.id,
-    integrationId: integration.integrationId,
-    config: integration.config,
-    capabilities: integration.capabilities, // Include capabilities for client-side filtering
-  }))
+  if (!definition.publicFields?.length) return {}
+  const result: Record<string, any> = {}
+  for (const key of definition.publicFields) {
+    if (key in config) {
+      result[key] = config[key]
+    }
+  }
+  return result
 }
 
 export async function getIntegration(
@@ -621,6 +643,28 @@ export async function updateIntegration(
   return updatedIntegration
 }
 
+/**
+ * Find all configured integrations that depend on the given integration ID
+ * via `requiresSystemIntegration`. Returns records across all users.
+ */
+export async function getDependentIntegrations(
+  integrationId: IntegrationId,
+): Promise<IntegrationRecord[]> {
+  // Find definitions that depend on this integration
+  const dependentDefinitions = availableIntegrations.filter(
+    (def) => def.requiresSystemIntegration === integrationId,
+  )
+  if (dependentDefinitions.length === 0) return []
+
+  const dependentIds = dependentDefinitions.map((def) => def.id)
+
+  // Find all configured instances of those dependent definitions
+  const allIntegrations = await db.select().from(integrations)
+  return allIntegrations
+    .filter((record) => dependentIds.includes(record.integrationId as IntegrationId))
+    .map(parseIntegrationData)
+}
+
 export async function deleteIntegration(
   id: string,
   userId?: string,
@@ -642,7 +686,19 @@ export async function deleteIntegration(
     throw new Error(`Integration with ID ${id} not found`)
   }
 
-  await db.delete(integrations).where(eq(integrations.id, id))
+  const record = parseIntegrationData(result[0])
+
+  // Cascade-delete dependent integrations (e.g. user OSM accounts when
+  // the system OSM integration is removed)
+  const dependents = await getDependentIntegrations(
+    record.integrationId as IntegrationId,
+  )
+  for (const dep of dependents) {
+    await db.delete(integrations).where(eq(integrations.id, dep.id))
+    integrationManager.removeIntegration(dep.userId ?? undefined, dep.id)
+  }
+
+  await db.delete(integrations).where(whereCondition)
 
   integrationManager.removeIntegration(userId, id)
 }

--- a/server/src/services/integrations/openstreetmap-integration.ts
+++ b/server/src/services/integrations/openstreetmap-integration.ts
@@ -10,9 +10,7 @@ import {
   OsmNoteComment,
 } from '../../types/integration.types'
 import { SOURCE } from '../../lib/constants'
-import { osmConfig } from '../../config/osm.config'
-
-const OSM_API_BASE = osmConfig.apiBase
+import { getOsmConfig } from '../../config/osm.config'
 
 export interface OpenStreetMapConfig extends IntegrationConfig {
   accessToken: string
@@ -79,7 +77,7 @@ export class OpenStreetMapIntegration
     }
 
     try {
-      const response = await axios.get(`${OSM_API_BASE}/user/details.json`, {
+      const response = await axios.get(`${getOsmConfig().apiBase}/user/details.json`, {
         headers: this.getAuthHeaders(config.accessToken),
       })
       const user = response.data?.user
@@ -122,7 +120,7 @@ export class OpenStreetMapIntegration
   ): Promise<OsmNote> {
     this.ensureInitialized()
     const response = await axios.post(
-      `${OSM_API_BASE}/notes.json`,
+      `${getOsmConfig().apiBase}/notes.json`,
       null,
       {
         params: { lat, lon: lng, text },
@@ -134,7 +132,7 @@ export class OpenStreetMapIntegration
 
   private async getNote(id: number): Promise<OsmNote> {
     this.ensureInitialized()
-    const response = await axios.get(`${OSM_API_BASE}/notes/${id}.json`, {
+    const response = await axios.get(`${getOsmConfig().apiBase}/notes/${id}.json`, {
       headers: this.getAuthHeaders(),
     })
     return this.adaptNote(response.data.properties)
@@ -143,7 +141,7 @@ export class OpenStreetMapIntegration
   private async commentOnNote(id: number, text: string): Promise<OsmNote> {
     this.ensureInitialized()
     const response = await axios.post(
-      `${OSM_API_BASE}/notes/${id}/comment.json`,
+      `${getOsmConfig().apiBase}/notes/${id}/comment.json`,
       null,
       {
         params: { text },
@@ -156,7 +154,7 @@ export class OpenStreetMapIntegration
   private async closeNote(id: number, text?: string): Promise<OsmNote> {
     this.ensureInitialized()
     const response = await axios.post(
-      `${OSM_API_BASE}/notes/${id}/close.json`,
+      `${getOsmConfig().apiBase}/notes/${id}/close.json`,
       null,
       {
         params: text ? { text } : undefined,
@@ -177,7 +175,7 @@ export class OpenStreetMapIntegration
       .join('')
     const body = `<osm><changeset>${tagsXml}</changeset></osm>`
 
-    const response = await axios.put(`${OSM_API_BASE}/changeset/create`, body, {
+    const response = await axios.put(`${getOsmConfig().apiBase}/changeset/create`, body, {
       headers: {
         ...this.getAuthHeaders(),
         'Content-Type': 'text/xml',
@@ -192,7 +190,7 @@ export class OpenStreetMapIntegration
   ): Promise<void> {
     this.ensureInitialized()
     await axios.post(
-      `${OSM_API_BASE}/changeset/${changesetId}/upload`,
+      `${getOsmConfig().apiBase}/changeset/${changesetId}/upload`,
       osmChange,
       {
         headers: {
@@ -206,7 +204,7 @@ export class OpenStreetMapIntegration
   private async closeChangeset(changesetId: number): Promise<void> {
     this.ensureInitialized()
     await axios.put(
-      `${OSM_API_BASE}/changeset/${changesetId}/close`,
+      `${getOsmConfig().apiBase}/changeset/${changesetId}/close`,
       null,
       { headers: this.getAuthHeaders() },
     )

--- a/server/src/services/integrations/openstreetmap-system-integration.ts
+++ b/server/src/services/integrations/openstreetmap-system-integration.ts
@@ -6,9 +6,14 @@ import type {
 } from '../../types/integration.types'
 import { IntegrationId, IntegrationCapabilityId } from '../../types/integration.enums'
 
+export type OsmServerOption = 'production' | 'sandbox' | 'custom'
+
 export interface OpenStreetMapSystemConfig extends IntegrationConfig {
   clientId: string
-  clientSecret: string
+  clientSecret?: string
+  server?: OsmServerOption
+  customServerUrl?: string
+  redirectUri?: string
 }
 
 /**
@@ -25,7 +30,7 @@ export class OpenStreetMapSystemIntegration
   readonly capabilities: IntegrationCapabilities = {}
 
   validateConfig(config: OpenStreetMapSystemConfig): boolean {
-    return !!(config?.clientId?.trim() && config?.clientSecret?.trim())
+    return !!config?.clientId?.trim()
   }
 
   async testConnection(
@@ -34,7 +39,7 @@ export class OpenStreetMapSystemIntegration
     if (!this.validateConfig(config)) {
       return {
         success: false,
-        message: 'Client ID and Client Secret are required',
+        message: 'Client ID is required',
       }
     }
     // OAuth app credentials can't be validated without a full user flow,

--- a/server/src/services/integrations/openstreetmap-system-integration.ts
+++ b/server/src/services/integrations/openstreetmap-system-integration.ts
@@ -1,3 +1,4 @@
+import axios from 'axios'
 import type {
   Integration,
   IntegrationConfig,
@@ -7,6 +8,11 @@ import type {
 import { IntegrationId, IntegrationCapabilityId } from '../../types/integration.enums'
 
 export type OsmServerOption = 'production' | 'sandbox' | 'custom'
+
+const OSM_SERVERS: Record<string, string> = {
+  production: 'https://www.openstreetmap.org',
+  sandbox: 'https://master.apis.dev.openstreetmap.org',
+}
 
 export interface OpenStreetMapSystemConfig extends IntegrationConfig {
   clientId: string
@@ -33,6 +39,14 @@ export class OpenStreetMapSystemIntegration
     return !!config?.clientId?.trim()
   }
 
+  private resolveServerUrl(config: OpenStreetMapSystemConfig): string {
+    const server = config.server || 'production'
+    if (server === 'custom' && config.customServerUrl) {
+      return config.customServerUrl.replace(/\/+$/, '')
+    }
+    return OSM_SERVERS[server] || OSM_SERVERS.production
+  }
+
   async testConnection(
     config: OpenStreetMapSystemConfig,
   ): Promise<IntegrationTestResult> {
@@ -42,9 +56,66 @@ export class OpenStreetMapSystemIntegration
         message: 'Client ID is required',
       }
     }
-    // OAuth app credentials can't be validated without a full user flow,
-    // so we just confirm the fields are present.
-    return { success: true }
+
+    const serverUrl = this.resolveServerUrl(config)
+    const tokenEndpoint = `${serverUrl}/oauth2/token`
+
+    try {
+      // Validate OAuth2 credentials by sending a token request with an
+      // intentionally invalid authorization code. If the client ID and
+      // secret are correct, the server returns 400 (bad grant). If they
+      // are wrong, it returns 401 (unauthorized).
+      const params = new URLSearchParams({
+        grant_type: 'authorization_code',
+        code: '__parchment_test__',
+        redirect_uri: config.redirectUri || 'https://localhost',
+        client_id: config.clientId,
+      })
+
+      if (config.clientSecret) {
+        params.set('client_secret', config.clientSecret)
+      }
+
+      const response = await axios.post(tokenEndpoint, params.toString(), {
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        validateStatus: () => true, // Don't throw on any status
+      })
+
+      const { status, data } = response
+      const errorType = typeof data === 'object' ? data?.error : typeof data === 'string' ? data : ''
+
+      if (status === 401 || status === 403) {
+        return {
+          success: false,
+          message: 'Invalid client ID or client secret',
+        }
+      }
+
+      // Some OAuth2 implementations return 400 with "invalid_client"
+      // instead of 401 for bad credentials
+      if (status === 400 && errorType === 'invalid_client') {
+        return {
+          success: false,
+          message: 'Invalid client ID or client secret',
+        }
+      }
+
+      // 400 with other errors (e.g. "invalid_grant") means the credentials
+      // were accepted but the dummy code was (expectedly) rejected — success
+      if (status === 400 || status === 200) {
+        return { success: true, message: `Connected to ${serverUrl}` }
+      }
+
+      return {
+        success: false,
+        message: `Unexpected response from OSM (HTTP ${status})`,
+      }
+    } catch (error: any) {
+      return {
+        success: false,
+        message: `Cannot reach OSM server at ${serverUrl}: ${error.message}`,
+      }
+    }
   }
 
   initialize(config: OpenStreetMapSystemConfig): void {

--- a/server/src/types/auth.types.ts
+++ b/server/src/types/auth.types.ts
@@ -6,8 +6,9 @@ export enum PermissionId {
   ROLES_READ = 'roles:read',
   PERMISSIONS_READ = 'permissions:read',
   SYSTEM_READ = 'system:read', // TODO
-  INTEGRATIONS_READ = 'integrations:read',
+  INTEGRATIONS_READ_USER = 'integrations:read:user',
   INTEGRATIONS_WRITE_USER = 'integrations:write:user',
+  INTEGRATIONS_READ_SYSTEM = 'integrations:read:system',
   INTEGRATIONS_WRITE_SYSTEM = 'integrations:write:system',
   LAYERS_READ = 'layers:read',
   LAYERS_WRITE = 'layers:write',

--- a/server/src/types/integration.types.ts
+++ b/server/src/types/integration.types.ts
@@ -318,7 +318,8 @@ export type IntegrationDefinition = {
   paid: boolean
   cloud: boolean
   configSchema: string // Reference to schema name used on the client
-  public?: boolean // Mark the integration as public/client-facing, keys will be exposed to all users
+  publicFields?: string[] // Config field names safe to expose to all users (including unauthenticated)
+  resolvePublicConfig?: (config: Record<string, any>) => Record<string, any> // Optional override to compute public config from raw config
   scope: IntegrationScope[] // Defines where this integration can be configured
   authType?: 'form' | 'oauth2' // Defaults to 'form'. OAuth2 integrations use redirect-based auth instead of config forms.
   requiresSystemIntegration?: IntegrationId // This integration is only available when the referenced system integration is configured

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.1.2-6",
+  "version": "0.1.3",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.1.2-6"
+version = "0.1.3"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.1.2-6",
+  "version": "0.1.3",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",
@@ -65,7 +65,7 @@
       "developmentTeam": "QPNGAD5BD2"
     },
     "android": {
-      "versionCode": 1026
+      "versionCode": 1030
     }
   }
 }

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -96,10 +96,14 @@ onMounted(async () => {
   commandService.bindAllHotkeysToCommands()
   themeStore.initAccentColor()
   await authService.getAuthenticatedUser()
+
+  // Fetch configured integrations for all users (public fields only).
+  // This provides Mapbox token, OSM server URL, etc. to the client.
+  await integrationService.fetchConfiguredIntegrations()
+
   if (authStore.me) {
     // These calls return immediately if cached, refreshing data in background
     await integrationService.fetchAvailableIntegrations()
-    await integrationService.fetchConfiguredIntegrations()
     // Load existing layers first
     await layersStore.loadLayers()
     // Then populate any missing template layers

--- a/web/src/components/integration/IntegrationForm.vue
+++ b/web/src/components/integration/IntegrationForm.vue
@@ -39,6 +39,15 @@ const formRef = ref(null)
 
 const DOCS_BASE = 'https://docs.parchment.app/usage/integrations'
 
+/** Trim all string values in a flat config object */
+function trimConfigStrings(config: Record<string, any>): Record<string, any> {
+  const result: Record<string, any> = {}
+  for (const [key, value] of Object.entries(config)) {
+    result[key] = typeof value === 'string' ? value.trim() : value
+  }
+  return result
+}
+
 const docsUrl = computed(() => {
   return `${DOCS_BASE}/${props.integration.id}`
 })
@@ -198,7 +207,7 @@ async function testConnection() {
   try {
     const result = await integrationService.testIntegrationConfig(
       props.integration.id,
-      configForm.values,
+      trimConfigStrings(configForm.values),
     )
 
     testResult.value = result
@@ -222,7 +231,7 @@ async function submit() {
   if (!isValid.value) return null
 
   return {
-    config: configForm.values,
+    config: trimConfigStrings(configForm.values),
     capabilities: values.capabilities.map(cap => ({
       id: cap.id,
       active: cap.active,

--- a/web/src/components/integration/IntegrationForm.vue
+++ b/web/src/components/integration/IntegrationForm.vue
@@ -5,6 +5,7 @@ import { useIntegrationService } from '@/services/integration.service'
 import {
   IntegrationDefinition,
   IntegrationRecord,
+  schemaConfigs,
 } from '@/types/integrations.types'
 import { ZodObject } from 'zod'
 import { AutoForm } from '@/components/ui/auto-form'
@@ -16,6 +17,8 @@ import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import * as z from 'zod'
 import { TransitionExpand } from '@morev/vue-transitions'
+import { useServerUrl } from '@/lib/api'
+import { ExternalLinkIcon } from 'lucide-vue-next'
 
 const props = defineProps<{
   integration: IntegrationDefinition
@@ -31,7 +34,31 @@ const emit = defineEmits<{
 const { t } = useI18n()
 const { toast } = useAppService()
 const integrationService = useIntegrationService()
+const serverUrl = useServerUrl()
 const formRef = ref(null)
+
+const DOCS_BASE = 'https://docs.parchment.app/usage/integrations'
+
+const docsUrl = computed(() => {
+  return `${DOCS_BASE}/${props.integration.id}`
+})
+
+const isOsmSystemSchema = computed(
+  () => props.integration.configSchema === 'openstreetmapSystemSchema',
+)
+
+const defaultRedirectUri = computed(() => {
+  const base = serverUrl.value
+  // OSM requires HTTPS redirect URIs. In dev mode (http://localhost),
+  // use https:// so the URI is accepted by OSM for registration.
+  // The dev workaround handles the redirect failure.
+  const httpsBase = base.replace(/^http:\/\//, 'https://')
+  return `${httpsBase}/integrations/osm/callback`
+})
+
+const currentSchemaConfig = computed(() =>
+  schemaConfigs[props.integration.configSchema] ?? {},
+)
 
 interface FormValues {
   config: Record<string, any>
@@ -267,6 +294,13 @@ onMounted(() => {
       validateConfigForm()
     }, 0)
   }
+
+  // Pre-fill default redirect URI for new OSM system integrations
+  if (isOsmSystemSchema.value && !props.isConfigured) {
+    setTimeout(() => {
+      configForm.setFieldValue('redirectUri', defaultRedirectUri.value)
+    }, 0)
+  }
 })
 
 defineExpose({ submit })
@@ -274,11 +308,25 @@ defineExpose({ submit })
 
 <template>
   <div class="space-y-6">
+    <div class="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <ExternalLinkIcon class="size-3.5 shrink-0" />
+      <a
+        :href="docsUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="underline hover:text-foreground transition-colors"
+      >
+        {{ t('settings.integrations.viewDocs') }}
+      </a>
+    </div>
+
     <!-- TODO: Add "show secrets" toggle to text fields -->
     <AutoForm
       ref="formRef"
       :schema="schema"
       :form="configForm"
+      :field-config="currentSchemaConfig.fieldConfig"
+      :dependencies="currentSchemaConfig.dependencies"
       class="space-y-4"
     />
 

--- a/web/src/components/integration/IntegrationTile.vue
+++ b/web/src/components/integration/IntegrationTile.vue
@@ -50,11 +50,102 @@ async function handleOAuthClick() {
   const isConfigured = !!config
 
   if (!isConfigured) {
-    // Redirect to OAuth authorization
+    // Open OAuth authorization in a popup/new tab
     try {
       const response = await api.get('/integrations/osm/authorize')
       const { url } = response.data
-      window.location.href = url
+
+      const isDevMode = window.location.protocol === 'http:'
+
+      if (isDevMode) {
+        // Dev mode: OSM doesn't allow HTTP redirect URIs, so provide a console-based workaround.
+        // Open the auth URL - the redirect will fail, but the user can copy the URL from the browser.
+        window.open(url, '_blank')
+
+        // Register a global callback for the dev workaround
+        ;(window as any).__osmDevCallback = async (redirectUrl: string) => {
+          try {
+            const parsedUrl = new URL(redirectUrl)
+            const code = parsedUrl.searchParams.get('code')
+            const state = parsedUrl.searchParams.get('state')
+
+            if (!code || !state) {
+              console.error('Missing code or state in URL. Make sure you copied the full URL.')
+              return
+            }
+
+            // Call the callback endpoint directly - it returns HTML but the server-side
+            // still performs the token exchange and creates the integration record
+            const response = await api.get('/integrations/osm/callback', {
+              params: { code, state },
+              // Accept any response type since it returns HTML
+              transformResponse: [(data: any) => data],
+            })
+
+            // Parse the HTML response to check for success/error
+            const html = response.data as string
+            if (html.includes('"status":"error"')) {
+              const msgMatch = html.match(/"message":"([^"]*)"/)
+              const errorMsg = msgMatch?.[1] || 'OAuth callback failed'
+              console.error(`%c❌ ${errorMsg}`, 'color: red; font-weight: bold;')
+              toast.error(errorMsg)
+              return
+            }
+
+            toast.success(t('settings.integrations.osm.connected'))
+            await integrationService.fetchConfiguredIntegrations()
+            await integrationService.fetchAvailableIntegrations()
+
+            delete (window as any).__osmDevCallback
+            console.log('%c✅ OSM account connected successfully!', 'color: green; font-weight: bold;')
+          } catch (error: any) {
+            console.error('Dev OAuth callback failed:', error)
+            toast.error(error.message || t('settings.integrations.osm.authError'))
+          }
+        }
+
+        console.log(
+          '%c🔑 OSM OAuth Dev Mode',
+          'font-weight: bold; font-size: 14px;',
+        )
+        console.log(
+          'After authorizing on OSM, the redirect will fail because the\n' +
+          'redirect URI uses HTTPS but your local server runs on HTTP.\n\n' +
+          'Copy the full URL from the browser address bar (it will contain\n' +
+          '?code=...&state=... parameters) and run:\n\n' +
+          "  window.__osmDevCallback('PASTE_FULL_URL_HERE')\n",
+        )
+
+        toast.info(t('settings.integrations.osm.devCallbackInstructions'))
+      } else {
+        const popup = window.open(url, 'osm-oauth', 'width=600,height=700,popup=yes')
+
+        // Listen for the callback postMessage from the popup
+        const expectedOrigin = new URL(api.defaults.baseURL as string).origin
+        const onMessage = async (event: MessageEvent) => {
+          if (event.data?.type !== 'osm-oauth-callback') return
+          if (event.origin !== expectedOrigin) return
+          window.removeEventListener('message', onMessage)
+
+          if (event.data.status === 'connected') {
+            toast.success(t('settings.integrations.osm.connected'))
+            await integrationService.fetchConfiguredIntegrations()
+            await integrationService.fetchAvailableIntegrations()
+          } else {
+            toast.error(event.data.message || t('settings.integrations.osm.authError'))
+          }
+        }
+
+        window.addEventListener('message', onMessage)
+
+        // Clean up listener if popup is closed without completing
+        const checkClosed = setInterval(() => {
+          if (popup?.closed) {
+            clearInterval(checkClosed)
+            window.removeEventListener('message', onMessage)
+          }
+        }, 500)
+      }
     } catch (error) {
       console.error('Failed to initiate OAuth flow:', error)
       toast.error(t('settings.integrations.osm.authError'))
@@ -127,6 +218,19 @@ async function handleClick() {
     return
   }
 
+  // When editing, fetch full config (including secrets) via the detail endpoint
+  let fullConfig: IntegrationRecord | undefined = config
+  if (isConfigured && config) {
+    try {
+      const response = await api.get<IntegrationRecord>(`/integrations/${config.id}`)
+      fullConfig = response.data
+    } catch (err) {
+      console.error('Failed to fetch full integration config:', err)
+      toast.error('Failed to load integration configuration')
+      return
+    }
+  }
+
   // Show our custom IntegrationForm component in a dialog
   const dialogResult = await appService.componentDialog({
     component: IntegrationForm,
@@ -134,7 +238,7 @@ async function handleClick() {
       integration,
       schema: formSchema,
       isConfigured,
-      config,
+      config: fullConfig,
     },
     footerPrepend: isConfigured
       ? () =>
@@ -199,11 +303,30 @@ async function handleDisconnect(
   integration: IntegrationDefinition,
   config: IntegrationRecord,
 ) {
+  // Check for dependent integrations before deleting
+  let dependents: { id: string; integrationId: string; userId: string | null; name: string }[] = []
+  try {
+    const response = await api.get(`/integrations/${config.id}/dependents`)
+    dependents = response.data
+  } catch {
+    // If we can't check dependents (e.g. no permission), proceed with basic confirm
+  }
+
+  let description = t('settings.integrations.disconnect.description', {
+    name: integration.name,
+  })
+
+  if (dependents.length > 0) {
+    const names = [...new Set(dependents.map((d) => d.name))].join(', ')
+    description += '\n\n' + t('settings.integrations.disconnect.dependentsWarning', {
+      count: dependents.length,
+      names,
+    })
+  }
+
   const confirmed = await appService.confirm({
     title: t('settings.integrations.disconnect.title'),
-    description: t('settings.integrations.disconnect.description', {
-      name: integration.name,
-    }),
+    description,
     continueText: t('settings.integrations.osm.disconnect'),
     cancelText: t('general.cancel'),
     destructive: true,

--- a/web/src/components/integration/OsmConnectedAccount.vue
+++ b/web/src/components/integration/OsmConnectedAccount.vue
@@ -3,8 +3,10 @@ import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import {
   IntegrationDefinition,
+  IntegrationId,
   IntegrationRecord,
 } from '@/types/integrations.types'
+import { useIntegrationsStore } from '@/stores/integrations.store'
 import { Switch } from '@/components/ui/switch'
 import { Label } from '@/components/ui/label'
 import { ExternalLinkIcon } from 'lucide-vue-next'
@@ -19,7 +21,12 @@ const emit = defineEmits<{
   (e: 'update:valid', valid: boolean): void
 }>()
 
+const DOCS_BASE = 'https://docs.parchment.app/usage/integrations'
+
 const { t } = useI18n()
+const integrationsStore = useIntegrationsStore()
+
+const docsUrl = `${DOCS_BASE}/${props.integration.id}`
 
 const capabilities = ref(
   props.integration.capabilities?.map(capId => ({
@@ -37,9 +44,11 @@ const osmProfileImageUrl = computed(
   () => (props.config?.config as any)?.osmProfileImageUrl as string | undefined,
 )
 
-const osmProfileUrl = computed(
-  () => `https://www.openstreetmap.org/user/${encodeURIComponent(osmDisplayName.value)}`,
-)
+const osmProfileUrl = computed(() => {
+  const osmConfig = integrationsStore.getIntegrationConfig(IntegrationId.OPENSTREETMAP)
+  const baseUrl = (osmConfig?.serverUrl as string) || 'https://www.openstreetmap.org'
+  return `${baseUrl}/user/${encodeURIComponent(osmDisplayName.value)}`
+})
 
 function toggleCapability(capabilityId: string, enabled: boolean) {
   const cap = capabilities.value.find(c => c.id === capabilityId)
@@ -62,6 +71,18 @@ defineExpose({ submit })
 
 <template>
   <div class="space-y-6">
+    <div class="flex items-center gap-1.5 text-sm text-muted-foreground">
+      <ExternalLinkIcon class="size-3.5 shrink-0" />
+      <a
+        :href="docsUrl"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="underline hover:text-foreground transition-colors"
+      >
+        {{ t('settings.integrations.viewDocs') }}
+      </a>
+    </div>
+
     <!-- Connected account info -->
     <div class="flex items-center gap-4 p-4 border border-border rounded-lg bg-muted/30">
       <Avatar size="sm" shape="circle">
@@ -112,5 +133,6 @@ defineExpose({ submit })
         </div>
       </div>
     </div>
+
   </div>
 </template>

--- a/web/src/components/map/StreetView.vue
+++ b/web/src/components/map/StreetView.vue
@@ -9,13 +9,15 @@ import { cn } from '@/lib/utils'
 import { TransitionFade } from '@morev/vue-transitions'
 import { Loader2Icon } from 'lucide-vue-next'
 import { updatePegmanData } from '@/lib/pegman.utils'
-import { api } from '@/lib/api'
+import { useIntegrationsStore } from '@/stores/integrations.store'
+import { IntegrationId } from '@server/types/integration.types'
 
 let viewer: Viewer | null = null
 const container = ref()
 const loading = ref(false)
 
 const mapService = useMapService()
+const integrationsStore = useIntegrationsStore()
 
 const props = defineProps<{
   pipSwapped: boolean
@@ -24,14 +26,11 @@ const props = defineProps<{
 const router = useRouter()
 const route = useRoute()
 
-async function getMapillaryAccessToken(): Promise<string | undefined> {
-  try {
-    const { data } = await api.get('/integrations/public')
-    const mapillary = (data as any[]).find(i => i.integrationId === 'mapillary')
-    return mapillary?.config?.accessToken
-  } catch (e) {
-    return undefined
-  }
+function getMapillaryAccessToken(): string | undefined {
+  return integrationsStore.getIntegrationConfigValue(
+    IntegrationId.MAPILLARY,
+    'accessToken',
+  ) as string | undefined
 }
 
 async function updatePegman(viewer: Viewer) {
@@ -54,7 +53,7 @@ onMounted(async () => {
   if (!container.value) return
 
   const token =
-    (await getMapillaryAccessToken()) ||
+    getMapillaryAccessToken() ||
     import.meta.env.VITE_MAPILLARY_ACCESS_TOKEN
 
   const options: ViewerOptions = {

--- a/web/src/components/navigation/AccountDropdown.vue
+++ b/web/src/components/navigation/AccountDropdown.vue
@@ -87,7 +87,7 @@ onMounted(() => {
     latestRelease.value = release
   })
 })
-const API_DOCS_HREF = 'https://docs.parchment.app/docs/api'
+const API_DOCS_HREF = 'https://docs.parchment.app/api'
 
 // Language options from command store
 const languageOptions = computed(() =>

--- a/web/src/components/notes/NoteDetailPanel.vue
+++ b/web/src/components/notes/NoteDetailPanel.vue
@@ -20,6 +20,8 @@ import {
 } from '@/components/ui/tooltip'
 import type { OsmNote } from '@/types/notes.types'
 import NoteComment from './NoteComment.vue'
+import { useIntegrationsStore } from '@/stores/integrations.store'
+import { IntegrationId } from '@server/types/integration.types'
 
 const props = defineProps<{
   note: OsmNote | null
@@ -36,6 +38,7 @@ const emit = defineEmits<{
 }>()
 
 const { t } = useI18n()
+const integrationsStore = useIntegrationsStore()
 
 const commentText = ref('')
 
@@ -44,9 +47,14 @@ const noteStatus = computed(() => {
   return props.note.status
 })
 
+const osmServerUrl = computed(() => {
+  const config = integrationsStore.getIntegrationConfig(IntegrationId.OPENSTREETMAP)
+  return (config?.serverUrl as string) || 'https://www.openstreetmap.org'
+})
+
 const osmNoteUrl = computed(() => {
   if (!props.note) return ''
-  return `https://www.openstreetmap.org/note/${props.note.id}`
+  return `${osmServerUrl.value}/note/${props.note.id}`
 })
 
 const createdDate = computed(() => {

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -1020,6 +1020,7 @@
       "disconnect": {
         "title": "Disconnect Integration",
         "description": "Are you sure you want to disconnect the {name} integration?",
+        "dependentsWarning": "This will also remove {count} dependent integration(s) ({names}) that rely on it.",
         "success": "{name} integration successfully disconnected"
       },
       "test": {
@@ -1072,8 +1073,8 @@
         "openweathermap": "Weather data and air quality information",
         "axiom": "Send server logs and traces to Axiom for debugging and monitoring",
         "barrelman": "Self-hosted OSM search and spatial engine",
-        "openstreetmap": "Configure OSM OAuth application credentials for user authentication",
-        "openstreetmap-account": "Connect your OSM account to add notes, comments, and make quick edits"
+        "openstreetmap": "Configure OSM OAuth",
+        "openstreetmap-account": "Add notes, comments, and make quick edits"
       },
       "osm": {
         "connected": "OpenStreetMap account connected successfully",
@@ -1081,8 +1082,11 @@
         "authError": "Failed to connect OpenStreetMap account",
         "disconnectError": "Failed to disconnect OpenStreetMap account",
         "disconnect": "Disconnect",
-        "viewProfile": "View OSM profile"
-      }
+        "viewProfile": "View OSM profile",
+        "configureOAuthApp": "Configure OAuth application on OSM server",
+        "devCallbackInstructions": "Dev mode: After authorizing in the browser, copy the full redirect URL and run window.__osmDevCallback('URL') in the console"
+      },
+      "viewDocs": "View documentation"
     },
     "users": {
       "title": "Users & Roles",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -983,6 +983,7 @@
       "disconnect": {
         "title": "Desconectar Integración",
         "description": "¿Estás seguro que quieres desconectar la integración {name}?",
+        "dependentsWarning": "Esto también eliminará {count} integración(es) dependiente(s) ({names}) que dependen de ella.",
         "success": "Integración {name} desconectada exitosamente"
       },
       "test": {
@@ -1033,8 +1034,8 @@
         "openweathermap": "Datos meteorológicos e información de calidad del aire",
         "axiom": "Enviar registros y trazas del servidor a Axiom para depuración y monitoreo",
         "barrelman": "Motor de búsqueda y espacial OSM autoalojado",
-        "openstreetmap": "Configurar credenciales de la aplicación OAuth de OSM para la autenticación de usuarios",
-        "openstreetmap-account": "Conecta tu cuenta OSM para agregar notas, comentarios y hacer ediciones rápidas"
+        "openstreetmap": "Configurar credenciales OAuth de OSM",
+        "openstreetmap-account": "Agregar notas, comentarios y hacer ediciones rápidas"
       },
       "osm": {
         "connected": "Cuenta de OpenStreetMap conectada exitosamente",
@@ -1042,8 +1043,11 @@
         "authError": "Error al conectar la cuenta de OpenStreetMap",
         "disconnectError": "Error al desconectar la cuenta de OpenStreetMap",
         "disconnect": "Desconectar",
-        "viewProfile": "Ver perfil de OSM"
-      }
+        "viewProfile": "Ver perfil de OSM",
+        "configureOAuthApp": "Configurar aplicación OAuth en el servidor OSM",
+        "devCallbackInstructions": "Modo dev: Después de autorizar en el navegador, copia la URL de redirección completa y ejecuta window.__osmDevCallback('URL') en la consola"
+      },
+      "viewDocs": "Ver documentación"
     },
     "users": {
       "title": "Usuarios y Roles",

--- a/web/src/services/integration.service.ts
+++ b/web/src/services/integration.service.ts
@@ -11,6 +11,7 @@ import {
 import { api } from '@/lib/api'
 import { useIntegrationsStore } from '@/stores/integrations.store'
 import { useLayersStore } from '@/stores/layers.store'
+import { useNotesStore } from '@/stores/notes.store'
 
 function hasMapLayerCapability(
   integration?:
@@ -38,6 +39,13 @@ export function useIntegrationService() {
         await layersStore.loadLayers()
       }
     } catch (e) {}
+  }
+
+  function clearNotesCacheIfNeeded(integrationId?: string) {
+    if (integrationId === IntegrationId.OPENSTREETMAP) {
+      const notesStore = useNotesStore()
+      notesStore.clearCache()
+    }
   }
 
   async function createIntegration(
@@ -81,6 +89,7 @@ export function useIntegrationService() {
     const configsAfterUpdate = Array.isArray(store.integrationConfigurations) ? store.integrationConfigurations : []
     const updated = configsAfterUpdate.find(i => i.id === id)
     await refreshLayersIfNeeded(updated?.integrationId)
+    clearNotesCacheIfNeeded(updated?.integrationId)
     return response.data
   }
 
@@ -96,6 +105,7 @@ export function useIntegrationService() {
     await fetchConfiguredIntegrations()
     await fetchAvailableIntegrations()
     await refreshLayersIfNeeded(deleted?.integrationId)
+    clearNotesCacheIfNeeded(deleted?.integrationId)
     isLoading.value = false
 
     return true

--- a/web/src/stores/integrations.store.test.ts
+++ b/web/src/stores/integrations.store.test.ts
@@ -1,0 +1,258 @@
+/**
+ * Unit tests for integrations store
+ *
+ * Tests cover:
+ * - Public config field access (mapbox token, OSM server URL, etc.)
+ * - Computed values (mapboxAccessToken, osmProfile, isMapboxEngineActive)
+ * - getIntegrationConfig / getIntegrationConfigValue helpers
+ * - Behavior with empty/missing config (public fields only)
+ */
+
+import { describe, test, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useIntegrationsStore } from './integrations.store'
+import { IntegrationId, IntegrationCapabilityId } from '@server/types/integration.types'
+import type { IntegrationRecord } from '@server/types/integration.types'
+
+function makeRecord(overrides: Partial<IntegrationRecord> = {}): IntegrationRecord {
+  return {
+    id: 'rec-1',
+    userId: null,
+    integrationId: 'test' as IntegrationId,
+    config: {},
+    capabilities: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    ...overrides,
+  } as IntegrationRecord
+}
+
+describe('useIntegrationsStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+  })
+
+  describe('getIntegrationConfig', () => {
+    test('returns config for a configured integration', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.MAPBOX,
+          config: { accessToken: 'pk.test123' },
+        }),
+      ]
+
+      const config = store.getIntegrationConfig(IntegrationId.MAPBOX)
+      expect(config).toEqual({ accessToken: 'pk.test123' })
+    })
+
+    test('returns undefined for unconfigured integration', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = []
+
+      const config = store.getIntegrationConfig(IntegrationId.MAPBOX)
+      expect(config).toBeUndefined()
+    })
+
+    test('returns undefined when configurations is null (not yet loaded)', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = null
+
+      const config = store.getIntegrationConfig(IntegrationId.MAPBOX)
+      expect(config).toBeUndefined()
+    })
+  })
+
+  describe('getIntegrationConfigValue', () => {
+    test('returns specific config value', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.MAPBOX,
+          config: { accessToken: 'pk.test123' },
+        }),
+      ]
+
+      expect(store.getIntegrationConfigValue(IntegrationId.MAPBOX, 'accessToken'))
+        .toBe('pk.test123')
+    })
+
+    test('returns undefined for missing key', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.MAPBOX,
+          config: { accessToken: 'pk.test123' },
+        }),
+      ]
+
+      expect(store.getIntegrationConfigValue(IntegrationId.MAPBOX, 'nonExistent'))
+        .toBeUndefined()
+    })
+  })
+
+  describe('mapboxAccessToken', () => {
+    test('returns token from configured Mapbox integration', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.MAPBOX,
+          config: { accessToken: 'pk.mapbox_token' },
+        }),
+      ]
+
+      expect(store.mapboxAccessToken).toBe('pk.mapbox_token')
+    })
+
+    test('returns undefined when Mapbox is not configured', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = []
+
+      expect(store.mapboxAccessToken).toBeUndefined()
+    })
+
+    test('returns undefined when config has empty object (public fields stripped)', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.MAPBOX,
+          config: {},
+        }),
+      ]
+
+      expect(store.mapboxAccessToken).toBeUndefined()
+    })
+  })
+
+  describe('osmProfile', () => {
+    test('returns profile data from OSM account integration', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.OPENSTREETMAP_ACCOUNT,
+          config: {
+            osmDisplayName: 'testuser',
+            osmProfileImageUrl: 'https://example.com/avatar.png',
+            osmAccountCreated: '2020-01-01',
+            osmChangesetCount: 42,
+            osmTraceCount: 5,
+          },
+        }),
+      ]
+
+      expect(store.osmProfile).toEqual({
+        osmDisplayName: 'testuser',
+        osmProfileImageUrl: 'https://example.com/avatar.png',
+        osmAccountCreated: '2020-01-01',
+        osmChangesetCount: 42,
+        osmTraceCount: 5,
+      })
+    })
+
+    test('returns null when OSM account is not configured', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = []
+
+      expect(store.osmProfile).toBeNull()
+    })
+
+    test('handles partial profile data (some fields public, some stripped)', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.OPENSTREETMAP_ACCOUNT,
+          config: {
+            osmDisplayName: 'testuser',
+            // Other profile fields might be missing
+          },
+        }),
+      ]
+
+      const profile = store.osmProfile
+      expect(profile).not.toBeNull()
+      expect(profile!.osmDisplayName).toBe('testuser')
+      expect(profile!.osmProfileImageUrl).toBeUndefined()
+    })
+  })
+
+  describe('isCapabilityActive', () => {
+    test('returns true for active capability', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.MAPBOX,
+          config: { accessToken: 'pk.test' },
+          capabilities: [
+            { id: IntegrationCapabilityId.MAP_ENGINE, active: true },
+          ],
+        }),
+      ]
+
+      expect(store.isCapabilityActive(IntegrationId.MAPBOX, IntegrationCapabilityId.MAP_ENGINE))
+        .toBe(true)
+    })
+
+    test('returns false for inactive capability', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [
+        makeRecord({
+          integrationId: IntegrationId.MAPBOX,
+          config: { accessToken: 'pk.test' },
+          capabilities: [
+            { id: IntegrationCapabilityId.MAP_ENGINE, active: false },
+          ],
+        }),
+      ]
+
+      expect(store.isCapabilityActive(IntegrationId.MAPBOX, IntegrationCapabilityId.MAP_ENGINE))
+        .toBe(false)
+    })
+
+    test('returns false for unconfigured integration', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = []
+
+      expect(store.isCapabilityActive(IntegrationId.MAPBOX, IntegrationCapabilityId.MAP_ENGINE))
+        .toBe(false)
+    })
+  })
+
+  describe('integrationsReady', () => {
+    test('returns false when neither data source is loaded', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = null
+      store.availableIntegrations = null
+
+      expect(store.integrationsReady).toBe(false)
+    })
+
+    test('returns false when only configurations loaded', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = []
+      store.availableIntegrations = null
+
+      expect(store.integrationsReady).toBe(false)
+    })
+
+    test('returns true when both are loaded (even if empty)', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = []
+      store.availableIntegrations = []
+
+      expect(store.integrationsReady).toBe(true)
+    })
+  })
+
+  describe('clearCache', () => {
+    test('resets both data sources to null', () => {
+      const store = useIntegrationsStore()
+      store.integrationConfigurations = [makeRecord()]
+      store.availableIntegrations = []
+
+      store.clearCache()
+
+      expect(store.integrationConfigurations).toBeNull()
+      expect(store.availableIntegrations).toBeNull()
+    })
+  })
+})

--- a/web/src/stores/notes.store.test.ts
+++ b/web/src/stores/notes.store.test.ts
@@ -1,0 +1,202 @@
+/**
+ * Unit tests for notes store
+ *
+ * Tests cover:
+ * - Tile-based caching (getUnloadedTileBboxes, markTilesLoaded)
+ * - Note merging and deduplication
+ * - Cache clearing
+ * - Bbox filtering
+ */
+
+import { describe, test, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useNotesStore, parseBbox, bboxToString } from './notes.store'
+import type { OsmNote } from '@/types/notes.types'
+
+function makeNote(overrides: Partial<OsmNote> = {}): OsmNote {
+  return {
+    id: 1,
+    lat: 40.0,
+    lng: -74.0,
+    status: 'open',
+    comments: [],
+    createdAt: new Date().toISOString(),
+    ...overrides,
+  }
+}
+
+describe('parseBbox', () => {
+  test('parses comma-separated bbox string', () => {
+    const bbox = parseBbox('-74.1,40.0,-73.9,40.2')
+    expect(bbox).toEqual({ west: -74.1, south: 40, east: -73.9, north: 40.2 })
+  })
+})
+
+describe('bboxToString', () => {
+  test('converts bbox object to string', () => {
+    const str = bboxToString({ west: -74.1, south: 40, east: -73.9, north: 40.2 })
+    expect(str).toBe('-74.1,40,-73.9,40.2')
+  })
+})
+
+describe('useNotesStore', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    localStorage.clear()
+  })
+
+  describe('mergeNotes', () => {
+    test('adds new notes to the store', () => {
+      const store = useNotesStore()
+      const notes = [makeNote({ id: 1 }), makeNote({ id: 2 })]
+
+      store.mergeNotes(notes)
+
+      expect(store.notes).toHaveLength(2)
+    })
+
+    test('updates existing notes by ID (deduplication)', () => {
+      const store = useNotesStore()
+      store.mergeNotes([makeNote({ id: 1, status: 'open' })])
+      store.mergeNotes([makeNote({ id: 1, status: 'closed' })])
+
+      expect(store.notes).toHaveLength(1)
+      expect(store.notes[0].status).toBe('closed')
+    })
+
+    test('enforces max cached notes limit', () => {
+      const store = useNotesStore()
+      const notes = Array.from({ length: 600 }, (_, i) =>
+        makeNote({
+          id: i + 1,
+          createdAt: new Date(Date.now() - i * 1000).toISOString(),
+        }),
+      )
+
+      store.mergeNotes(notes)
+
+      // MAX_CACHED_NOTES is 500
+      expect(store.notes.length).toBeLessThanOrEqual(500)
+    })
+  })
+
+  describe('updateNote', () => {
+    test('updates an existing note in place', () => {
+      const store = useNotesStore()
+      store.mergeNotes([makeNote({ id: 1, status: 'open' })])
+
+      store.updateNote(makeNote({ id: 1, status: 'closed' }))
+
+      expect(store.notes).toHaveLength(1)
+      expect(store.notes[0].status).toBe('closed')
+    })
+
+    test('adds a new note if not found', () => {
+      const store = useNotesStore()
+      store.updateNote(makeNote({ id: 99 }))
+
+      expect(store.notes).toHaveLength(1)
+      expect(store.notes[0].id).toBe(99)
+    })
+  })
+
+  describe('getNotesInBbox', () => {
+    test('returns only notes within the bounding box', () => {
+      const store = useNotesStore()
+      store.mergeNotes([
+        makeNote({ id: 1, lat: 40.1, lng: -74.0 }), // inside
+        makeNote({ id: 2, lat: 50.0, lng: -74.0 }), // outside (too far north)
+        makeNote({ id: 3, lat: 40.1, lng: -80.0 }), // outside (too far west)
+      ])
+
+      const result = store.getNotesInBbox({
+        west: -75,
+        south: 39,
+        east: -73,
+        north: 41,
+      })
+
+      expect(result).toHaveLength(1)
+      expect(result[0].id).toBe(1)
+    })
+  })
+
+  describe('clearCache', () => {
+    test('removes all notes and loaded tiles', () => {
+      const store = useNotesStore()
+      store.mergeNotes([makeNote({ id: 1 }), makeNote({ id: 2 })])
+      store.markTilesLoaded({ west: -74, south: 40, east: -73, north: 41 })
+
+      store.clearCache()
+
+      expect(store.notes).toHaveLength(0)
+    })
+
+    test('subsequent fetches treat all tiles as unloaded after clear', () => {
+      const store = useNotesStore()
+      const bbox = { west: -74, south: 40, east: -73.5, north: 40.5 }
+
+      // Mark tiles as loaded
+      store.markTilesLoaded(bbox)
+      const beforeClear = store.getUnloadedTileBboxes(bbox)
+      expect(beforeClear).toHaveLength(0)
+
+      // Clear cache
+      store.clearCache()
+
+      // Same tiles should now be unloaded
+      const afterClear = store.getUnloadedTileBboxes(bbox)
+      expect(afterClear.length).toBeGreaterThan(0)
+    })
+  })
+
+  describe('getUnloadedTileBboxes', () => {
+    test('returns tile bboxes for an unvisited area', () => {
+      const store = useNotesStore()
+      const bbox = { west: -74, south: 40, east: -73.5, north: 40.5 }
+
+      const tiles = store.getUnloadedTileBboxes(bbox)
+      expect(tiles.length).toBeGreaterThan(0)
+    })
+
+    test('returns empty array after tiles are marked loaded', () => {
+      const store = useNotesStore()
+      const bbox = { west: -74, south: 40, east: -73.5, north: 40.5 }
+
+      // First call returns tiles to fetch
+      const tiles = store.getUnloadedTileBboxes(bbox)
+      expect(tiles.length).toBeGreaterThan(0)
+
+      // Mark them loaded
+      store.markTilesLoaded(bbox)
+
+      // Second call returns empty (all cached)
+      const tilesAfter = store.getUnloadedTileBboxes(bbox)
+      expect(tilesAfter).toHaveLength(0)
+    })
+  })
+
+  describe('selectedNote', () => {
+    test('returns null when no note selected', () => {
+      const store = useNotesStore()
+      expect(store.selectedNote).toBeNull()
+    })
+
+    test('returns the selected note', () => {
+      const store = useNotesStore()
+      store.mergeNotes([makeNote({ id: 42 })])
+      store.selectedNoteId = 42
+
+      expect(store.selectedNote).not.toBeNull()
+      expect(store.selectedNote!.id).toBe(42)
+    })
+
+    test('returns null when selected ID does not match any note', () => {
+      const store = useNotesStore()
+      store.mergeNotes([makeNote({ id: 1 })])
+      store.selectedNoteId = 999
+
+      expect(store.selectedNote).toBeNull()
+    })
+  })
+})

--- a/web/src/stores/notes.store.ts
+++ b/web/src/stores/notes.store.ts
@@ -94,7 +94,6 @@ export const useNotesStore = defineStore('notes', () => {
   const isLayerVisible = useStorage<boolean>('notes-layer-visible', false)
   const lastBbox = ref<string | null>(null)
   const loadedTiles = ref<Record<string, number>>(cache.loadedTiles)
-
   const selectedNote = computed(() => {
     if (selectedNoteId.value === null) return null
     return notes.value.find(note => note.id === selectedNoteId.value) ?? null

--- a/web/src/types/integrations.types.ts
+++ b/web/src/types/integrations.types.ts
@@ -4,15 +4,66 @@ export * from '@server/types/integration.types'
 // Client-side types
 import { z } from 'zod'
 import { IntegrationDefinition } from '@server/types/integration.types'
+import { DependencyType, type Dependency, type Config } from '@/components/ui/auto-form/interface'
 
 // TODO: i18n translate error messages
+
+export interface SchemaConfig {
+  fieldConfig?: Config<any>
+  dependencies?: Dependency<any>[]
+}
+
+/** Per-schema field config and dependencies for AutoForm. */
+export const schemaConfigs: Partial<Record<string, SchemaConfig>> = {
+  openstreetmapSystemSchema: {
+    fieldConfig: {
+      server: {
+        label: 'Server',
+        description: 'Which OpenStreetMap instance to connect to',
+      },
+      customServerUrl: {
+        label: 'Custom Server URL',
+        inputProps: {
+          placeholder: 'https://your-osm-instance.example.com',
+        },
+      },
+      clientId: {
+        label: 'Client ID',
+      },
+      clientSecret: {
+        label: 'Client Secret',
+      },
+      redirectUri: {
+        label: 'Redirect URI',
+        description: 'Must match the redirect URI registered in your OSM OAuth app. HTTPS is required by OSM.',
+        inputProps: {
+          placeholder: 'https://your-server.example.com/integrations/osm/callback',
+        },
+      },
+    },
+    dependencies: [
+      {
+        sourceField: 'server',
+        targetField: 'customServerUrl',
+        type: DependencyType.HIDES,
+        when: (serverValue: string) => serverValue !== 'custom',
+      },
+      {
+        sourceField: 'server',
+        targetField: 'customServerUrl',
+        type: DependencyType.REQUIRES,
+        when: (serverValue: string) => serverValue === 'custom',
+      },
+    ],
+  },
+}
 
 export const configSchemas: Record<
   IntegrationDefinition['configSchema'],
   z.ZodTypeAny
 > = {
   apiKeySchema: z.object({
-    apiKey: z.string().min(1, 'API Key is required'),
+    apiKey: z.string().min(1, 'API Key is required').describe('public'),
   }),
 
   hostConfigSchema: z.object({
@@ -23,6 +74,17 @@ export const configSchemas: Record<
   oauthConfigSchema: z.object({
     clientId: z.string().min(1, 'Client ID is required'),
     clientSecret: z.string().min(1, 'Client Secret is required'),
+  }),
+
+  openstreetmapSystemSchema: z.object({
+    server: z
+      .enum(['production', 'sandbox', 'custom'])
+      .default('production')
+      .describe('public'),
+    customServerUrl: z.string().url('Please enter a valid URL').optional().describe('public'),
+    clientId: z.string().min(1, 'Client ID is required'),
+    clientSecret: z.string().optional(),
+    redirectUri: z.string().url('Please enter a valid URL').optional(),
   }),
 
   nominatimSchema: z.object({
@@ -48,7 +110,7 @@ export const configSchemas: Record<
   }),
 
   mapboxSchema: z.object({
-    accessToken: z.string().min(1, 'Access token is required'),
+    accessToken: z.string().min(1, 'Access token is required').describe('public'),
   }),
 
   valhallaSchema: z.object({
@@ -67,7 +129,7 @@ export const configSchemas: Record<
   ),
 
   mapillarySchema: z.object({
-    accessToken: z.string().min(1, 'Access token is required'),
+    accessToken: z.string().min(1, 'Access token is required').describe('public'),
   }),
 
   transitlandSchema: z.object({

--- a/web/src/views/settings/Navigation.vue
+++ b/web/src/views/settings/Navigation.vue
@@ -56,7 +56,12 @@ const pages: {
     id: 'integrations',
     to: '/settings/integrations',
     icon: BlocksIcon,
-    permissions: PermissionId.INTEGRATIONS_READ,
+    permissions: {
+      any: [
+        PermissionId.INTEGRATIONS_READ_USER,
+        PermissionId.INTEGRATIONS_READ_SYSTEM,
+      ],
+    },
   },
   {
     id: 'users',


### PR DESCRIPTION
### Added
- OSM Notes layer — toggle in layers panel to view OpenStreetMap notes on the map, with grid-based tile caching (0.5° tiles, 24h TTL, 500 note cap)
- Note detail view — view note comments, status, and metadata with sticky header (back button, status badge, external link to OSM) and fixed footer actions
- Note commenting — add comments to open notes, resolve notes, or reopen resolved notes with per-action loading spinners
- Note creation — right-click context menu "Add note" places a draggable amber pulsing marker, submit via form panel
- OSM OAuth2 integration — connect your OpenStreetMap account to associate notes with your profile

### Changed
- Place detail view only removes its own marker instead of calling `removeAllMarkers`, preserving note layer markers
- Added `text-2xs` (0.625rem) font size to Tailwind theme