### PR TITLE
Add intersection and coordinate place support

### DIFF
--- a/server/src/controllers/library/bookmarks.controller.ts
+++ b/server/src/controllers/library/bookmarks.controller.ts
@@ -40,10 +40,9 @@ const bookmarksRouter = new Elysia({ prefix: '/bookmarks' })
   .post(
     '/',
     async ({ body, user, set }) => {
-      // Ensure the externalIds contains at least osm
-      if (!body.externalIds || !body.externalIds.osm) {
+      if (!body.externalIds || Object.keys(body.externalIds).length === 0) {
         set.status = 400
-        return { error: 'Missing required OSM ID in externalIds' }
+        return { error: 'Missing required externalIds' }
       }
 
       if (!body.collectionIds || body.collectionIds.length === 0) {

--- a/server/src/controllers/place.controller.ts
+++ b/server/src/controllers/place.controller.ts
@@ -46,7 +46,7 @@ app.get(
             ? id.split('/')
             : [null, id]
 
-          if (!osmType || !['node', 'way', 'relation'].includes(osmType)) {
+          if (!osmType || !['node', 'way', 'relation', 'intersection'].includes(osmType)) {
             return status(400, {
               message: t('errors.place.invalidOsmType'),
             })
@@ -119,11 +119,11 @@ app.get(
           language,
         })
       } else if (isCoordinateLookup) {
-        // New: Coordinate-based lookup with enrichment
         place = await lookupEnrichedPlaceByCoordinates(lat!, lng!, {
           userId: user?.id,
           radius: Math.round(radius),
           language,
+          addressOnly: true,
         })
       }
 

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -437,10 +437,14 @@ export class BarrelmanIntegration
     const tags = r.tags || {}
     const summary = this.buildPlaceSummary(tags)
     const osmGeomHint = r.geom_type === 'area' ? 'area' : r.geom_type === 'line' ? 'line' : 'point'
-    const presetMatch = matchTags(tags, osmGeomHint as GeometryType)
-    const icon: PlaceIcon | undefined = buildPlaceIcon(presetMatch)
-    const placeTypeLabel =
-      getPlaceType(tags, 'en', osmGeomHint as GeometryType) || r.categories?.[0] || 'place'
+    const isIntersection = r.id.startsWith('intersection/')
+    const presetMatch = isIntersection ? null : matchTags(tags, osmGeomHint as GeometryType)
+    const icon: PlaceIcon | undefined = isIntersection
+      ? { icon: 'Signpost', iconPack: 'lucide' as const }
+      : buildPlaceIcon(presetMatch)
+    const placeTypeLabel = isIntersection
+      ? 'Intersection'
+      : getPlaceType(tags, 'en', osmGeomHint as GeometryType) || r.categories?.[0] || 'place'
 
     // Contact info
     const phone = r.phones?.length ? r.phones[0] : null
@@ -472,8 +476,11 @@ export class BarrelmanIntegration
 
     // Build OSM URL — r.id is always "node/123456" format, so parse from that
     // (r.osm_type may be stored as uppercase 'N'/'W'/'R' in some DB versions)
-    const osmTypeFromId = r.id.split('/')[0] // 'node', 'way', or 'relation'
-    const osmUrl = `https://www.openstreetmap.org/${osmTypeFromId}/${r.osm_id}`
+    const osmTypeFromId = r.id.split('/')[0]
+    const isRealOsmType = ['node', 'way', 'relation'].includes(osmTypeFromId)
+    const osmUrl = isRealOsmType
+      ? `https://www.openstreetmap.org/${osmTypeFromId}/${r.osm_id}`
+      : undefined
 
     return {
       id: `${SOURCE.OSM}/${r.id}`,
@@ -505,8 +512,8 @@ export class BarrelmanIntegration
       sources: [
         {
           id: sourceId,
-          name: 'OpenStreetMap',
-          url: osmUrl,
+          name: isRealOsmType ? 'OpenStreetMap' : 'Parchment',
+          ...(osmUrl ? { url: osmUrl } : {}),
         },
       ],
 

--- a/server/src/services/merge.service.ts
+++ b/server/src/services/merge.service.ts
@@ -292,6 +292,12 @@ function mergeAttributedRecord<T>(
  * Determines if two places should be merged based on name, address, and distance similarity
  */
 function shouldMergePlaces(place1: Place, place2: Place): boolean {
+  // Never merge intersections with non-intersections (e.g. a tram stop named
+  // "Hawthorne & 8th" co-located with the road intersection)
+  const isIntersection1 = place1.placeType?.value === 'Intersection'
+  const isIntersection2 = place2.placeType?.value === 'Intersection'
+  if (isIntersection1 !== isIntersection2) return false
+
   const point1 = createTurfPoint(place1)
   const point2 = createTurfPoint(place2)
   const distanceMeters = turf.distance(point1, point2, { units: 'meters' })

--- a/server/src/services/place.service.ts
+++ b/server/src/services/place.service.ts
@@ -1090,13 +1090,14 @@ export async function lookupEnrichedPlaceByCoordinates(
     userId?: User['id']
     radius?: number
     language?: Language
+    addressOnly?: boolean
   },
 ): Promise<Place | null> {
   const startTime = Date.now()
   console.log(`⏱️ [PERF] Starting coordinate-based place lookup: lat=${lat}, lng=${lng}`)
   
   try {
-    const { userId, radius = 50, language = 'en' } = options || {}
+    const { userId, radius = 50, language = 'en', addressOnly = false } = options || {}
 
     // Step 1: Reverse geocode to find place at coordinates
     const geocodingIntegrations = integrationManager.getConfiguredIntegrationsByCapability(
@@ -1126,10 +1127,51 @@ export async function lookupEnrichedPlaceByCoordinates(
     }
     
     let place = results[0]
-    
+
+    // addressOnly mode: skip full enrichment, return coordinates as the title
+    // with geocoded address for supplemental info (used by /place/coords/:lat/:lng)
+    if (addressOnly) {
+      place.geometry = {
+        ...place.geometry,
+        value: {
+          type: 'point',
+          center: { lat, lng },
+        },
+      }
+      place.id = `coords/${lat}/${lng}`
+      place.externalIds = { coords: `${lat}/${lng}` }
+      place.name = { value: `${parseFloat(lat.toFixed(5))}, ${parseFloat(lng.toFixed(5))}`, sourceId: 'geocoding', timestamp: new Date().toISOString() }
+      place.description = null
+      place.placeType = { value: 'Coordinates', sourceId: 'geocoding', timestamp: new Date().toISOString() }
+      place.icon = { icon: 'Crosshair', iconPack: 'lucide' }
+      place.photos = []
+      place.contactInfo = { phone: null, email: null, website: null, socials: {} }
+      place.openingHours = null
+      place.ratings = undefined
+      place.transit = null
+      place.relations = null
+      place.amenities = {}
+      place.sources = []
+
+      const { resolveWidgetDescriptors } = await import('./widget.service')
+      place.widgets = resolveWidgetDescriptors(place)
+
+      if (userId) {
+        const bookmarkInfo = await findBookmarkByExternalIds(place.externalIds, userId)
+        if (bookmarkInfo) {
+          place.bookmark = bookmarkInfo.bookmark
+          place.collectionIds = bookmarkInfo.collectionIds
+        }
+      }
+
+      const totalTime = Date.now() - startTime
+      console.log(`⏱️ [PERF] Total coordinate lookup time (address-only): ${totalTime}ms`)
+      return place
+    }
+
     // Step 2: If we found a place with a name or ID, try to get full enriched details
     // This handles clicking near a POI - we want the full POI details, not just address
-    
+
     // First, check if we have an OSM ID - if so, use the full enrichment pipeline
     const osmId = place.externalIds?.[SOURCE.OSM]
     if (osmId) {

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -343,14 +343,7 @@ export async function search(
     })
   }
 
-  // Search recent places (handles both empty query and fuzzy search)
-  const recentPlaceResults = await searchRecentPlaces(userId, query)
-  scoredResults.push(
-    ...recentPlaceResults.map((r, i) => ({
-      result: r,
-      relevance: 0.6 - i * 0.05,
-    })),
-  )
+  // TODO: searchRecentPlaces — not yet implemented, skipping to avoid no-op await
 
   // Search external places using place service (only for 1+ character queries)
   if (query && query.length > 0 && lat && lng) {

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -21,6 +21,49 @@ import { integrationManager } from './integrations'
 import { resolveIcon } from '../lib/place-categories'
 
 
+function parseCoordinateQuery(query: string): { lat: number; lng: number } | null {
+  const trimmed = query.trim()
+
+  // "35.2271, -80.8431" or "35.2271,-80.8431"
+  const commaMatch = trimmed.match(/^(-?\d{1,3}(?:\.\d+)?)\s*,\s*(-?\d{1,3}(?:\.\d+)?)$/)
+  if (commaMatch) {
+    return validateAndNormalizeCoords(parseFloat(commaMatch[1]), parseFloat(commaMatch[2]))
+  }
+
+  // "35.2271 -80.8431" (both must have decimals to avoid "123 Main" false positives)
+  const spaceMatch = trimmed.match(/^(-?\d{1,3}\.\d+)\s+(-?\d{1,3}\.\d+)$/)
+  if (spaceMatch) {
+    return validateAndNormalizeCoords(parseFloat(spaceMatch[1]), parseFloat(spaceMatch[2]))
+  }
+
+  // "35.2271N 80.8431W" or "35.2271N, 80.8431W"
+  const nsewMatch = trimmed.match(/^(\d{1,3}(?:\.\d+)?)\s*([NSns])\s*,?\s*(\d{1,3}(?:\.\d+)?)\s*([EWew])$/)
+  if (nsewMatch) {
+    let lat = parseFloat(nsewMatch[1])
+    let lng = parseFloat(nsewMatch[3])
+    if (/[Ss]/.test(nsewMatch[2])) lat = -lat
+    if (/[Ww]/.test(nsewMatch[4])) lng = -lng
+    return validateAndNormalizeCoords(lat, lng)
+  }
+
+  return null
+}
+
+function validateAndNormalizeCoords(a: number, b: number): { lat: number; lng: number } | null {
+  if (!isFinite(a) || !isFinite(b)) return null
+
+  if (Math.abs(a) <= 90 && Math.abs(b) <= 180) {
+    return { lat: a, lng: b }
+  }
+
+  // Auto-swap if user entered lng,lat order
+  if (Math.abs(b) <= 90 && Math.abs(a) <= 180) {
+    return { lat: b, lng: a }
+  }
+
+  return null
+}
+
 /**
  * Convert a CategoryResult/preset to a SearchResult
  */
@@ -224,6 +267,54 @@ export async function search(
 
   // Collect all results with normalized relevance scores (0-1) for interleaving
   const scoredResults: Array<{ result: SearchResult; relevance: number }> = []
+
+  // Coordinate detection — inject synthetic result if query looks like coordinates
+  if (query) {
+    const coords = parseCoordinateQuery(query)
+    if (coords) {
+      const coordId = `coords/${coords.lat}/${coords.lng}`
+      const timestamp = new Date().toISOString()
+      scoredResults.push({
+        result: {
+          id: coordId,
+          type: 'place',
+          title: `${coords.lat}, ${coords.lng}`,
+          description: 'Coordinates',
+          icon: 'MapPin',
+          iconPack: 'lucide',
+          metadata: {
+            place: {
+              id: coordId,
+              externalIds: {},
+              name: { value: `${coords.lat}, ${coords.lng}`, sourceId: 'input', timestamp },
+              description: null,
+              placeType: { value: 'Coordinates', sourceId: 'input', timestamp },
+              icon: { icon: 'MapPin', iconPack: 'lucide' as const },
+              geometry: {
+                value: {
+                  type: 'point',
+                  center: { lat: coords.lat, lng: coords.lng },
+                },
+                sourceId: 'input',
+                timestamp,
+              },
+              photos: [],
+              address: null,
+              contactInfo: { phone: null, email: null, website: null, websites: null, socials: {} },
+              openingHours: null,
+              amenities: {},
+              tags: {},
+              summary: null,
+              sources: [],
+              lastUpdated: timestamp,
+              createdAt: timestamp,
+            } as any,
+          },
+        },
+        relevance: 1.0,
+      })
+    }
+  }
 
   // Search presets/categories (only for 1+ character queries)
   if (query && query.length > 0) {

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -164,50 +164,69 @@ export function resolveWidgetDescriptors(place: Place): WidgetDescriptor[] {
     const hasNearbyCategories = Boolean(place.nearbyCategories?.length)
     const isContainerPlace = isAreaPlace && hasNearbyCategories
 
-    if (osmId && center) {
-      // Children strategy: show interesting POIs inside this area
-      if (isContainerPlace) {
-        descriptors.push({
-          type: WidgetType.RELATED_PLACES,
-          dataType: WidgetDataType.ASYNC,
-          title: 'Related Places',
-          estimatedHeight: 110,
-          params: {
-            strategy: 'children' as RelatedPlacesStrategy,
-            osmId,
-            lat: String(center.lat),
-            lng: String(center.lng),
-            south: String(bounds?.minLat || ''),
-            west: String(bounds?.minLng || ''),
-            north: String(bounds?.maxLat || ''),
-            east: String(bounds?.maxLng || ''),
-            presetIds: place.nearbyCategories!.map((c) => c.presetId).join(','),
-            placeId: place.id,
-            limit: '20',
-            offset: '0',
-          },
-        })
-      }
+    if (center) {
+      if (osmId) {
+        // Children strategy: show interesting POIs inside this area
+        if (isContainerPlace) {
+          descriptors.push({
+            type: WidgetType.RELATED_PLACES,
+            dataType: WidgetDataType.ASYNC,
+            title: 'Related Places',
+            estimatedHeight: 110,
+            params: {
+              strategy: 'children' as RelatedPlacesStrategy,
+              osmId,
+              lat: String(center.lat),
+              lng: String(center.lng),
+              south: String(bounds?.minLat || ''),
+              west: String(bounds?.minLng || ''),
+              north: String(bounds?.maxLat || ''),
+              east: String(bounds?.maxLng || ''),
+              presetIds: place.nearbyCategories!.map((c) => c.presetId).join(','),
+              placeId: place.id,
+              limit: '20',
+              offset: '0',
+            },
+          })
+        }
 
-      if (isAdminPlace) {
-        // Admin strategy: show next-level-up administrative boundary
-        descriptors.push({
-          type: WidgetType.RELATED_PLACES,
-          dataType: WidgetDataType.ASYNC,
-          title: 'Related Places',
-          estimatedHeight: 76,
-          params: {
-            strategy: 'admin' as RelatedPlacesStrategy,
-            osmId,
-            lat: String(center.lat),
-            lng: String(center.lng),
-            south: '', west: '', north: '', east: '',
-            presetIds: '',
-            placeId: place.id,
-          },
-        })
+        if (isAdminPlace) {
+          // Admin strategy: show next-level-up administrative boundary
+          descriptors.push({
+            type: WidgetType.RELATED_PLACES,
+            dataType: WidgetDataType.ASYNC,
+            title: 'Related Places',
+            estimatedHeight: 76,
+            params: {
+              strategy: 'admin' as RelatedPlacesStrategy,
+              osmId,
+              lat: String(center.lat),
+              lng: String(center.lng),
+              south: '', west: '', north: '', east: '',
+              presetIds: '',
+              placeId: place.id,
+            },
+          })
+        } else {
+          // Parent strategy: show the containing area for any non-admin place
+          descriptors.push({
+            type: WidgetType.RELATED_PLACES,
+            dataType: WidgetDataType.ASYNC,
+            title: 'Related Places',
+            estimatedHeight: 76,
+            params: {
+              strategy: 'parent' as RelatedPlacesStrategy,
+              osmId,
+              lat: String(center.lat),
+              lng: String(center.lng),
+              south: '', west: '', north: '', east: '',
+              presetIds: '',
+              placeId: place.id,
+            },
+          })
+        }
       } else {
-        // Parent strategy: show the containing area for any non-admin place
+        // No OSM ID (e.g. coordinate lookup) — still show parent containers
         descriptors.push({
           type: WidgetType.RELATED_PLACES,
           dataType: WidgetDataType.ASYNC,
@@ -215,7 +234,7 @@ export function resolveWidgetDescriptors(place: Place): WidgetDescriptor[] {
           estimatedHeight: 76,
           params: {
             strategy: 'parent' as RelatedPlacesStrategy,
-            osmId,
+            osmId: '',
             lat: String(center.lat),
             lng: String(center.lng),
             south: '', west: '', north: '', east: '',
@@ -556,10 +575,10 @@ async function fetchParentPlaces(
   lng: number,
   adminOnly: boolean,
 ): Promise<RelatedParent[]> {
-  if (!osmId) return []
+  if (!lat || !lng) return []
 
   // Try Barrelman first for spatial contains queries
-  if (lat && lng) {
+  {
     const barrelman = getBarrelmanContainsInstance()
     if (barrelman) {
       try {
@@ -567,10 +586,12 @@ async function fetchParentPlaces(
         const containers = await barrelman.getContainingAreas(lat, lng, osmId)
         if (containers.length) {
           // Filter self-references: c.id is "osm/way/123", osmId is "way/123"
-          const nonSelf = containers.filter((c) => {
-            const cOsmId = c.externalIds?.[SOURCE.OSM] || ''
-            return cOsmId !== osmId && c.id !== osmId && c.id !== `osm/${osmId}`
-          })
+          const nonSelf = osmId
+            ? containers.filter((c) => {
+                const cOsmId = c.externalIds?.[SOURCE.OSM] || ''
+                return cOsmId !== osmId && c.id !== osmId && c.id !== `osm/${osmId}`
+              })
+            : containers
           console.debug(`✅ [Widget/Parent] Barrelman returned ${nonSelf.length} containers`)
           if (nonSelf.length) {
             return nonSelf.map((c) => ({

--- a/web/src/components/library/BookmarkCard.vue
+++ b/web/src/components/library/BookmarkCard.vue
@@ -18,6 +18,7 @@ import { useBookmarksService } from '@/services/library/bookmarks.service'
 import { storeToRefs } from 'pinia'
 import type { Bookmark } from '@/types/library.types'
 import type { ThemeColor } from '@/lib/utils'
+import { getPlaceRoute } from '@/lib/place.utils'
 import { useAppService } from '@/services/app.service'
 import BookmarkForm from '@/components/library/BookmarkForm.vue'
 import CollectionPicker from '@/components/library/CollectionPicker.vue'
@@ -53,17 +54,13 @@ onMounted(async () => {
 })
 
 function navigateToBookmark() {
-  const route = bookmarksStore.navigateToBookmark(props.bookmark)
-  const [type, osmId] = props.bookmark.externalIds.osm.split('/')
-  console.log(type, osmId)
+  bookmarksStore.navigateToBookmark(props.bookmark)
+  const ids = props.bookmark.externalIds as Record<string, string>
+  const [key, value] = ids.osm ? ['osm', ids.osm] : ids.coords ? ['coords', ids.coords] : [Object.keys(ids)[0], Object.values(ids)[0]]
+  if (!key || !value) return
+  const route = getPlaceRoute(`${key}/${value}`)
   if (route) {
-    router.push({
-      name: 'place',
-      params: {
-        id: osmId,
-        type,
-      },
-    })
+    router.push(route)
   }
 }
 

--- a/web/src/components/map/ContextMenu.vue
+++ b/web/src/components/map/ContextMenu.vue
@@ -29,6 +29,7 @@ import {
   MapPinIcon,
   RulerIcon,
   CircleDotIcon,
+  CrosshairIcon,
 } from 'lucide-vue-next'
 import ResponsiveDropdown from '@/components/responsive/ResponsiveDropdown.vue'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -150,6 +151,17 @@ function openPlaceAtLocation() {
       },
     })
   }
+}
+
+function openCoordinateDetail() {
+  if (!clickedLngLat.value) return
+  router.push({
+    name: AppRoute.PLACE_COORDS,
+    params: {
+      lat: clickedLngLat.value.lat.toString(),
+      lng: clickedLngLat.value.lng.toString(),
+    },
+  })
 }
 
 // Reverse geocode when context menu opens
@@ -323,7 +335,6 @@ const menuItems = computed<MenuItemDefinition[]>(() => {
       icon: MapPinIcon,
       onSelect: openPlaceAtLocation,
     })
-    items.push({ type: 'separator' })
   } else if (isGeocoding.value) {
     items.push({
       type: 'custom',
@@ -346,8 +357,19 @@ const menuItems = computed<MenuItemDefinition[]>(() => {
         ],
       ),
     })
-    items.push({ type: 'separator' })
   }
+
+  if (clickedLngLat.value) {
+    items.push({
+      type: 'item',
+      id: 'open-coords',
+      label: `${clickedLngLat.value.lat.toFixed(5)}, ${clickedLngLat.value.lng.toFixed(5)}`,
+      icon: CrosshairIcon,
+      onSelect: openCoordinateDetail,
+    })
+  }
+
+  items.push({ type: 'separator' })
 
   // Directions items
   if (!useMultistopDirections.value) {

--- a/web/src/components/place/actions/PlaceActions.vue
+++ b/web/src/components/place/actions/PlaceActions.vue
@@ -52,8 +52,9 @@ const singleCollection = computed(() => {
   return collectionsStore.getCollectionById(collectionIds.value[0]) ?? null
 })
 
-const hasOsmId = computed(() => {
-  return props.place.externalIds?.['osm'] // TODO: Use enum constant
+const canBookmark = computed(() => {
+  const ids = props.place.externalIds
+  return ids && Object.keys(ids).length > 0
 })
 
 // `place.collectionIds` is the source of truth for the badge; sync it
@@ -105,7 +106,7 @@ function onBookmarkDeleted() {
            the corner badge: count of collections (≥2), the single
            collection's icon (=1), or no badge (unsaved). -->
       <ResponsivePopover
-        v-if="hasOsmId"
+        v-if="canBookmark"
         align="end"
         desktop-content-class="w-auto px-0 py-1 min-w-[240px]"
         :peek-height="'400px'"

--- a/web/src/components/place/sources/PlaceSources.vue
+++ b/web/src/components/place/sources/PlaceSources.vue
@@ -31,7 +31,7 @@ function formatDate(dateString: string) {
 </script>
 
 <template>
-  <PlaceSection>
+  <PlaceSection v-if="place.sources?.length">
     <template #main>
       <div class="space-y-3">
         <div

--- a/web/src/lib/place.utils.ts
+++ b/web/src/lib/place.utils.ts
@@ -25,6 +25,22 @@ export function getPlaceRoute(placeId: string): RouteLocationRaw {
       }
     }
   }
+  // Coordinates format: "coords/35.2271/-80.8431"
+  else if (placeId.startsWith('coords/')) {
+    const parts = placeId.substring(7).split('/')
+    if (parts.length >= 2) {
+      console.log(
+        `Parsed as coords route: lat=${parts[0]}, lng=${parts[1]}`,
+      )
+      return {
+        name: AppRoute.PLACE_COORDS,
+        params: {
+          lat: parts[0],
+          lng: parts[1],
+        },
+      }
+    }
+  }
   // Location format: "location/name/lat/lng"
   else if (placeId.startsWith('location/')) {
     const parts = placeId.substring(9).split('/')

--- a/web/src/services/library/bookmarks.service.ts
+++ b/web/src/services/library/bookmarks.service.ts
@@ -49,7 +49,7 @@ export const useBookmarksService = createSharedComposable(() => {
   }
 
   async function createBookmark(place: Place, collectionIds?: string[]) {
-    if (!place.externalIds?.osm) {
+    if (!place.externalIds || Object.keys(place.externalIds).length === 0) {
       toast.error(t('services.bookmarks.saveErrorNoOsmId'))
       return null
     }

--- a/web/src/services/library/bookmarks.service.ts
+++ b/web/src/services/library/bookmarks.service.ts
@@ -239,7 +239,7 @@ export const useBookmarksService = createSharedComposable(() => {
     if (!bookmark.id) return false
 
     return bookmarksStore.bookmarks.some(
-      bookmark => bookmark.id === bookmark.id,
+      existing => existing.id === bookmark.id,
     )
   }
 


### PR DESCRIPTION
## Summary

- **Intersection places**: Accept `intersection` as valid OSM type in place controller. Barrelman integration adapts intersection results with Signpost icon, "Intersection" type label, and skips OSM URL construction.
- **Coordinate search**: Detect coordinate queries in three formats (decimal comma, space-separated, NSEW suffix) and inject synthetic coordinate results at relevance 1.0. Add `coords/` route parsing in `getPlaceRoute` for coordinate place navigation.
- **Coordinate place features**: Enable related places widget for coordinate-only lookups via parent spatial containment strategy. Resolve widgets and bookmark state for addressOnly coordinate places.
- **Bookmarking**: Relax bookmark guards across all three layers (UI, client service, server controller) from requiring `externalIds.osm` to any non-empty `externalIds`, enabling bookmarks for coordinates and intersections.
- **Search deduplication**: Prevent intersection/non-intersection merging in `shouldMergePlaces` to stop intersections being collapsed into co-located tram stops.
- **Bug fixes**: Fix `isBookmarkSaved` shadowed variable (`.some(bookmark => bookmark.id === bookmark.id)` always returned true), remove `searchRecentPlaces` no-op await from search hot path, fix BookmarkCard crash on coordinate bookmarks, show coordinate button instantly in context menu.

## Test plan

- [x] Search "trade and tryon" → intersection result with Signpost icon → click → `/place/intersection/42` renders
- [x] Type "35.2271, -80.8431" → coordinate result at top → click → `/place/coords/35.2271/-80.8431` renders with reverse-geocoded address
- [x] Bookmark a coordinate place and an intersection → reopen from library → navigates correctly
- [x] Context menu coordinate button appears instantly without waiting for geocoding
- [x] Empty sources card hidden when place has no sources