### PR TITLE
Group search results by type in command palette

### DIFF
--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -39,6 +39,7 @@ function convertPresetToSearchResult(preset: any): SearchResult {
       : undefined,
     icon: resolvedIcon.icon,
     iconPack: resolvedIcon.iconPack,
+    iconCategory: preset.iconCategory,
     metadata: {
       category: {
         tags: preset.tags,

--- a/web/src/components/map/FilterChips.vue
+++ b/web/src/components/map/FilterChips.vue
@@ -3,7 +3,6 @@ import {
   ArrowUpDownIcon,
   SlidersHorizontalIcon,
   XIcon,
-  MapIcon,
   LocateFixedIcon,
 } from 'lucide-vue-next'
 import ResponsiveDropdown, { type MenuItemDefinition } from '@/components/responsive/ResponsiveDropdown.vue'
@@ -215,29 +214,20 @@ function isOptionSelected(def: FilterDef, optionValue: any): boolean {
         </template>
       </ResponsiveDropdown>
 
-      <!-- Search context toggle -->
-      <div v-if="hasGeolocation" class="flex rounded-full border border-border bg-background overflow-hidden">
-        <button
-          class="px-2.5 py-1 text-xs font-medium flex items-center gap-1 transition-colors"
-          :class="searchContext === 'map'
-            ? 'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200'
-            : 'text-muted-foreground hover:text-foreground'"
-          @click="emit('update:searchContext', 'map')"
-        >
-          <MapIcon class="size-3.5" />
-          This area
-        </button>
-        <button
-          class="px-2.5 py-1 text-xs font-medium flex items-center gap-1 transition-colors border-l border-border"
-          :class="searchContext === 'nearby'
-            ? 'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200'
-            : 'text-muted-foreground hover:text-foreground'"
-          @click="emit('update:searchContext', 'nearby')"
-        >
-          <LocateFixedIcon class="size-3.5" />
-          Near me
-        </button>
-      </div>
+      <!-- Near me toggle -->
+      <Button
+        v-if="hasGeolocation"
+        variant="outline"
+        size="xs"
+        class="rounded-full gap-1"
+        :class="searchContext === 'nearby'
+          ? 'bg-primary-100 text-primary-800 border-primary-300 dark:bg-primary-800 dark:text-primary-200 dark:border-primary-600'
+          : 'bg-background'"
+        @click="emit('update:searchContext', searchContext === 'nearby' ? 'map' : 'nearby')"
+      >
+        <LocateFixedIcon class="size-3.5" />
+        <span>Near me</span>
+      </Button>
 
       <!-- Filters -->
       <ResponsiveDropdown

--- a/web/src/components/map/FilterChips.vue
+++ b/web/src/components/map/FilterChips.vue
@@ -3,6 +3,8 @@ import {
   ArrowUpDownIcon,
   SlidersHorizontalIcon,
   XIcon,
+  MapIcon,
+  LocateFixedIcon,
 } from 'lucide-vue-next'
 import ResponsiveDropdown, { type MenuItemDefinition } from '@/components/responsive/ResponsiveDropdown.vue'
 import { Button } from '@/components/ui/button'
@@ -17,11 +19,14 @@ const props = defineProps<{
   filterOptions: Record<string, ChipOption[]>
   sortOptions: SortDef[]
   sortBy: string
+  searchContext: 'map' | 'nearby'
+  hasGeolocation: boolean
 }>()
 
 const emit = defineEmits<{
   'update:filter': [id: string, value: any]
   'update:sortBy': [value: string]
+  'update:searchContext': [value: 'map' | 'nearby']
 }>()
 
 const sortOpen = ref(false)
@@ -209,6 +214,30 @@ function isOptionSelected(def: FilterDef, optionValue: any): boolean {
           </Button>
         </template>
       </ResponsiveDropdown>
+
+      <!-- Search context toggle -->
+      <div v-if="hasGeolocation" class="flex rounded-full border border-border bg-background overflow-hidden">
+        <button
+          class="px-2.5 py-1 text-xs font-medium flex items-center gap-1 transition-colors"
+          :class="searchContext === 'map'
+            ? 'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200'
+            : 'text-muted-foreground hover:text-foreground'"
+          @click="emit('update:searchContext', 'map')"
+        >
+          <MapIcon class="size-3.5" />
+          This area
+        </button>
+        <button
+          class="px-2.5 py-1 text-xs font-medium flex items-center gap-1 transition-colors border-l border-border"
+          :class="searchContext === 'nearby'
+            ? 'bg-primary-100 text-primary-800 dark:bg-primary-800 dark:text-primary-200'
+            : 'text-muted-foreground hover:text-foreground'"
+          @click="emit('update:searchContext', 'nearby')"
+        >
+          <LocateFixedIcon class="size-3.5" />
+          Near me
+        </button>
+      </div>
 
       <!-- Filters -->
       <ResponsiveDropdown

--- a/web/src/components/map/FilterChips.vue
+++ b/web/src/components/map/FilterChips.vue
@@ -3,6 +3,7 @@ import {
   ArrowUpDownIcon,
   SlidersHorizontalIcon,
   XIcon,
+  MapIcon,
   LocateFixedIcon,
 } from 'lucide-vue-next'
 import ResponsiveDropdown, { type MenuItemDefinition } from '@/components/responsive/ResponsiveDropdown.vue'
@@ -214,7 +215,7 @@ function isOptionSelected(def: FilterDef, optionValue: any): boolean {
         </template>
       </ResponsiveDropdown>
 
-      <!-- Near me toggle -->
+      <!-- Search context toggle -->
       <Button
         v-if="hasGeolocation"
         variant="outline"
@@ -225,8 +226,9 @@ function isOptionSelected(def: FilterDef, optionValue: any): boolean {
           : 'bg-background'"
         @click="emit('update:searchContext', searchContext === 'nearby' ? 'map' : 'nearby')"
       >
-        <LocateFixedIcon class="size-3.5" />
-        <span>Near me</span>
+        <LocateFixedIcon v-if="searchContext === 'nearby'" class="size-3.5" />
+        <MapIcon v-else class="size-3.5" />
+        <span>{{ searchContext === 'nearby' ? 'Near me' : 'This area' }}</span>
       </Button>
 
       <!-- Filters -->

--- a/web/src/components/map/FilterChips.vue
+++ b/web/src/components/map/FilterChips.vue
@@ -220,10 +220,7 @@ function isOptionSelected(def: FilterDef, optionValue: any): boolean {
         v-if="hasGeolocation"
         variant="outline"
         size="xs"
-        class="rounded-full gap-1"
-        :class="searchContext === 'nearby'
-          ? 'bg-primary-100 text-primary-800 border-primary-300 dark:bg-primary-800 dark:text-primary-200 dark:border-primary-600'
-          : 'bg-background'"
+        class="rounded-full gap-1 bg-background"
         @click="emit('update:searchContext', searchContext === 'nearby' ? 'map' : 'nearby')"
       >
         <LocateFixedIcon v-if="searchContext === 'nearby'" class="size-3.5" />

--- a/web/src/components/palette/Palette.vue
+++ b/web/src/components/palette/Palette.vue
@@ -123,6 +123,27 @@ const filteredArgumentOptions = computed(() => {
     : argumentOptions.value
 })
 
+const SEARCH_GROUP_ORDER = ['fullSearch', 'categories', 'places'] as const
+
+const groupedArgumentOptions = computed(() => {
+  if (!isSearch.value) return null
+
+  const groups: { key: string; heading: string; items: CommandArgumentOption[] }[] = []
+  for (const groupKey of SEARCH_GROUP_ORDER) {
+    const items = filteredArgumentOptions.value.filter(
+      item => item.group === groupKey,
+    )
+    if (items.length > 0) {
+      groups.push({
+        key: groupKey,
+        heading: t(`palette.commands.search.groups.${groupKey}`),
+        items,
+      })
+    }
+  }
+  return groups
+})
+
 function openPalette(withSearch = false) {
   commandOpen.value = true
   showResults.value = true
@@ -445,20 +466,63 @@ const filterFunction = computed(() => {
 
         <!-- Command selected, display arguments -->
         <CommandList v-if="activeArgument && (!isSearch || query.length)">
-          <CommandGroup :heading="activeArgument.name">
-            <div v-if="loadingOptions" class="py-6 text-center">
-              <LoaderIcon class="mx-auto h-4 w-4 animate-spin opacity-50" />
-              <p class="mt-2 text-sm text-muted-foreground">
-                Loading suggestions...
-              </p>
-            </div>
-            <CommandEmpty v-else-if="argumentOptions.length === 0">
-              <!-- TODO: Get this to show when no search results are found -->
-              <!-- TODO: i18n -->
+          <div v-if="loadingOptions" class="py-6 text-center">
+            <LoaderIcon class="mx-auto h-4 w-4 animate-spin opacity-50" />
+            <p class="mt-2 text-sm text-muted-foreground">
+              Loading suggestions...
+            </p>
+          </div>
+
+          <!-- Grouped rendering for search command -->
+          <template v-else-if="groupedArgumentOptions">
+            <CommandEmpty v-if="groupedArgumentOptions.length === 0">
+              No results found.
+            </CommandEmpty>
+            <CommandGroup
+              v-for="group in groupedArgumentOptions"
+              :key="group.key"
+              :heading="group.heading"
+            >
+              <CommandItem
+                v-for="argumentOption in group.items"
+                :key="argumentOption.value"
+                :value="argumentOption"
+                class="flex gap-2"
+                @select="onArgumentSelected(argumentOption.value)"
+              >
+                <ItemIcon
+                  v-if="argumentOption.iconColor"
+                  :icon="argumentOption.iconName"
+                  :icon-pack="argumentOption.iconPack"
+                  :custom-color="argumentOption.iconColor"
+                  shape="circle"
+                  variant="solid"
+                  size="sm"
+                />
+                <component
+                  v-else-if="argumentOption.icon"
+                  :is="argumentOption.icon"
+                  class="size-5 opacity-50"
+                />
+                <div class="flex-1 flex flex-col">
+                  <span class="font-semibold">{{ argumentOption.name }}</span>
+                  <span
+                    class="text-sm text-gray-500"
+                    v-if="argumentOption.description"
+                  >
+                    {{ argumentOption.description }}
+                  </span>
+                </div>
+              </CommandItem>
+            </CommandGroup>
+          </template>
+
+          <!-- Default flat rendering for non-search commands -->
+          <CommandGroup v-else :heading="activeArgument.name">
+            <CommandEmpty v-if="argumentOptions.length === 0">
               No results found.
             </CommandEmpty>
             <CommandItem
-              v-else
               v-for="argumentOption in filteredArgumentOptions"
               :key="argumentOption.value"
               :value="argumentOption"

--- a/web/src/config/search-filters.ts
+++ b/web/src/config/search-filters.ts
@@ -130,11 +130,14 @@ const HARDCODED_TAG_KEYS = new Set(['access', 'fee'])
 const FILTERABLE_FIELD_TYPES = new Set(['combo', 'check', 'semiCombo', 'radio'])
 
 export function generateFiltersFromFields(fields: FieldDefinition[]): FilterDef[] {
+  const seen = new Set<string>()
   return fields
     .filter(field => {
       if (!FILTERABLE_FIELD_TYPES.has(field.type)) return false
       if (HARDCODED_TAG_KEYS.has(field.key)) return false
       if (field.type !== 'check' && !field.options) return false
+      if (seen.has(field.key)) return false
+      seen.add(field.key)
       return true
     })
     .map(field => {

--- a/web/src/config/search-filters.ts
+++ b/web/src/config/search-filters.ts
@@ -227,19 +227,8 @@ export const SORT_DEFINITIONS: SortDef[] = [
     serverValue: 'relevance',
   },
   {
-    id: 'nearby',
-    label: 'Nearby',
-    isAvailable: (_places, ctx) => ctx?.userLocation != null,
-    compare: (a, b, { userLocation }) => {
-      if (!userLocation) return 0
-      const distA = turf.distance(userLocation, placeCenter(a))
-      const distB = turf.distance(userLocation, placeCenter(b))
-      return distA - distB
-    },
-  },
-  {
     id: 'distance',
-    label: 'Near map center',
+    label: 'Distance',
     isAvailable: () => true,
     compare: (a, b, { mapCenter }) => {
       const distA = turf.distance(mapCenter, placeCenter(a))

--- a/web/src/config/search-filters.ts
+++ b/web/src/config/search-filters.ts
@@ -27,11 +27,16 @@ export interface FilterDef {
   toServerFilter?: (value: any) => Record<string, any> | null
 }
 
+export interface SortContext {
+  mapCenter: [number, number]
+  userLocation: [number, number] | null
+}
+
 export interface SortDef {
   id: string
   label: string
-  isAvailable: (places: Place[]) => boolean
-  compare: (a: Place, b: Place, ctx: { mapCenter: [number, number] }) => number
+  isAvailable: (places: Place[], ctx?: SortContext) => boolean
+  compare: (a: Place, b: Place, ctx: SortContext) => number
   serverValue?: string
 }
 
@@ -216,14 +221,25 @@ function createSemiComboFilter(field: FieldDefinition): FilterDef {
 export const SORT_DEFINITIONS: SortDef[] = [
   {
     id: 'relevance',
-    label: 'Relevance',
+    label: 'Best match',
     isAvailable: () => true,
     compare: () => 0,
     serverValue: 'relevance',
   },
   {
+    id: 'nearby',
+    label: 'Nearby',
+    isAvailable: (_places, ctx) => ctx?.userLocation != null,
+    compare: (a, b, { userLocation }) => {
+      if (!userLocation) return 0
+      const distA = turf.distance(userLocation, placeCenter(a))
+      const distB = turf.distance(userLocation, placeCenter(b))
+      return distA - distB
+    },
+  },
+  {
     id: 'distance',
-    label: 'Distance',
+    label: 'Near map center',
     isAvailable: () => true,
     compare: (a, b, { mapCenter }) => {
       const distA = turf.distance(mapCenter, placeCenter(a))
@@ -234,7 +250,7 @@ export const SORT_DEFINITIONS: SortDef[] = [
   },
   {
     id: 'rating',
-    label: 'Rating',
+    label: 'Top rated',
     isAvailable: (places) =>
       places.some(p => p.ratings?.rating?.value != null),
     compare: (a, b) => {

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -89,6 +89,11 @@
           "places": {
             "name": "Places"
           }
+        },
+        "groups": {
+          "fullSearch": "Search",
+          "categories": "Categories",
+          "places": "Places"
         }
       },
       "goto": {

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -88,6 +88,11 @@
           "places": {
             "name": "Lugares"
           }
+        },
+        "groups": {
+          "fullSearch": "Buscar",
+          "categories": "Categorías",
+          "places": "Lugares"
         }
       },
       "goto": {

--- a/web/src/services/search.service.test.ts
+++ b/web/src/services/search.service.test.ts
@@ -163,7 +163,7 @@ describe('useSearchService', () => {
         bounds: { north: 1, south: 0, east: 1, west: 0 },
         maxResults: 50,
       })
-      expect(results).toEqual(mockPlaces)
+      expect(results).toEqual({ results: mockPlaces, fieldDefinitions: [] })
     })
 
     test('uses default maxResults when not provided', async () => {

--- a/web/src/stores/command.store.ts
+++ b/web/src/stores/command.store.ts
@@ -191,14 +191,16 @@ export const useCommandStore = defineStore('command', () => {
                     iconName: result.icon || 'MapPin',
                     iconPack: result.iconPack || 'lucide',
                     iconColor: getCategoryColor(iconCategory, isDark.value),
+                    group: result.type === 'category' ? 'categories' : 'places',
                   }
                 })
 
                 return [
                   {
                     value: 'search-more-results',
-                    name: `Search "${searchText}"`,
+                    name: searchText,
                     icon: SearchIcon,
+                    group: 'fullSearch',
                   },
                   ...results,
                 ]

--- a/web/src/stores/search.store.ts
+++ b/web/src/stores/search.store.ts
@@ -37,10 +37,11 @@ export const useSearchStore = defineStore('search', () => {
   const lastMaxResults = ref<number | null>(null)
   const lastResultCount = ref<number>(0)
 
-  // ── Filter / Sort state ────────────────────────────────────────────────
+  // ── Filter / Sort / Search context state ────────────────────────────────
   const filters = ref<Record<string, any>>({})
   const sortBy = ref<string>('relevance')
   const categoryFields = ref<FieldDefinition[]>([])
+  const searchContext = ref<'map' | 'nearby'>('map')
 
   // Computed values
   const hasResults = computed(() => searchResults.value.length > 0)
@@ -100,6 +101,10 @@ export const useSearchStore = defineStore('search', () => {
     const sortDef = SORT_DEFINITIONS.find(s => s.id === sortBy.value)
     if (sortDef && sortDef.id !== 'relevance') {
       const ctx = getSortContext()
+      // When searching nearby, use user location as the distance reference
+      if (sortDef.id === 'distance' && searchContext.value === 'nearby' && ctx.userLocation) {
+        ctx.mapCenter = ctx.userLocation
+      }
       results = [...results].sort((a, b) => sortDef.compare(a, b, ctx))
     }
 
@@ -214,6 +219,10 @@ export const useSearchStore = defineStore('search', () => {
     sortBy.value = id
   }
 
+  function setSearchContext(ctx: 'map' | 'nearby') {
+    searchContext.value = ctx
+  }
+
   function resetFilters() {
     filters.value = {}
     sortBy.value = 'relevance'
@@ -234,6 +243,7 @@ export const useSearchStore = defineStore('search', () => {
     filters,
     sortBy,
     categoryFields,
+    searchContext,
 
     // Computed
     hasResults,
@@ -262,6 +272,7 @@ export const useSearchStore = defineStore('search', () => {
     removeSearchResult,
     setFilter,
     setSortBy,
+    setSearchContext,
     resetFilters,
   }
 })

--- a/web/src/stores/search.store.ts
+++ b/web/src/stores/search.store.ts
@@ -4,12 +4,14 @@ import type { Place } from '@/types/place.types'
 import type { MapBounds } from '@/types/map.types'
 import type { ChipOption } from '@/components/ui/chip'
 import { useMapStore } from '@/stores/map.store'
+import { useGeolocationService } from '@/services/geolocation.service'
 import {
   FILTER_DEFINITIONS,
   SORT_DEFINITIONS,
   generateFiltersFromFields,
   type FilterDef,
   type SortDef,
+  type SortContext,
   type FieldDefinition,
 } from '@/config/search-filters'
 
@@ -59,9 +61,21 @@ export const useSearchStore = defineStore('search', () => {
     allFilterDefs.value.filter(def => def.isAvailable(searchResults.value)),
   )
 
-  const activeSortDefs = computed<SortDef[]>(() =>
-    SORT_DEFINITIONS.filter(def => def.isAvailable(searchResults.value)),
-  )
+  function getSortContext(): SortContext {
+    const mapStore = useMapStore()
+    const geo = useGeolocationService()
+    const mapCenter = resolveMapCenter(mapStore.mapCamera.center)
+    const ll = geo.lngLat.value
+    return {
+      mapCenter,
+      userLocation: ll ? [ll.lng, ll.lat] : null,
+    }
+  }
+
+  const activeSortDefs = computed<SortDef[]>(() => {
+    const ctx = getSortContext()
+    return SORT_DEFINITIONS.filter(def => def.isAvailable(searchResults.value, ctx))
+  })
 
   const dynamicFilterOptions = computed<Record<string, ChipOption[]>>(() => {
     const options: Record<string, ChipOption[]> = {}
@@ -85,9 +99,8 @@ export const useSearchStore = defineStore('search', () => {
 
     const sortDef = SORT_DEFINITIONS.find(s => s.id === sortBy.value)
     if (sortDef && sortDef.id !== 'relevance') {
-      const mapStore = useMapStore()
-      const mapCenter = resolveMapCenter(mapStore.mapCamera.center)
-      results = [...results].sort((a, b) => sortDef.compare(a, b, { mapCenter }))
+      const ctx = getSortContext()
+      results = [...results].sort((a, b) => sortDef.compare(a, b, ctx))
     }
 
     return results

--- a/web/src/types/command.types.ts
+++ b/web/src/types/command.types.ts
@@ -38,4 +38,5 @@ export type CommandArgument = {
 
 export type CommandArgumentOption = PaletteItem & {
   value: string | number
+  group?: string
 }

--- a/web/src/views/search/Search.vue
+++ b/web/src/views/search/Search.vue
@@ -204,6 +204,7 @@ function shouldMapRefresh(camera: MapCamera) {
 }
 
 useMapListener('moveend', () => {
+  if (searchStore.searchContext === 'nearby') return
   if (!shouldMapRefresh(camera.value)) return
 
   if (canAutoRefresh.value) {

--- a/web/src/views/search/Search.vue
+++ b/web/src/views/search/Search.vue
@@ -23,6 +23,7 @@ import { useAuthService } from '@/services/auth.service'
 import { PermissionId } from '@/types/auth.types'
 import { SearchIcon } from 'lucide-vue-next'
 import { newViewFraction } from '@/lib/map-bounds.utils'
+import { useGeolocationService } from '@/services/geolocation.service'
 
 const route = useRoute()
 const router = useRouter()
@@ -30,7 +31,10 @@ const searchService = useSearchService()
 const mapService = useMapService()
 const searchStore = useSearchStore()
 
+const geolocationService = useGeolocationService()
+
 const SIGNIFICANT_MOVEMENT_THRESHOLD = 0.3 // If camera moves to new area, refresh search results
+const NEARBY_RADIUS_KM = 5
 
 let lastRefreshBounds: MapBounds | null = null
 let suppressUrlSync = false
@@ -96,6 +100,23 @@ const { camera } = useMapCamera()
 
 const authService = useAuthService()
 const canAutoRefresh = computed(() => authService.hasPermission(PermissionId.SEARCH_AUTO_REFRESH))
+
+const hasGeolocation = computed(() => geolocationService.hasLocation.value)
+
+/** Build a bounding box around user location for "Near me" searches. */
+function nearbyBounds(): MapBounds | null {
+  const ll = geolocationService.lngLat.value
+  if (!ll) return null
+  // ~0.045 degrees ≈ 5 km at the equator; scale longitude by cos(lat)
+  const latDelta = NEARBY_RADIUS_KM / 111
+  const lngDelta = NEARBY_RADIUS_KM / (111 * Math.cos((ll.lat * Math.PI) / 180))
+  return {
+    north: ll.lat + latDelta,
+    south: ll.lat - latDelta,
+    east: ll.lng + lngDelta,
+    west: ll.lng - lngDelta,
+  }
+}
 
 // True when the map has moved enough to warrant a new search, but the user
 // must manually confirm (shown as a "Search this area" button for non-premium users)
@@ -217,8 +238,11 @@ async function performSearch() {
     searchStore.setSearchQuery(categoryTitle.value)
   }
 
-  const bounds = mapService.getBounds()
-  const center = mapService.getCenter()
+  const isNearby = searchStore.searchContext === 'nearby'
+  const bounds = isNearby ? nearbyBounds() : mapService.getBounds()
+  const center = isNearby && geolocationService.lngLat.value
+    ? geolocationService.lngLat.value
+    : mapService.getCenter()
 
   try {
     let places: Place[] = []
@@ -343,6 +367,11 @@ watch(
 )
 
 watch(
+  () => searchStore.searchContext,
+  () => performSearch(),
+)
+
+watch(
   [() => searchStore.filters, () => searchStore.sortBy],
   () => {
     syncFiltersToUrl()
@@ -402,8 +431,11 @@ watch(
         :filter-options="searchStore.dynamicFilterOptions"
         :sort-options="searchStore.activeSortDefs"
         :sort-by="searchStore.sortBy"
+        :search-context="searchStore.searchContext"
+        :has-geolocation="hasGeolocation"
         @update:filter="searchStore.setFilter"
         @update:sort-by="searchStore.setSortBy"
+        @update:search-context="searchStore.setSearchContext"
       />
     </div>
 


### PR DESCRIPTION
## Summary
- Split command palette search results into three grouped sections: Search, Categories, and Places
- Each group has its own heading via `CommandGroup`, with empty groups hidden automatically
- Non-search commands retain flat single-group rendering

## Test plan
- [ ] Open command palette, type a search query — confirm three groups appear with headings
- [ ] Verify empty groups are hidden (e.g., query that matches no categories)
- [ ] Verify non-search commands (Go To, Theme, etc.) still render normally
- [ ] Verify keyboard navigation works across groups