### PR TITLE
Add dynamic sort/filter system for search results

### DIFF
--- a/server/src/controllers/search.controller.ts
+++ b/server/src/controllers/search.controller.ts
@@ -10,6 +10,7 @@ import {
 import { OverpassIntegration } from '../services/integrations/overpass-integration'
 import { categoryService } from '../services/category.service'
 import { categoryPalette } from '../lib/place-categories'
+import { getPresetById, getPresetFields } from '../lib/osm-presets'
 
 const searchRouter = new Elysia({ prefix: '/search' })
   .use(requireAuth)
@@ -169,18 +170,25 @@ const searchRouter = new Elysia({ prefix: '/search' })
   // TODO: Remove client-side category cache. Return category suggestions in search endpoint
   .post(
     '/category',
-    async ({ body, status }) => {
-      const { presetId, bounds, maxResults = 100 } = body
+    async ({ body, status, language }) => {
+      const { presetId, bounds, maxResults = 100, sort, filter, tags } = body
 
       try {
         const results = await searchService.searchByCategory(presetId, {
           bounds,
           limit: maxResults,
+          sort,
+          filter,
+          tags,
         })
+
+        const preset = getPresetById(presetId)
+        const fieldDefinitions = preset ? getPresetFields(preset, language) : []
 
         return {
           presetId,
           results,
+          fieldDefinitions,
           totalCount: results.length,
           executedAt: new Date().toISOString(),
         }
@@ -204,6 +212,17 @@ const searchRouter = new Elysia({ prefix: '/search' })
           west: t.Number(),
         }),
         maxResults: t.Optional(t.Number({ minimum: 1, maximum: 1000 })),
+        sort: t.Optional(t.Union([
+          t.Literal('relevance'),
+          t.Literal('distance'),
+          t.Literal('name'),
+        ])),
+        filter: t.Optional(t.Object({
+          access: t.Optional(t.Array(t.String())),
+          fee: t.Optional(t.Union([t.Literal('yes'), t.Literal('no')])),
+          hasHours: t.Optional(t.Boolean()),
+        })),
+        tags: t.Optional(t.Record(t.String(), t.String())),
       }),
       detail: {
         tags: ['Search'],

--- a/server/src/lib/display-chips.ts
+++ b/server/src/lib/display-chips.ts
@@ -100,9 +100,17 @@ const CHIP_LABELS: Record<string, ChipDef> = {
   second_hand_only:            { label: 'Second Hand Only',           icon: 'recycle',         sentiment: 'neutral',  category: 'offerings' },
   bulk_purchase_yes:           { label: 'Bulk Purchase',              icon: 'shopping-bag',    sentiment: 'neutral',  category: 'offerings' },
 
-  // ── Water ────────────────────────────────────────────────────────────────
+  // ── Water & Utilities ─────────────────────────────────────────────────────
   drinking_water_yes:  { label: 'Drinking Water',     icon: 'droplet', sentiment: 'positive', category: 'water' },
   drinking_water_no:   { label: 'No Drinking Water',  icon: 'droplet', sentiment: 'negative', category: 'water' },
+  bottle_yes:          { label: 'Bottle Refill',      icon: 'droplet', sentiment: 'positive', category: 'water' },
+  bottle_no:           { label: 'No Bottle Refill',   icon: 'droplet', sentiment: 'negative', category: 'water' },
+  hot_water_yes:       { label: 'Hot Water',          icon: 'droplet', sentiment: 'positive', category: 'water' },
+  hot_water_no:        { label: 'No Hot Water',       icon: 'droplet', sentiment: 'negative', category: 'water' },
+
+  // ── Seasonal & Timing ───────────────────────────────────────────────────
+  seasonal_yes:        { label: 'Seasonal',           icon: 'calendar', sentiment: 'neutral', category: 'timing' },
+  seasonal_no:         { label: 'Year-Round',          icon: 'calendar', sentiment: 'positive', category: 'timing' },
 
   // ── Pets & Family ────────────────────────────────────────────────────────
   dog_yes:             { label: 'Dog Friendly',    icon: 'dog',       sentiment: 'positive', category: 'family' },
@@ -132,6 +140,47 @@ const CHIP_LABELS: Record<string, ChipDef> = {
   'payment:apple_pay_yes':     { label: 'Apple Pay',       icon: 'smartphone',  sentiment: 'positive', category: 'payment' },
   'payment:google_pay_yes':    { label: 'Google Pay',      icon: 'smartphone',  sentiment: 'positive', category: 'payment' },
 
+  // ── Accommodation & Facilities ────────────────────────────────────────────
+  heating_yes:         { label: 'Heating',            icon: 'flame',     sentiment: 'positive', category: 'facilities' },
+  heating_no:          { label: 'No Heating',         icon: 'flame',     sentiment: 'negative', category: 'facilities' },
+  kitchen_yes:         { label: 'Kitchen',            icon: 'cooking-pot', sentiment: 'positive', category: 'facilities' },
+  kitchen_no:          { label: 'No Kitchen',         icon: 'cooking-pot', sentiment: 'negative', category: 'facilities' },
+  fireplace_yes:       { label: 'Fireplace',          icon: 'flame',     sentiment: 'positive', category: 'facilities' },
+  fireplace_no:        { label: 'No Fireplace',       icon: 'flame',     sentiment: 'negative', category: 'facilities' },
+  cabins_yes:          { label: 'Cabins',             icon: 'home',      sentiment: 'positive', category: 'facilities' },
+  caravans_yes:        { label: 'Caravans',           icon: 'home',      sentiment: 'positive', category: 'facilities' },
+  tents_yes:           { label: 'Tents',              icon: 'tent',      sentiment: 'positive', category: 'facilities' },
+  openfire_yes:        { label: 'Open Fire',          icon: 'flame',     sentiment: 'positive', category: 'facilities' },
+  openfire_no:         { label: 'No Open Fire',       icon: 'flame',     sentiment: 'negative', category: 'facilities' },
+  bbq_yes:             { label: 'BBQ',                icon: 'flame',     sentiment: 'positive', category: 'facilities' },
+  bbq_no:              { label: 'No BBQ',             icon: 'flame',     sentiment: 'negative', category: 'facilities' },
+  power_supply_yes:    { label: 'Power Supply',       icon: 'plug',      sentiment: 'positive', category: 'facilities' },
+  power_supply_no:     { label: 'No Power Supply',    icon: 'plug',      sentiment: 'negative', category: 'facilities' },
+
+  // ── Recreation & Outdoor ────────────────────────────────────────────────
+  bench_yes:           { label: 'Bench',              icon: 'armchair',  sentiment: 'positive', category: 'recreation' },
+  bench_no:            { label: 'No Bench',           icon: 'armchair',  sentiment: 'negative', category: 'recreation' },
+  shelter_yes:         { label: 'Shelter',            icon: 'home',      sentiment: 'positive', category: 'recreation' },
+  shelter_no:          { label: 'No Shelter',         icon: 'home',      sentiment: 'negative', category: 'recreation' },
+  picnic_table_yes:    { label: 'Picnic Table',       icon: 'armchair',  sentiment: 'positive', category: 'recreation' },
+  picnic_table_no:     { label: 'No Picnic Table',    icon: 'armchair',  sentiment: 'negative', category: 'recreation' },
+
+  // ── Accessibility Details ───────────────────────────────────────────────
+  handrail_yes:        { label: 'Handrail',           icon: 'accessibility', sentiment: 'positive', category: 'accessibility' },
+  handrail_no:         { label: 'No Handrail',        icon: 'accessibility', sentiment: 'negative', category: 'accessibility' },
+  step_count_yes:      { label: 'Steps',              icon: 'accessibility', sentiment: 'neutral',  category: 'accessibility' },
+
+  // ── Services ────────────────────────────────────────────────────────────
+  dispensing_yes:      { label: 'Dispensing',         icon: 'pill',       sentiment: 'positive', category: 'services' },
+  dispensing_no:       { label: 'Non-Dispensing',     icon: 'pill',       sentiment: 'neutral',  category: 'services' },
+  parcel_pickup_yes:   { label: 'Parcel Pickup',     icon: 'package',    sentiment: 'positive', category: 'services' },
+  parcel_mail_in_yes:  { label: 'Parcel Drop-Off',   icon: 'package',    sentiment: 'positive', category: 'services' },
+  compressed_air_yes:  { label: 'Compressed Air',    icon: 'wind',       sentiment: 'positive', category: 'services' },
+
+  // ── Cycling ─────────────────────────────────────────────────────────────
+  cargo_bike_yes:      { label: 'Cargo Bike',         icon: 'bike',      sentiment: 'positive', category: 'cycling' },
+  cargo_bike_no:       { label: 'No Cargo Bike',      icon: 'bike',      sentiment: 'negative', category: 'cycling' },
+
   // ── Automation ───────────────────────────────────────────────────────────
   automated_yes: { label: 'Automated', icon: 'bot',  sentiment: 'neutral', category: 'automation' },
   automated_no:  { label: 'Staffed',   icon: 'bot',  sentiment: 'neutral', category: 'automation' },
@@ -149,6 +198,14 @@ const CHIP_LABELS: Record<string, ChipDef> = {
   'diet:lactose_free_yes':{ label: 'Lactose Free',   icon: 'leaf', sentiment: 'positive', section: 'diet', category: 'diet' },
   'diet:pescetarian_yes': { label: 'Pescetarian',    icon: 'leaf', sentiment: 'positive', section: 'diet', category: 'diet' },
   'diet:dairy_free_yes':  { label: 'Dairy Free',     icon: 'leaf', sentiment: 'positive', section: 'diet', category: 'diet' },
+}
+
+/**
+ * Look up the curated display label for a tag key+value combination.
+ * Returns null if no curated label exists.
+ */
+export function getChipLabel(key: string, value: string): string | null {
+  return CHIP_LABELS[`${key}_${value}`]?.label ?? null
 }
 
 // ── Root keys eligible for chip display ───────────────────────────────────────

--- a/server/src/lib/osm-presets.ts
+++ b/server/src/lib/osm-presets.ts
@@ -1,5 +1,6 @@
 import type { Language } from './i18n'
 import { getLanguageCode } from './i18n'
+import { getChipLabel } from './display-chips'
 
 export type GeometryType = 'point' | 'line' | 'area' | 'vertex' | 'relation'
 
@@ -184,13 +185,18 @@ function loadFields(): Record<string, FieldDefinition> {
 
   for (const [id, field] of Object.entries(rawFields)) {
     const def = field as any
+    const rawOptions = def.options
+    const normalizedOptions = Array.isArray(rawOptions)
+      ? Object.fromEntries(rawOptions.map((v: string) => [v, v]))
+      : rawOptions
+
     fields[id] = {
       id,
       key: def.key || id,
       type: def.type || 'text',
       label: def.label || id,
       placeholder: def.placeholder,
-      options: def.options,
+      options: normalizedOptions,
     }
   }
 
@@ -532,10 +538,28 @@ export function getPresetFields(
           }
         }
 
+        // Enrich with curated display-chip labels where available
+        if (translatedField.type === 'check') {
+          const chipLabel = getChipLabel(translatedField.key, 'yes')
+          if (chipLabel) translatedField.label = chipLabel
+        }
+
+        if (translatedField.options) {
+          for (const [optKey] of Object.entries(translatedField.options)) {
+            const chipLabel = getChipLabel(translatedField.key, optKey)
+            if (chipLabel) translatedField.options[optKey] = chipLabel
+          }
+        }
+
         return translatedField
       })
       .filter((field): field is FieldDefinition => field !== null)
   })
