### PR TITLE
Trip planner and UI redesign

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build:emails": "cd emails && bun install && npx maizzle build production",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.3.0-1"
+version = "0.3.0-2"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.3.0-1",
+  "version": "0.3.0-2",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",
@@ -65,7 +65,7 @@
       "developmentTeam": "QPNGAD5BD2"
     },
     "android": {
-      "versionCode": 3001
+      "versionCode": 3002
     }
   }
 }

--- a/web/src/views/directions/TripItem.vue
+++ b/web/src/views/directions/TripItem.vue
@@ -10,6 +10,7 @@ import type {
   TripOption,
   TripsResponse,
 } from '@/types/directions.types'
+import { TravelMode } from '@/types/directions.types'
 
 interface Props {
   trip: TripOption
@@ -40,13 +41,12 @@ function formatCo2(kg: number): string {
 const dominantMode = computed(() => {
   const durations: Record<string, number> = {}
   for (const seg of props.trip.segments) {
-    const mode = seg.mode === 'biking' ? 'cycling' : seg.mode
-    durations[mode] = (durations[mode] || 0) + seg.duration
+    durations[seg.mode] = (durations[seg.mode] || 0) + seg.duration
   }
-  let best = props.trip.mode
+  let best: TravelMode = props.trip.mode
   let max = 0
   for (const [mode, dur] of Object.entries(durations)) {
-    if (dur > max) { max = dur; best = mode }
+    if (dur > max) { max = dur; best = mode as TravelMode }
   }
   return best
 })

--- a/web/src/views/directions/TripsList.vue
+++ b/web/src/views/directions/TripsList.vue
@@ -97,7 +97,7 @@ const timelineWidth = computed(() => {
   return fullRange * pxPerMinute.value
 })
 
-const tickIntervals = computed(() => {
+const tickIntervals = computed((): { tickSec: number; labelSec: number } | { tick: number; label: number } => {
   const viewMin = barAreaWidth.value / pxPerMinute.value
   if (viewMin <= 2) return { tickSec: 10, labelSec: 30 }
   if (viewMin <= 4) return { tickSec: 15, labelSec: 60 }

--- a/web/src/views/friends/FriendDetail.vue
+++ b/web/src/views/friends/FriendDetail.vue
@@ -144,11 +144,11 @@ function getDirections() {
     lngLat: { lng, lat },
     place: {
       id: `friend-${friend.value!.friendHandle}`,
-      name: { value: displayName.value },
-      geometry: { value: { type: 'point', center: { lat, lng } } },
+      name: { value: displayName.value, sourceId: '' },
+      geometry: { value: { type: 'point' as const, center: { lat, lng } }, sourceId: '' },
       externalIds: {},
       address: null,
-      placeType: { value: 'friend' },
+      placeType: { value: 'friend', sourceId: '' },
     },
   }
 

--- a/web/src/views/library/Library.vue
+++ b/web/src/views/library/Library.vue
@@ -53,8 +53,8 @@ watch(
   { immediate: true },
 )
 
-function handleTabChange(tabId: string) {
-  const tab = tabs.find(t => t.id === tabId)
+function handleTabChange(tabId: string | number) {
+  const tab = tabs.find(t => t.id === String(tabId))
   if (tab) {
     router.push({ name: tab.route })
   }


### PR DESCRIPTION
### Added

* Multimodal trip planner — plan trips with transit, walking, cycling, driving, and park-and-ride combinations powered by MOTIS and GraphHopper
* Multi-itinerary transit — returns multiple trip candidates from MOTIS, scored across fastest, fewest transfers, and least walking
* Departure time picker and sort preferences for trip planning
* Transit detail view — route-colored timeline segments, departure cards, and stop lists
* Realtime transit indicators — wifi icon and delay labels on departure boards and trip segments, powered by GTFS-RT
* Park-and-ride support — finds parking near transit stops and composes drive→park→transit→walk trips
* Per-waypoint time constraints — departAfter, arriveBy, and dwellTime on any stop
* Onboarding wizard — profile setup, alias, recovery key, passkey, theme, and subscription steps for new users
* Admin user management — user detail pages, role CRUD, permission management, impersonation, and pagination
* Avatar upload and serving
* Dashboard with inline command palette, pinned bookmarks, and card layout

### Changed

* Full UI redesign — warm neominimal theme, 3D depth styling on buttons/inputs/cards, Geist and Boston Angel typography
* Redesigned friends page, place detail, trip timeline, settings sidebar, and library layout
* Redesigned trip detail timeline with colored segments and aligned mode icons
* Migrated transit departures from Transitland to Barrelman (MOTIS stoptimes)
* Removed dead Transitland code from place service

### Fixed

* Widget transit detection crashing on Place amenities shape
* Dialog open animation flying in from top-left corner
* Orphaned and duplicated markers on style reload and drag
* Cycling/walking speed using wrong GraphHopper modifier
* Command palette vertical positioning after dialog centering change
* Location sharing, auth middleware, and polygon layer bugs
* Marker layer watcher leaks causing stale map markers