+}
+
+export function getPresetById(id: string): PresetDefinition | null {
+  const data = loadPresets()
+  return data[id] || null
 }
 
 export function getPlaceType(

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -521,11 +521,8 @@ export class BarrelmanIntegration
     query: string,
     lat?: number,
     lng?: number,
-    options?: { radius?: number; limit?: number },
+    options?: { radius?: number; limit?: number; sort?: string; filter?: Record<string, any> },
   ): Promise<Place[]> {
-    // Barrelman searches globally for text queries (no spatial filter) and
-    // uses proximity re-rank to bias closer results. Radius is passed as a
-    // hint but does NOT act as a hard boundary.
     const response = await axios.post(
       `${this.config.host}/search`,
       {
@@ -535,6 +532,8 @@ export class BarrelmanIntegration
         radius: options?.radius,
         limit: options?.limit || 20,
         semantic: true,
+        ...(options?.sort ? { sort: options.sort } : {}),
+        ...(options?.filter ? { filter: options.filter } : {}),
       },
       { headers: this.headers, timeout: 10000 },
     )
@@ -569,7 +568,7 @@ export class BarrelmanIntegration
   async searchByCategory(
     presetId: string,
     bounds: MapBounds,
-    options?: { limit?: number; filterTags?: Record<string, string> },
+    options?: { limit?: number; filterTags?: Record<string, string>; sort?: string; filter?: Record<string, any> },
   ): Promise<Place[]> {
     const lat = (bounds.north + bounds.south) / 2
     const lng = (bounds.east + bounds.west) / 2
@@ -586,6 +585,8 @@ export class BarrelmanIntegration
         categories: [presetId],
         limit: options?.limit || 20,
         ...(options?.filterTags ? { tags: options.filterTags } : {}),
+        ...(options?.sort ? { sort: options.sort } : {}),
+        ...(options?.filter ? { filter: options.filter } : {}),
       },
       { headers: this.headers, timeout: 10000 },
     )

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -316,6 +316,13 @@ export async function search(
 export interface CategorySearchOptions {
   bounds: MapBounds
   limit?: number
+  sort?: 'relevance' | 'distance' | 'name'
+  filter?: {
+    access?: string[]
+    fee?: 'yes' | 'no'
+    hasHours?: boolean
+  }
+  tags?: Record<string, string>
 }
 
 /**
@@ -395,9 +402,13 @@ export async function searchByCategory(
   // Resolve sub-preset IDs to parent category + filter tags
   const { categoryId, filterTags } = derivePresetFilter(presetId)
 
+  const mergedTags = { ...filterTags, ...options.tags }
+
   return await searchCapability.searchByCategory(categoryId, options.bounds, {
     limit: options.limit,
-    filterTags: Object.keys(filterTags).length > 0 ? filterTags : undefined,
+    filterTags: Object.keys(mergedTags).length > 0 ? mergedTags : undefined,
+    sort: options.sort,
+    filter: options.filter,
   })
 }
 

--- a/server/src/types/integration.types.ts
+++ b/server/src/types/integration.types.ts
@@ -51,6 +51,12 @@ export interface ConfiguredIntegrationDto {
 
 // Capability interfaces
 
+export interface SearchFilter {
+  access?: string[]
+  fee?: 'yes' | 'no'
+  hasHours?: boolean
+}
+
 export interface SearchCapability {
   searchPlaces(
     query: string,
@@ -60,6 +66,8 @@ export interface SearchCapability {
       radius?: number
       limit?: number
       language?: import('../lib/i18n').Language
+      sort?: 'relevance' | 'distance' | 'name'
+      filter?: SearchFilter
     },
   ): Promise<Place[]>
 }
@@ -178,6 +186,8 @@ export interface SearchCategoryCapability {
       limit?: number
       /** Extra OSM tag key/value pairs to filter results beyond the primary category. */
       filterTags?: Record<string, string>
+      sort?: 'relevance' | 'distance' | 'name'
+      filter?: SearchFilter
     },
   ): Promise<Place[]>
 }

--- a/web/src/components/map/FilterChips.vue
+++ b/web/src/components/map/FilterChips.vue
@@ -1,177 +1,265 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import {
-  LockIcon,
-  DollarSignIcon,
-  StarIcon,
-  ClockIcon,
   ArrowUpDownIcon,
-  MapPinIcon,
+  SlidersHorizontalIcon,
+  XIcon,
 } from 'lucide-vue-next'
-import { Chip, type ChipOption } from '@/components/ui/chip'
+import ResponsiveDropdown, { type MenuItemDefinition } from '@/components/responsive/ResponsiveDropdown.vue'
+import { Button } from '@/components/ui/button'
+import { Badge } from '@/components/ui/badge'
+import type { FilterDef, SortDef } from '@/config/search-filters'
+import type { ChipOption } from '@/components/ui/chip'
+import { computed, ref } from 'vue'
 
-// Filter state
-const selectedAccess = ref<string[]>([])
-const selectedPrice = ref<string>('')
-const selectedRating = ref<number | ''>('')
-const selectedSort = ref<string>('relevance')
-const openNow = ref<boolean>(false)
-
-// Access options
-const accessOptions: ChipOption[] = [
-  { label: 'Public', value: 'public' },
-  { label: 'Private', value: 'private' },
-  { label: 'Customers Only', value: 'customers' },
-  { label: 'Members Only', value: 'members' },
-  { label: 'Permit Required', value: 'permit' },
-  { label: 'No Access', value: 'no' },
-]
-
-// Price options
-const priceOptions: ChipOption[] = [
-  { label: 'Free', value: 'free' },
-  { label: '$', value: 'low' },
-  { label: '$$', value: 'medium' },
-  { label: '$$$', value: 'high' },
-  { label: '$$$$', value: 'very_high' },
-]
-
-// Rating options
-const ratingOptions: ChipOption[] = [
-  { label: '1+ Stars', value: 1 },
-  { label: '2+ Stars', value: 2 },
-  { label: '3+ Stars', value: 3 },
-  { label: '4+ Stars', value: 4 },
-  { label: '5 Stars', value: 5 },
-]
-
-// Sort options
-const sortOptions: ChipOption[] = [
-  { label: 'Relevance', value: 'relevance' },
-  { label: 'Distance', value: 'distance' },
-  { label: 'Rating', value: 'rating' },
-  { label: 'Price', value: 'price' },
-]
-
-// Emit filter changes to parent
-const emit = defineEmits<{
-  filtersChanged: [
-    filters: {
-      access: string[]
-      price: string
-      rating: number | ''
-      openNow: boolean
-      sort: string
-    },
-  ]
+const props = defineProps<{
+  filterDefs: FilterDef[]
+  filterValues: Record<string, any>
+  filterOptions: Record<string, ChipOption[]>
+  sortOptions: SortDef[]
+  sortBy: string
 }>()
 
-// Watch for filter changes and emit to parent
-function emitFiltersChanged() {
-  emit('filtersChanged', {
-    access: selectedAccess.value,
-    price: selectedPrice.value,
-    rating: selectedRating.value,
-    openNow: openNow.value,
-    sort: selectedSort.value,
-  })
-}
+const emit = defineEmits<{
+  'update:filter': [id: string, value: any]
+  'update:sortBy': [value: string]
+}>()
 
-// Handle filter updates
-function handleAccessUpdate(value: string[]) {
-  selectedAccess.value = value
-  emitFiltersChanged()
-}
+const sortOpen = ref(false)
+const filterOpen = ref(false)
 
-function handlePriceUpdate(value: string) {
-  selectedPrice.value = value
-  emitFiltersChanged()
-}
+// ── Sort menu items ─────────────────────────────────────────────────────
 
-function handleRatingUpdate(value: number) {
-  selectedRating.value = value
-  emitFiltersChanged()
-}
+const sortMenuItems = computed<MenuItemDefinition[]>(() =>
+  props.sortOptions.map(s => ({
+    type: 'item' as const,
+    id: s.id,
+    label: s.label,
+    active: props.sortBy === s.id,
+    onSelect: () => emit('update:sortBy', s.id),
+  })),
+)
 
-function handleOpenNowUpdate(value: boolean) {
-  openNow.value = value
-  emitFiltersChanged()
-}
-
-function handleSortUpdate(value: string) {
-  selectedSort.value = value
-  emitFiltersChanged()
-}
-
-// Reset all filters
-function resetFilters() {
-  selectedAccess.value = []
-  selectedPrice.value = ''
-  selectedRating.value = ''
-  selectedSort.value = 'relevance'
-  openNow.value = false
-  emitFiltersChanged()
-}
-
-// Expose reset function to parent
-defineExpose({
-  resetFilters,
+const sortLabel = computed(() => {
+  const selected = props.sortOptions.find(s => s.id === props.sortBy)
+  return selected?.label ?? 'Sort'
 })
+
+// ── Filter menu items ───────────────────────────────────────────────────
+
+const activeFilterCount = computed(() =>
+  props.filterDefs.filter(def => {
+    const value = props.filterValues[def.id] ?? def.defaultValue
+    if (value === null || value === undefined) return false
+    if (value === def.defaultValue) return false
+    if (Array.isArray(value) && value.length === 0) return false
+    return true
+  }).length,
+)
+
+const filterMenuItems = computed<MenuItemDefinition[]>(() =>
+  props.filterDefs.map(def => {
+    if (def.type === 'toggle') {
+      return {
+        type: 'item' as const,
+        id: def.id,
+        label: def.label,
+        active: !!getFilterValue(def),
+        keepOpen: true,
+        onSelect: () => emit('update:filter', def.id, !getFilterValue(def)),
+      }
+    }
+
+    const options = getFilterOptions(def)
+    return {
+      type: 'submenu' as const,
+      id: def.id,
+      label: def.label,
+      active: isFilterActive(def),
+      searchable: options.length > 15,
+      items: options.map(opt => ({
+        type: 'item' as const,
+        id: `${def.id}:${opt.value}`,
+        label: opt.label,
+        active: isOptionSelected(def, opt.value),
+        keepOpen: true,
+        onSelect: () => handleDropdownSelect(def, opt.value),
+      })),
+    }
+  }),
+)
+
+// ── Active filter chips ─────────────────────────────────────────────────
+
+const activeFilterChips = computed(() => {
+  const chips: { id: string; label: string; value: any; def: FilterDef }[] = []
+  for (const def of props.filterDefs) {
+    const value = props.filterValues[def.id] ?? def.defaultValue
+    if (value === null || value === undefined) continue
+    if (value === def.defaultValue) continue
+    if (Array.isArray(value) && value.length === 0) continue
+
+    if (def.type === 'toggle') {
+      chips.push({ id: def.id, label: def.label, value: true, def })
+    } else if (def.type === 'multi-select' && Array.isArray(value)) {
+      const options = getFilterOptions(def)
+      for (const v of value) {
+        const opt = options.find(o => o.value === v)
+        chips.push({
+          id: def.id,
+          label: `${def.label}: ${opt?.label ?? v}`,
+          value: v,
+          def,
+        })
+      }
+    } else {
+      const options = getFilterOptions(def)
+      const opt = options.find(o => String(o.value) === String(value))
+      chips.push({
+        id: def.id,
+        label: `${def.label}: ${opt?.label ?? value}`,
+        value,
+        def,
+      })
+    }
+  }
+  return chips
+})
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function getFilterValue(def: FilterDef): any {
+  return props.filterValues[def.id] ?? def.defaultValue
+}
+
+function getFilterOptions(def: FilterDef): ChipOption[] {
+  return props.filterOptions[def.id] ?? def.getOptions?.([]) ?? []
+}
+
+function handleDropdownSelect(def: FilterDef, value: any) {
+  if (def.type === 'multi-select') {
+    const current = Array.isArray(getFilterValue(def)) ? [...getFilterValue(def)] : []
+    const idx = current.indexOf(value)
+    if (idx >= 0) {
+      current.splice(idx, 1)
+    } else {
+      current.push(value)
+    }
+    emit('update:filter', def.id, current)
+  } else {
+    const currentValue = getFilterValue(def)
+    emit('update:filter', def.id, currentValue === value ? null : value)
+  }
+}
+
+function removeFilterChip(chip: { id: string; value: any; def: FilterDef }) {
+  if (chip.def.type === 'toggle') {
+    emit('update:filter', chip.id, false)
+  } else if (chip.def.type === 'multi-select') {
+    const current = Array.isArray(getFilterValue(chip.def)) ? [...getFilterValue(chip.def)] : []
+    emit('update:filter', chip.id, current.filter((v: any) => v !== chip.value))
+  } else {
+    emit('update:filter', chip.id, null)
+  }
+}
+
+function clearAllFilters() {
+  for (const def of props.filterDefs) {
+    emit('update:filter', def.id, def.defaultValue)
+  }
+}
+
+function isFilterActive(def: FilterDef): boolean {
+  const value = getFilterValue(def)
+  if (value === null || value === undefined) return false
+  if (value === def.defaultValue) return false
+  if (Array.isArray(value) && value.length === 0) return false
+  return true
+}
+
+function isOptionSelected(def: FilterDef, optionValue: any): boolean {
+  const value = getFilterValue(def)
+  if (def.type === 'multi-select') {
+    return Array.isArray(value) && value.includes(optionValue)
+  }
+  return String(value) === String(optionValue)
+}
 </script>
 
 <template>
-  <div class="flex flex-row gap-1 items-start pb-1">
-    <!-- Sort -->
-    <!-- TODO: Handle filter updates -->
-    <!-- @update:dropdown-value="handleSortUpdate" -->
-    <Chip
-      :icon="ArrowUpDownIcon"
-      label="Sort"
-      variant="dropdown"
-      size="xs"
-      :options="sortOptions"
-      :dropdown-value="selectedSort"
-      :force-icon="true"
-      :show-clear="false"
-    />
+  <div class="flex flex-col gap-1.5">
+    <!-- Row 1: Sort + Filters -->
+    <div class="flex flex-row gap-1.5 items-center overflow-visible">
+      <!-- Sort -->
+      <ResponsiveDropdown
+        :items="sortMenuItems"
+        :open="sortOpen"
+        title="Sort"
+        content-class="w-40"
+        @update:open="sortOpen = $event"
+      >
+        <template #trigger="{ open }">
+          <Button
+            variant="outline"
+            size="xs"
+            class="rounded-full gap-1 bg-background"
+            @click="open"
+          >
+            <ArrowUpDownIcon class="size-3.5" />
+            <span>{{ sortLabel }}</span>
+          </Button>
+        </template>
+      </ResponsiveDropdown>
 
-    <Chip
-      :icon="LockIcon"
-      label="Access"
-      variant="dropdown"
-      size="xs"
-      :options="accessOptions"
-      :multiple="true"
-      :dropdown-value="selectedAccess"
-    />
+      <!-- Filters -->
+      <ResponsiveDropdown
+        v-if="filterDefs.length > 0"
+        :items="filterMenuItems"
+        :open="filterOpen"
+        title="Filters"
+        content-class="w-48"
+        @update:open="filterOpen = $event"
+      >
+        <template #trigger="{ open }">
+          <Button
+            variant="outline"
+            size="xs"
+            class="rounded-full gap-1 bg-background relative overflow-visible"
+            @click="open"
+          >
+            <SlidersHorizontalIcon class="size-3.5" />
+            <span>Filters</span>
+            <Badge
+              v-if="activeFilterCount > 0"
+              variant="primary"
+              class="absolute -top-1.5 -right-1.5 px-1 py-0 text-[10px] min-w-4 h-4 justify-center"
+            >
+              {{ activeFilterCount }}
+            </Badge>
+          </Button>
+        </template>
+      </ResponsiveDropdown>
+    </div>
 
-    <!-- Price Filter -->
-    <Chip
-      :icon="DollarSignIcon"
-      label="Price"
-      variant="dropdown"
-      size="xs"
-      :options="priceOptions"
-      :dropdown-value="selectedPrice"
-    />
-
-    <!-- Rating Filter -->
-    <Chip
-      :icon="StarIcon"
-      label="Rating"
-      variant="dropdown"
-      size="xs"
-      :options="ratingOptions"
-      :dropdown-value="selectedRating"
-    />
-
-    <!-- Open Now Toggle -->
-    <Chip
-      :icon="ClockIcon"
-      label="Open Now"
-      variant="toggle"
-      size="xs"
-      :model-value="openNow"
-    />
+    <!-- Row 2: Active filter chips (removable) -->
+    <div
+      v-if="activeFilterChips.length > 0"
+      class="flex items-center gap-1.5 flex-wrap"
+    >
+      <button
+        v-for="chip in activeFilterChips"
+        :key="`${chip.id}:${chip.value}`"
+        class="inline-flex items-center gap-1 rounded-full border border-border bg-background text-foreground px-2.5 py-0.5 text-xs font-medium hover:bg-muted transition-colors cursor-pointer"
+        @click="removeFilterChip(chip)"
+      >
+        {{ chip.label }}
+        <XIcon class="size-3" />
+      </button>
+      <button
+        class="text-xs text-muted-foreground hover:text-foreground transition-colors px-1 cursor-pointer"
+        @click="clearAllFilters"
+      >
+        Clear all
+      </button>
+    </div>
   </div>
 </template>

--- a/web/src/components/responsive/ResponsiveDropdown.vue
+++ b/web/src/components/responsive/ResponsiveDropdown.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { ref, watch, nextTick, markRaw, type Component } from 'vue'
+import { ref, watch, nextTick, markRaw, computed, reactive, type Component } from 'vue'
 import { useRouter } from 'vue-router'
 import { useExternalLink } from '@/composables/useExternalLink'
 import {
@@ -23,7 +23,7 @@ import {
   DropdownMenuSubContent,
   DropdownMenuPortal,
 } from '@/components/ui/dropdown-menu'
-import { ChevronRight, ChevronLeft } from 'lucide-vue-next'
+import { ChevronRight, ChevronLeft, SearchIcon } from 'lucide-vue-next'
 
 export interface MenuItem {
   type: 'item'
@@ -33,6 +33,7 @@ export interface MenuItem {
   trailing?: Component
   trailingProps?: Record<string, any>
   disabled?: boolean
+  active?: boolean
   variant?: 'default' | 'destructive'
   to?: string
   href?: string
@@ -59,6 +60,8 @@ export interface MenuSubmenu {
   label: string
   icon?: Component
   disabled?: boolean
+  active?: boolean
+  searchable?: boolean
   items?: MenuItemDefinition[]
   customComponent?: Component
   customProps?: Record<string, any>
@@ -192,6 +195,36 @@ function handleItemClick(item: MenuItem, event?: Event) {
   }
 }
 
+// ── Submenu search ──────────────────────────────────────────────────────
+
+const submenuSearchQueries = reactive<Record<string, string>>({})
+
+function getSubmenuSearchQuery(id: string): string {
+  return submenuSearchQueries[id] ?? ''
+}
+
+function setSubmenuSearchQuery(id: string, value: string) {
+  submenuSearchQueries[id] = value
+}
+
+function filteredSubmenuItems(submenu: MenuSubmenu): MenuItemDefinition[] {
+  const query = getSubmenuSearchQuery(submenu.id ?? submenu.label)
+  if (!query || !submenu.items) return submenu.items ?? []
+  const lower = query.toLowerCase()
+  return submenu.items.filter(item => {
+    if (item.type !== 'item') return true
+    return item.label.toLowerCase().includes(lower)
+  })
+}
+
+// Clear search when menu closes
+watch(internalOpen, open => {
+  if (!open) {
+    for (const key of Object.keys(submenuSearchQueries)) {
+      delete submenuSearchQueries[key]
+    }
+  }
+})
 
 </script>
 
@@ -266,6 +299,8 @@ function handleItemClick(item: MenuItem, event?: Event) {
                   'text-destructive hover:text-destructive':
                     item.variant === 'destructive' && !item.disabled,
                   'opacity-50 cursor-not-allowed': item.disabled,
+                  'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200':
+                    item.active && !item.disabled,
                 },
               ]"
               :disabled="item.disabled"
@@ -300,6 +335,8 @@ function handleItemClick(item: MenuItem, event?: Event) {
               class="w-full justify-between h-auto min-h-11 px-3 py-2 "
               :class="{
                 'opacity-50 cursor-not-allowed': item.disabled,
+                'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200':
+                  item.active && !item.disabled,
               }"
               :disabled="item.disabled"
               @click="openSubmenu(item)"
@@ -342,9 +379,9 @@ function handleItemClick(item: MenuItem, event?: Event) {
           />
         </div>
 
-        <div v-else class="pt-5 pb-2">
+        <div v-else class="pt-5 pb-2 flex flex-col max-h-[70vh]">
           <!-- Submenu header with back button -->
-          <div class="flex items-center gap-2 mb-2 mx-1">
+          <div class="flex items-center gap-2 mb-2 mx-1 shrink-0">
             <Button
               variant="ghost"
               size="icon"
@@ -358,9 +395,22 @@ function handleItemClick(item: MenuItem, event?: Event) {
             </h2>
           </div>
 
-          <div class="px-2">
+          <!-- Search input for searchable submenus (mobile) -->
+          <div v-if="entry.submenu.searchable" class="px-3 mb-2 shrink-0">
+            <div class="relative">
+              <SearchIcon class="absolute left-2.5 top-1/2 -translate-y-1/2 size-4 text-muted-foreground" />
+              <input
+                :value="getSubmenuSearchQuery(entry.submenu.id ?? entry.submenu.label)"
+                class="w-full h-9 pl-8 pr-3 text-sm rounded-md border border-input bg-transparent placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                placeholder="Search…"
+                @input="setSubmenuSearchQuery(entry.submenu.id ?? entry.submenu.label, ($event.target as HTMLInputElement).value)"
+              />
+            </div>
+          </div>
+
+          <div class="px-2 overflow-y-auto flex-1 min-h-0">
             <template
-              v-for="(subItem, subIndex) in entry.submenu.items"
+              v-for="(subItem, subIndex) in filteredSubmenuItems(entry.submenu)"
               :key="subItem.id || subIndex"
             >
               <Separator v-if="subItem.type === 'separator'" class="my-2" />
@@ -382,6 +432,8 @@ function handleItemClick(item: MenuItem, event?: Event) {
                     'text-destructive hover:text-destructive':
                       subItem.variant === 'destructive' && !subItem.disabled,
                     'opacity-50 cursor-not-allowed': subItem.disabled,
+                    'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200':
+                      subItem.active && !subItem.disabled,
                   },
                 ]"
                 :disabled="subItem.disabled"
@@ -490,6 +542,8 @@ function handleItemClick(item: MenuItem, event?: Event) {
               {
                 'text-destructive focus:text-destructive':
                   item.variant === 'destructive' && !item.disabled,
+                'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200':
+                  item.active && !item.disabled,
               },
             ]"
             @click="handleItemClick(item, $event)"
@@ -518,75 +572,98 @@ function handleItemClick(item: MenuItem, event?: Event) {
           </DropdownMenuItem>
 
           <DropdownMenuSub v-else-if="item.type === 'submenu'">
-            <DropdownMenuSubTrigger :disabled="item.disabled">
+            <DropdownMenuSubTrigger
+              :disabled="item.disabled"
+              :class="{
+                'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200':
+                  item.active && !item.disabled,
+              }"
+            >
               <component v-if="item.icon" :is="item.icon" class="size-4" />
               <span>{{ item.label }}</span>
             </DropdownMenuSubTrigger>
             <DropdownMenuPortal>
-              <DropdownMenuSubContent>
+              <DropdownMenuSubContent class="max-h-72 flex flex-col">
                 <component
                   v-if="item.customComponent"
                   :is="item.customComponent"
                   v-bind="item.customProps"
                 />
                 <template v-else>
-                  <template
-                    v-for="(subItem, subIndex) in item.items"
-                    :key="subItem.id || subIndex"
-                  >
-                    <DropdownMenuSeparator
-                      v-if="subItem.type === 'separator'"
-                    />
-
-                    <!-- Label with optional custom component in submenu -->
-                    <template v-else-if="subItem.type === 'label'">
-                      <component
-                        v-if="subItem.customComponent"
-                        :is="markRaw(subItem.customComponent)"
-                        v-bind="subItem.customProps"
+                  <!-- Search input for searchable submenus -->
+                  <div v-if="item.searchable" class="p-1.5 bg-popover">
+                    <div class="relative">
+                      <SearchIcon class="absolute left-2 top-1/2 -translate-y-1/2 size-3.5 text-muted-foreground" />
+                      <input
+                        :value="getSubmenuSearchQuery(item.id ?? item.label)"
+                        class="w-full h-7 pl-7 pr-2 text-sm rounded-md border border-input bg-transparent placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
+                        placeholder="Search…"
+                        @input="setSubmenuSearchQuery(item.id ?? item.label, ($event.target as HTMLInputElement).value)"
+                        @keydown.stop
                       />
-                      <DropdownMenuLabel v-else class="text-xs font-semibold">
-                        {{ subItem.label }}
-                      </DropdownMenuLabel>
-                    </template>
-
-                    <DropdownMenuItem
-                      v-else-if="subItem.type === 'item'"
-                      :disabled="subItem.disabled"
-                      :class="[
-                        subItem.trailing ? 'flex items-center justify-between' : '',
-                        {
-                          'text-destructive focus:text-destructive':
-                            subItem.variant === 'destructive' &&
-                            !subItem.disabled,
-                        },
-                      ]"
-                      @click="handleItemClick(subItem, $event)"
-                      @select="subItem.keepOpen ? $event.preventDefault() : undefined"
+                    </div>
+                  </div>
+                  <div class="overflow-y-auto flex-1">
+                    <template
+                      v-for="(subItem, subIndex) in filteredSubmenuItems(item)"
+                      :key="subItem.id || subIndex"
                     >
-                      <span class="flex items-center gap-2">
-                        <component
-                          v-if="subItem.icon"
-                          :is="subItem.icon"
-                          :class="[
-                            'size-4',
-                            {
-                              'text-destructive':
-                                subItem.variant === 'destructive' &&
-                                !subItem.disabled,
-                            },
-                          ]"
-                        />
-                        <span>{{ subItem.label }}</span>
-                      </span>
-                      <component
-                        v-if="subItem.trailing"
-                        :is="subItem.trailing"
-                        v-bind="subItem.trailingProps"
-                        @click.stop
+                      <DropdownMenuSeparator
+                        v-if="subItem.type === 'separator'"
                       />
-                    </DropdownMenuItem>
-                  </template>
+
+                      <!-- Label with optional custom component in submenu -->
+                      <template v-else-if="subItem.type === 'label'">
+                        <component
+                          v-if="subItem.customComponent"
+                          :is="markRaw(subItem.customComponent)"
+                          v-bind="subItem.customProps"
+                        />
+                        <DropdownMenuLabel v-else class="text-xs font-semibold">
+                          {{ subItem.label }}
+                        </DropdownMenuLabel>
+                      </template>
+
+                      <DropdownMenuItem
+                        v-else-if="subItem.type === 'item'"
+                        :disabled="subItem.disabled"
+                        :class="[
+                          subItem.trailing ? 'flex items-center justify-between' : '',
+                          {
+                            'text-destructive focus:text-destructive':
+                              subItem.variant === 'destructive' &&
+                              !subItem.disabled,
+                            'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200':
+                              subItem.active && !subItem.disabled,
+                          },
+                        ]"
+                        @click="handleItemClick(subItem, $event)"
+                        @select="subItem.keepOpen ? $event.preventDefault() : undefined"
+                      >
+                        <span class="flex items-center gap-2">
+                          <component
+                            v-if="subItem.icon"
+                            :is="subItem.icon"
+                            :class="[
+                              'size-4',
+                              {
+                                'text-destructive':
+                                  subItem.variant === 'destructive' &&
+                                  !subItem.disabled,
+                              },
+                            ]"
+                          />
+                          <span>{{ subItem.label }}</span>
+                        </span>
+                        <component
+                          v-if="subItem.trailing"
+                          :is="subItem.trailing"
+                          v-bind="subItem.trailingProps"
+                          @click.stop
+                        />
+                      </DropdownMenuItem>
+                    </template>
+                  </div>
                 </template>
               </DropdownMenuSubContent>
             </DropdownMenuPortal>

--- a/web/src/components/ui/chip/Chip.vue
+++ b/web/src/components/ui/chip/Chip.vue
@@ -193,7 +193,7 @@ function getDropdownItemComponent(): Component {
     v-else-if="variant === 'toggle'"
     variant="outline"
     :size="size"
-    :class="cn(chipClasses, 'whitespace-nowrap')"
+    :class="cn(chipClasses, 'whitespace-nowrap data-[state=on]:bg-primary-100 data-[state=on]:text-primary-800 data-[state=on]:border-primary-300 dark:data-[state=on]:bg-primary-800 dark:data-[state=on]:text-primary-200 dark:data-[state=on]:border-primary-600 data-[state=on]:shadow-xs')"
     :disabled="disabled"
     :pressed="isPressed"
     @click="handleClick"

--- a/web/src/config/search-filters.ts
+++ b/web/src/config/search-filters.ts
@@ -1,0 +1,243 @@
+import type { Component } from 'vue'
+import type { Place } from '@/types/place.types'
+import type { ChipOption } from '@/components/ui/chip'
+import { isPlaceOpenNow } from '@/lib/place-open.utils'
+import { getOsmTagLabel } from '@/lib/osm-tag-labels'
+import * as turf from '@turf/turf'
+import {
+  ClockIcon,
+  LockIcon,
+  DollarSignIcon,
+  TagIcon,
+} from 'lucide-vue-next'
+
+// ── Types ────────────────────────────────────────────────────────────────
+
+export type FilterType = 'toggle' | 'select' | 'multi-select'
+
+export interface FilterDef {
+  id: string
+  type: FilterType
+  label: string
+  icon: Component
+  defaultValue: any
+  isAvailable: (places: Place[]) => boolean
+  getOptions?: (places: Place[]) => ChipOption[]
+  match: (place: Place, value: any) => boolean
+  toServerFilter?: (value: any) => Record<string, any> | null
+}
+
+export interface SortDef {
+  id: string
+  label: string
+  isAvailable: (places: Place[]) => boolean
+  compare: (a: Place, b: Place, ctx: { mapCenter: [number, number] }) => number
+  serverValue?: string
+}
+
+export interface FieldDefinition {
+  id: string
+  key: string
+  type: string
+  label: string
+  placeholder?: string
+  options?: Record<string, string | { title: string }>
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function placeCenter(place: Place): [number, number] {
+  const c = place.geometry?.value?.center
+  return c ? [c.lng, c.lat] : [0, 0]
+}
+
+function formatTagLabel(value: string): string {
+  return value.replace(/_/g, ' ').replace(/\b\w/g, l => l.toUpperCase())
+}
+
+function getOptionLabel(opt: string | { title: string }): string {
+  if (typeof opt === 'string') return opt
+  return opt.title
+}
+
+// ── Filter Definitions (hardcoded special filters) ───────────────────────
+
+export const FILTER_DEFINITIONS: FilterDef[] = [
+  {
+    id: 'openNow',
+    type: 'toggle',
+    label: 'Open Now',
+    icon: ClockIcon,
+    defaultValue: false,
+    isAvailable: () => true,
+    match: (place, active: boolean) => {
+      if (!active) return true
+      const status = isPlaceOpenNow(place.openingHours?.value)
+      return status === true || status === null
+    },
+    toServerFilter: (active: boolean) =>
+      active ? { hasHours: true } : null,
+  },
+  {
+    id: 'access',
+    type: 'multi-select',
+    label: 'Access',
+    icon: LockIcon,
+    defaultValue: [],
+    isAvailable: () => true,
+    getOptions: () => [
+      { label: 'Public', value: 'yes' },
+      { label: 'Private', value: 'private' },
+      { label: 'Permissive', value: 'permissive' },
+      { label: 'Customers', value: 'customers' },
+      { label: 'Permit Only', value: 'permit' },
+      { label: 'Destination Only', value: 'destination' },
+    ],
+    match: (place, selected: string[]) => {
+      if (!selected.length) return true
+      return selected.includes(place.tags?.access ?? '')
+    },
+    toServerFilter: (selected: string[]) =>
+      selected.length ? { access: selected } : null,
+  },
+  {
+    id: 'fee',
+    type: 'select',
+    label: 'Fee',
+    icon: DollarSignIcon,
+    defaultValue: null,
+    isAvailable: () => true,
+    getOptions: () => [
+      { label: 'Free', value: 'free' },
+      { label: 'Paid', value: 'paid' },
+    ],
+    match: (place, value: string | null) => {
+      if (!value) return true
+      if (value === 'free') return place.tags?.fee === 'no'
+      if (value === 'paid') return place.tags?.fee === 'yes'
+      return true
+    },
+    toServerFilter: (value: string | null) =>
+      value ? { fee: value === 'free' ? 'no' : 'yes' } : null,
+  },
+]
+
+// Tag keys already handled by hardcoded definitions above
+const HARDCODED_TAG_KEYS = new Set(['access', 'fee'])
+
+// ── Auto-generated filters from OSM field definitions ────────────────────
+
+const FILTERABLE_FIELD_TYPES = new Set(['combo', 'check', 'semiCombo', 'radio'])
+
+export function generateFiltersFromFields(fields: FieldDefinition[]): FilterDef[] {
+  return fields
+    .filter(field => {
+      if (!FILTERABLE_FIELD_TYPES.has(field.type)) return false
+      if (HARDCODED_TAG_KEYS.has(field.key)) return false
+      if (field.type !== 'check' && !field.options) return false
+      return true
+    })
+    .map(field => {
+      if (field.type === 'check') return createCheckFilter(field)
+      if (field.type === 'semiCombo') return createSemiComboFilter(field)
+      return createComboFilter(field)
+    })
+}
+
+function createCheckFilter(field: FieldDefinition): FilterDef {
+  return {
+    id: `tag:${field.key}`,
+    type: 'toggle',
+    label: field.label || getOsmTagLabel(field.key),
+    icon: TagIcon,
+    defaultValue: false,
+    isAvailable: () => true,
+    match: (place, active: boolean) => {
+      if (!active) return true
+      return place.tags?.[field.key] === 'yes'
+    },
+    toServerFilter: (active: boolean) =>
+      active ? { [`tag:${field.key}`]: 'yes' } : null,
+  }
+}
+
+function allComboOptions(options: Record<string, string | { title: string }>): ChipOption[] {
+  return Object.entries(options)
+    .map(([k, label]) => ({
+      label: getOptionLabel(label) || formatTagLabel(k),
+      value: k,
+    }))
+}
+
+function createComboFilter(field: FieldDefinition): FilterDef {
+  const options = field.options || {}
+  return {
+    id: `tag:${field.key}`,
+    type: 'select',
+    label: getOsmTagLabel(field.key),
+    icon: TagIcon,
+    defaultValue: null,
+    isAvailable: () => true,
+    getOptions: () => allComboOptions(options),
+    match: (place, value: string | null) => {
+      if (!value) return true
+      return place.tags?.[field.key] === value
+    },
+    toServerFilter: (value: string | null) =>
+      value ? { [`tag:${field.key}`]: value } : null,
+  }
+}
+
+function createSemiComboFilter(field: FieldDefinition): FilterDef {
+  const options = field.options || {}
+  return {
+    id: `tag:${field.key}`,
+    type: 'multi-select',
+    label: getOsmTagLabel(field.key),
+    icon: TagIcon,
+    defaultValue: [],
+    isAvailable: () => true,
+    getOptions: () => allComboOptions(options),
+    match: (place, selected: string[]) => {
+      if (!selected.length) return true
+      const val = place.tags?.[field.key]
+      if (!val) return false
+      const placeValues = val.split(';').map(v => v.trim())
+      return selected.some(s => placeValues.includes(s))
+    },
+  }
+}
+
+// ── Sort Definitions ─────────────────────────────────────────────────────
+
+export const SORT_DEFINITIONS: SortDef[] = [
+  {
+    id: 'relevance',
+    label: 'Relevance',
+    isAvailable: () => true,
+    compare: () => 0,
+    serverValue: 'relevance',
+  },
+  {
+    id: 'distance',
+    label: 'Distance',
+    isAvailable: () => true,
+    compare: (a, b, { mapCenter }) => {
+      const distA = turf.distance(mapCenter, placeCenter(a))
+      const distB = turf.distance(mapCenter, placeCenter(b))
+      return distA - distB
+    },
+    serverValue: 'distance',
+  },
+  {
+    id: 'rating',
+    label: 'Rating',
+    isAvailable: (places) =>
+      places.some(p => p.ratings?.rating?.value != null),
+    compare: (a, b) => {
+      const rA = a.ratings?.rating?.value ?? -1
+      const rB = b.ratings?.rating?.value ?? -1
+      return rB - rA
+    },
+  },
+]

--- a/web/src/lib/osm-tag-labels.ts
+++ b/web/src/lib/osm-tag-labels.ts
@@ -127,6 +127,29 @@ export const TAG_LABELS: Record<string, string> = {
   'payment:contactless': 'Contactless Payment',
   'payment:apple_pay': 'Apple Pay',
   'payment:google_pay': 'Google Pay',
+  // Accommodation & Facilities
+  heating: 'Heating',
+  hot_water: 'Hot Water',
+  kitchen: 'Kitchen',
+  fireplace: 'Fireplace',
+  openfire: 'Open Fire',
+  bbq: 'BBQ',
+  cabins: 'Cabins',
+  caravans: 'Caravans',
+  tents: 'Tents',
+  power_supply: 'Power Supply',
+  // Recreation & Outdoor
+  bench: 'Bench',
+  shelter: 'Shelter',
+  picnic_table: 'Picnic Table',
+  // Accessibility
+  handrail: 'Handrail',
+  step_count: 'Steps',
+  // Services
+  dispensing: 'Dispensing',
+  parcel_pickup: 'Parcel Pickup',
+  parcel_mail_in: 'Parcel Drop-Off',
+  compressed_air: 'Compressed Air',
 }
 
 /**

--- a/web/src/lib/place-open.utils.ts
+++ b/web/src/lib/place-open.utils.ts
@@ -1,0 +1,25 @@
+import type { OpeningHours } from '@/types/place.types'
+
+/**
+ * Check if a place is currently open based on its opening hours.
+ * Returns true (open), false (closed), or null (indeterminate / no data).
+ * null means filters should pass this place through rather than hiding it.
+ */
+export function isPlaceOpenNow(hours: OpeningHours | null | undefined): boolean | null {
+  if (!hours) return null
+
+  if (hours.isPermanentlyClosed || hours.isTemporarilyClosed) return false
+  if (hours.isOpen24_7) return true
+
+  if (!hours.regularHours?.length) return null
+
+  const now = new Date()
+  const currentDay = now.getDay()
+  const currentTime =
+    `${now.getHours().toString().padStart(2, '0')}:${now.getMinutes().toString().padStart(2, '0')}`
+
+  const todaySlots = hours.regularHours.filter(h => h.day === currentDay)
+  if (!todaySlots.length) return false
+
+  return todaySlots.some(slot => currentTime >= slot.open && currentTime <= slot.close)
+}

--- a/web/src/services/layers/features/search-results-layer.service.ts
+++ b/web/src/services/layers/features/search-results-layer.service.ts
@@ -51,7 +51,7 @@ export function useSearchResultsLayerService() {
 
     // Get current search results to restore data after style change
     const searchStore = useSearchStore()
-    const currentResults = searchStore.searchResults
+    const currentResults = searchStore.filteredSearchResults
     const currentGeoJSON =
       currentResults.length > 0
         ? createResultsGeoJSON(currentResults)
@@ -101,7 +101,7 @@ export function useSearchResultsLayerService() {
     const searchStore = useSearchStore()
 
     watch(
-      () => searchStore.searchResults,
+      () => searchStore.filteredSearchResults,
       newResults => {
         updateSearchResultsData(
           mapStrategy,
@@ -117,7 +117,7 @@ export function useSearchResultsLayerService() {
       newHoveredId => {
         updateSearchResultsHoverState(
           mapStrategy,
-          searchStore.searchResults,
+          searchStore.filteredSearchResults,
           newHoveredId,
         )
       },

--- a/web/src/services/search.service.ts
+++ b/web/src/services/search.service.ts
@@ -24,11 +24,24 @@ interface AdvancedSearchResponse {
 interface CategorySearchOptions {
   bounds?: MapBounds
   maxResults?: number
+  sort?: string
+  filter?: Record<string, any>
+  tags?: Record<string, string>
+}
+
+interface CategoryFieldDefinition {
+  id: string
+  key: string
+  type: string
+  label: string
+  placeholder?: string
+  options?: Record<string, string | { title: string }>
 }
 
 interface CategorySearchResponse {
   presetId: string
   results: Place[]
+  fieldDefinitions?: CategoryFieldDefinition[]
   totalCount: number
   executedAt: string
 }
@@ -122,7 +135,7 @@ function searchService() {
   async function searchByCategory(
     presetId: string,
     options: CategorySearchOptions = {},
-  ): Promise<Place[]> {
+  ): Promise<{ results: Place[]; fieldDefinitions: CategoryFieldDefinition[] }> {
     loading.value = true
     error.value = null
 
@@ -133,10 +146,16 @@ function searchService() {
           presetId,
           bounds: options.bounds,
           maxResults: options.maxResults || 100,
+          ...(options.sort ? { sort: options.sort } : {}),
+          ...(options.filter ? { filter: options.filter } : {}),
+          ...(options.tags ? { tags: options.tags } : {}),
         },
       )
 
-      return response.data.results
+      return {
+        results: response.data.results,
+        fieldDefinitions: response.data.fieldDefinitions || [],
+      }
     } catch (err) {
       console.error('Error in category search:', err)
       error.value =

--- a/web/src/stores/search.store.ts
+++ b/web/src/stores/search.store.ts
@@ -2,6 +2,23 @@ import { defineStore } from 'pinia'
 import { ref, computed } from 'vue'
 import type { Place } from '@/types/place.types'
 import type { MapBounds } from '@/types/map.types'
+import type { ChipOption } from '@/components/ui/chip'
+import { useMapStore } from '@/stores/map.store'
+import {
+  FILTER_DEFINITIONS,
+  SORT_DEFINITIONS,
+  generateFiltersFromFields,
+  type FilterDef,
+  type SortDef,
+  type FieldDefinition,
+} from '@/config/search-filters'
+
+function resolveMapCenter(center: any): [number, number] {
+  if (Array.isArray(center)) return [center[0], center[1]]
+  if (center?.lng != null) return [center.lng, center.lat]
+  if (center?.lon != null) return [center.lon, center.lat]
+  return [0, 0]
+}
 
 export const useSearchStore = defineStore('search', () => {
   // Core search state
@@ -18,19 +35,106 @@ export const useSearchStore = defineStore('search', () => {
   const lastMaxResults = ref<number | null>(null)
   const lastResultCount = ref<number>(0)
 
+  // ── Filter / Sort state ────────────────────────────────────────────────
+  const filters = ref<Record<string, any>>({})
+  const sortBy = ref<string>('relevance')
+  const categoryFields = ref<FieldDefinition[]>([])
+
   // Computed values
   const hasResults = computed(() => searchResults.value.length > 0)
   const isLoading = computed(() => isSearching.value || isMapRefreshing.value)
   const hitMaxResults = computed(() => {
-    return lastMaxResults.value !== null && 
+    return lastMaxResults.value !== null &&
            lastResultCount.value >= lastMaxResults.value
   })
 
-  // Actions
+  // ── All filter defs (hardcoded + auto-generated from category fields) ──
+  const allFilterDefs = computed<FilterDef[]>(() => [
+    ...FILTER_DEFINITIONS,
+    ...generateFiltersFromFields(categoryFields.value),
+  ])
+
+  // ── Available filters & sorts based on current result set ──────────────
+  const activeFilterDefs = computed<FilterDef[]>(() =>
+    allFilterDefs.value.filter(def => def.isAvailable(searchResults.value)),
+  )
+
+  const activeSortDefs = computed<SortDef[]>(() =>
+    SORT_DEFINITIONS.filter(def => def.isAvailable(searchResults.value)),
+  )
+
+  const dynamicFilterOptions = computed<Record<string, ChipOption[]>>(() => {
+    const options: Record<string, ChipOption[]> = {}
+    for (const def of activeFilterDefs.value) {
+      if (def.getOptions) {
+        options[def.id] = def.getOptions(searchResults.value)
+      }
+    }
+    return options
+  })
+
+  // ── Filtered & sorted results ──────────────────────────────────────────
+  const filteredSearchResults = computed<Place[]>(() => {
+    const defs = allFilterDefs.value
+    let results = searchResults.value.filter(place =>
+      defs.every(def => {
+        const value = filters.value[def.id] ?? def.defaultValue
+        return def.match(place, value)
+      }),
+    )
+
+    const sortDef = SORT_DEFINITIONS.find(s => s.id === sortBy.value)
+    if (sortDef && sortDef.id !== 'relevance') {
+      const mapStore = useMapStore()
+      const mapCenter = resolveMapCenter(mapStore.mapCamera.center)
+      results = [...results].sort((a, b) => sortDef.compare(a, b, { mapCenter }))
+    }
+
+    return results
+  })
+
+  const hasActiveFilters = computed(() =>
+    allFilterDefs.value.some(def => {
+      const value = filters.value[def.id]
+      if (value === undefined || value === null) return false
+      if (value === def.defaultValue) return false
+      if (Array.isArray(value) && value.length === 0) return false
+      return true
+    }) || sortBy.value !== 'relevance',
+  )
+
+  const serverFilterParams = computed(() => {
+    const filterObj: Record<string, any> = {}
+    const tagsObj: Record<string, string> = {}
+    for (const def of allFilterDefs.value) {
+      const value = filters.value[def.id] ?? def.defaultValue
+      const serverFilter = def.toServerFilter?.(value)
+      if (!serverFilter) continue
+      for (const [k, v] of Object.entries(serverFilter)) {
+        if (k.startsWith('tag:')) {
+          tagsObj[k.slice(4)] = v as string
+        } else {
+          filterObj[k] = v
+        }
+      }
+    }
+    const sortDef = SORT_DEFINITIONS.find(s => s.id === sortBy.value)
+    return {
+      sort: sortDef?.serverValue || undefined,
+      filter: Object.keys(filterObj).length > 0 ? filterObj : undefined,
+      tags: Object.keys(tagsObj).length > 0 ? tagsObj : undefined,
+    }
+  })
+
+  // ── Actions ────────────────────────────────────────────────────────────
   function setSearchResults(places: Place[]) {
     searchResults.value = places
     lastResultCount.value = places.length
     searchError.value = null
+  }
+
+  function setCategoryFields(fields: FieldDefinition[]) {
+    categoryFields.value = fields
   }
 
   function clearSearchResults() {
@@ -39,6 +143,8 @@ export const useSearchStore = defineStore('search', () => {
     lastMaxResults.value = null
     searchError.value = null
     hoveredPlaceId.value = null
+    categoryFields.value = []
+    resetFilters()
   }
 
   function setSearchLoading(loading: boolean) {
@@ -73,7 +179,6 @@ export const useSearchStore = defineStore('search', () => {
     lastMaxResults.value = maxResults
   }
 
-  // Helper to add a single result (for incremental loading)
   function addSearchResult(place: Place) {
     const exists = searchResults.value.find(p => p.id === place.id)
     if (!exists) {
@@ -81,12 +186,24 @@ export const useSearchStore = defineStore('search', () => {
     }
   }
 
-  // Helper to remove a single result
   function removeSearchResult(placeId: string) {
     const index = searchResults.value.findIndex(p => p.id === placeId)
     if (index !== -1) {
       searchResults.value.splice(index, 1)
     }
+  }
+
+  function setFilter(id: string, value: any) {
+    filters.value = { ...filters.value, [id]: value }
+  }
+
+  function setSortBy(id: string) {
+    sortBy.value = id
+  }
+
+  function resetFilters() {
+    filters.value = {}
+    sortBy.value = 'relevance'
   }
 
   return {
@@ -101,14 +218,24 @@ export const useSearchStore = defineStore('search', () => {
     lastSearchBounds,
     lastMaxResults,
     lastResultCount,
+    filters,
+    sortBy,
+    categoryFields,
 
     // Computed
     hasResults,
     isLoading,
     hitMaxResults,
+    activeFilterDefs,
+    activeSortDefs,
+    dynamicFilterOptions,
+    filteredSearchResults,
+    hasActiveFilters,
+    serverFilterParams,
 
     // Actions
     setSearchResults,
+    setCategoryFields,
     clearSearchResults,
     setSearchLoading,
     setMapRefreshing,
@@ -120,5 +247,8 @@ export const useSearchStore = defineStore('search', () => {
     setLastMaxResults,
     addSearchResult,
     removeSearchResult,
+    setFilter,
+    setSortBy,
+    resetFilters,
   }
 })

--- a/web/src/views/search/Search.vue
+++ b/web/src/views/search/Search.vue
@@ -1,7 +1,6 @@
 <script setup lang="ts">
-import { ref, watch, onMounted, onUnmounted, computed } from 'vue'
+import { ref, watch, onMounted, onUnmounted, computed, nextTick } from 'vue'
 import { useRoute } from 'vue-router'
-import { useMapStore } from '@/stores/map.store'
 import { useSearchStore } from '@/stores/search.store'
 import { useMapService } from '@/services/map.service'
 import { useMapCamera } from '@/composables/useMapCamera'
@@ -15,9 +14,7 @@ import PlaceList from '@/components/place/PlaceList.vue'
 import FilterChips from '@/components/map/FilterChips.vue'
 import ErrorMessage from '@/components/ErrorMessage.vue'
 import { useRouter } from 'vue-router'
-import { AppRoute } from '@/router'
 import { getPlaceRoute } from '@/lib/place.utils'
-import { storeToRefs } from 'pinia'
 import { useCategoryStore } from '@/stores/category.store'
 import { getCategoryColor } from '@/lib/place-colors'
 import { useThemeStore } from '@/stores/theme.store'
@@ -30,13 +27,70 @@ import { newViewFraction } from '@/lib/map-bounds.utils'
 const route = useRoute()
 const router = useRouter()
 const searchService = useSearchService()
-const mapStore = useMapStore()
 const mapService = useMapService()
 const searchStore = useSearchStore()
 
 const SIGNIFICANT_MOVEMENT_THRESHOLD = 0.3 // If camera moves to new area, refresh search results
 
 let lastRefreshBounds: MapBounds | null = null
+let suppressUrlSync = false
+let filtersRestored = false
+
+// ── URL ↔ filter/sort sync ──────────────────────────────────────────────
+
+function filtersToQuery(): Record<string, string | undefined> {
+  const q: Record<string, string | undefined> = {}
+
+  if (searchStore.sortBy !== 'relevance') {
+    q.sort = searchStore.sortBy
+  }
+
+  for (const def of searchStore.activeFilterDefs) {
+    const value = searchStore.filters[def.id]
+    if (value === undefined || value === null) continue
+    if (value === def.defaultValue) continue
+    if (Array.isArray(value) && value.length === 0) continue
+    if (def.type === 'toggle') {
+      q[`f.${def.id}`] = '1'
+    } else if (Array.isArray(value)) {
+      q[`f.${def.id}`] = value.join(',')
+    } else {
+      q[`f.${def.id}`] = String(value)
+    }
+  }
+  return q
+}
+
+function restoreFiltersFromQuery() {
+  const query = route.query
+  if (query.sort && typeof query.sort === 'string') {
+    searchStore.setSortBy(query.sort)
+  }
+  for (const [key, raw] of Object.entries(query)) {
+    if (!key.startsWith('f.') || typeof raw !== 'string') continue
+    const filterId = key.slice(2)
+    const def = searchStore.activeFilterDefs.find(d => d.id === filterId)
+    if (!def) continue
+    if (def.type === 'toggle') {
+      searchStore.setFilter(filterId, raw === '1')
+    } else if (def.type === 'multi-select') {
+      searchStore.setFilter(filterId, raw.split(',').filter(Boolean))
+    } else {
+      searchStore.setFilter(filterId, raw)
+    }
+  }
+}
+
+function syncFiltersToUrl() {
+  if (suppressUrlSync) return
+  const filterParams = filtersToQuery()
+
+  const cleaned: Record<string, any> = {}
+  for (const [k, v] of Object.entries(route.query)) {
+    if (k !== 'sort' && !k.startsWith('f.')) cleaned[k] = v
+  }
+  router.replace({ query: { ...cleaned, ...filterParams } })
+}
 
 const { camera } = useMapCamera()
 
@@ -95,19 +149,9 @@ const categoryIconColor = computed(() => {
   return getCategoryColor('default', themeStore.isDark)
 })
 
-// Note: Using searchStore directly in template due to TypeScript complexity with storeToRefs
-
 // Event listener reference for cleanup
 let searchClickHandler: ((event: Event) => void) | null = null
 
-// Filter state
-const activeFilters = ref({
-  access: [] as string[],
-  price: '' as string,
-  rating: '' as number | '',
-  openNow: false as boolean,
-  sort: 'relevance' as string,
-})
 
 // Search management
 
@@ -183,15 +227,23 @@ async function performSearch() {
     // Track the max results in the search store
     searchStore.setLastMaxResults(maxResults)
 
+    const { sort, filter, tags } = searchStore.serverFilterParams
+
     if (searchType.value === 'category') {
-      places = await searchService.searchByCategory(
+      const { results, fieldDefinitions } = await searchService.searchByCategory(
         route.query.categoryId as string,
         {
           bounds: bounds || undefined,
           maxResults,
+          sort,
+          filter,
+          tags,
         },
       )
+      places = results
+      searchStore.setCategoryFields(fieldDefinitions)
     } else if (searchType.value === 'text') {
+      searchStore.setCategoryFields([])
       const searchResults = await searchService.search({
         query: route.query.q as string,
         lat: center.lat,
@@ -199,17 +251,24 @@ async function performSearch() {
         autocomplete: false,
         maxResults,
       })
-      // Since autocomplete is false, we should get SearchResult objects with full metadata
       places = (searchResults as SearchResult[])
         .filter(result => result.type === 'place')
         .map(result => result.metadata.place as unknown as Place)
-      console.log('Search results:', places)
     }
 
     // Update the search store with results - this will automatically update the map layer
     searchStore.setSearchResults(places)
     searchStore.setLastSearchBounds(bounds)
     lastRefreshBounds = bounds
+
+    // On first load, restore filters from URL (after categoryFields are set)
+    if (!filtersRestored) {
+      filtersRestored = true
+      suppressUrlSync = true
+      restoreFiltersFromQuery()
+      await nextTick()
+      suppressUrlSync = false
+    }
   } catch (error) {
     console.error('Search error:', error)
     searchStore.setSearchError(
@@ -269,25 +328,28 @@ onUnmounted(() => {
 
 watch(
   () => route.query,
-  () => {
+  (newQuery, oldQuery) => {
+    const searchChanged =
+      newQuery.categoryId !== oldQuery?.categoryId ||
+      newQuery.q !== oldQuery?.q
+    if (!searchChanged) return
+    filtersRestored = false
+    suppressUrlSync = true
+    searchStore.resetFilters()
+    suppressUrlSync = false
     performSearch()
   },
   { deep: true },
 )
 
-// Handle filter changes
-function handleFiltersChanged(filters: {
-  access: string[]
-  price: string
-  rating: number | ''
-  openNow: boolean
-  sort: string
-}) {
-  activeFilters.value = filters
-  console.log('Filters changed:', filters)
-  // TODO: Apply filters to places or re-fetch with filters
-  // For now, just log the filter changes
-}
+watch(
+  [() => searchStore.filters, () => searchStore.sortBy],
+  () => {
+    syncFiltersToUrl()
+  },
+  { deep: true },
+)
+
 </script>
 
 <template>
@@ -317,8 +379,8 @@ function handleFiltersChanged(filters: {
         </h2>
         <div class="flex items-center gap-2 text-sm text-muted-foreground">
           <span>
-            {{ searchStore.searchResults.length.toLocaleString() }}
-            {{ searchStore.searchResults.length === 1 ? 'result' : 'results' }}
+            {{ searchStore.filteredSearchResults.length.toLocaleString() }}
+            {{ searchStore.filteredSearchResults.length === 1 ? 'result' : 'results' }}
           </span>
           <!-- Premium: auto-refresh spinner -->
           <div
@@ -332,10 +394,16 @@ function handleFiltersChanged(filters: {
       </div>
     </div>
 
-    <div class="-mx-4">
+    <div class="-mx-4 overflow-visible">
       <FilterChips
-        class="w-full overflow-x-auto scrollbar-hidden px-4"
-        @filters-changed="handleFiltersChanged"
+        class="w-full px-4"
+        :filter-defs="searchStore.activeFilterDefs"
+        :filter-values="searchStore.filters"
+        :filter-options="searchStore.dynamicFilterOptions"
+        :sort-options="searchStore.activeSortDefs"
+        :sort-by="searchStore.sortBy"
+        @update:filter="searchStore.setFilter"
+        @update:sort-by="searchStore.setSortBy"
       />
     </div>
 
@@ -380,8 +448,8 @@ function handleFiltersChanged(filters: {
     >
       <div class="max-w-4xl mx-auto">
         <PlaceList
-          :places="searchStore.searchResults"
-          :loading="searchStore.isLoading"
+          :places="searchStore.filteredSearchResults"
+          :loading="searchStore.isSearching && !searchStore.hasResults"
           @place-hover="searchStore.setHoveredPlace($event)"
           @place-leave="searchStore.setHoveredPlace(null)"
         />


### PR DESCRIPTION
## Summary

- Adds a definition-driven filter and sort system for search results, replacing the hardcoded non-functional filter chips
- Filters apply client-side for instant feedback; on map-move re-search, active filters are sent server-side to barrelman for DB-level filtering
- Auto-generates filter UI from OSM preset field definitions (combo, check, semiCombo types), with searchable dropdowns for long option lists (e.g. cuisine)
- Sort options: relevance, distance, rating (rating only appears when Google-enriched results are present)
- Filter/sort state syncs to URL params (`f.{id}`, `sort`) for shareable links
- Extends barrelman search API with `sort` and `filter` query parameters applied at the SQL level
- Map markers update reactively to reflect filtered results

## Key files

| Area | Files |
|------|-------|
| Barrelman | `src/routes/search.ts`, `src/services/search.service.ts` |
| Server | `search.controller.ts`, `barrelman-integration.ts`, `search.service.ts`, `integration.types.ts` |
| Frontend (new) | `web/src/config/search-filters.ts`, `web/src/lib/place-open.utils.ts` |
| Frontend (modified) | `search.store.ts`, `FilterChips.vue`, `ResponsiveDropdown.vue`, `Search.vue`, `search-results-layer.service.ts` |

## Test plan

- [ ] Category search (e.g. Restaurants): verify Open Now, Access, Fee, and auto-generated filters (cuisine, etc.) appear
- [ ] Text search: verify Rating sort appears when Google results are present, hidden otherwise
- [ ] Toggle a filter → list and map markers update instantly (client-side)
- [ ] Pan map → re-search sends active filters to server (check network tab)
- [ ] Searchable dropdown for long filter lists (cuisine has 90+ options)
- [ ] Filter state persists in URL — reload page with filter params and verify they restore
- [ ] Mobile: filter/sort dropdowns render as bottom sheets with fixed search header