### PR TITLE
Search: palette rework, category widen + pagination, faster queries

### DIFF
--- a/server/src/controllers/search.controller.ts
+++ b/server/src/controllers/search.controller.ts
@@ -175,12 +175,13 @@ const searchRouter = new Elysia({ prefix: '/search' })
   .post(
     '/category',
     async ({ body, status, language }) => {
-      const { presetId, bounds, maxResults = 100, sort, filter, tags } = body
+      const { presetId, bounds, maxResults = 30, offset = 0, sort, filter, tags } = body
 
       try {
         const results = await searchService.searchByCategory(presetId, {
           bounds,
           limit: maxResults,
+          offset,
           sort,
           filter,
           tags,
@@ -193,7 +194,9 @@ const searchRouter = new Elysia({ prefix: '/search' })
           presetId,
           results,
           fieldDefinitions,
-          totalCount: results.length,
+          // No total count: a COUNT over a broad category/wide area is expensive.
+          // `hasMore` (a full page came back) drives scroll pagination instead.
+          hasMore: results.length >= maxResults,
           executedAt: new Date().toISOString(),
         }
       } catch (err) {
@@ -216,6 +219,7 @@ const searchRouter = new Elysia({ prefix: '/search' })
           west: t.Number(),
         }),
         maxResults: t.Optional(t.Number({ minimum: 1, maximum: 1000 })),
+        offset: t.Optional(t.Number({ minimum: 0 })),
         sort: t.Optional(t.Union([
           t.Literal('relevance'),
           t.Literal('distance'),

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -46,10 +46,16 @@ const pinoToSeverity: Record<string, SeverityNumber> = {
 export interface EmitLogRecordOptions {
   /** When false, only log to pino (stdout). When true, also send to OTLP (e.g. Axiom). Default true. */
   sendToOtlp?: boolean
+  /**
+   * When false, skip the pino/stdout line entirely and only export to OTLP.
+   * Used to keep routine events (client errors, slow requests) out of the noisy
+   * stdout stream while still recording them for analytics. Default true.
+   */
+  stdout?: boolean
 }
 
 /**
- * Emit a structured log record to pino (stdout). Optionally also send to the OTLP pipeline.
+ * Emit a structured log record to pino (stdout) and/or the OTLP pipeline.
  * Use this for canonical/wide event log lines — NOT for per-line debug output.
  */
 export function emitLogRecord(
@@ -58,9 +64,11 @@ export function emitLogRecord(
   attributes: Record<string, unknown> = {},
   options: EmitLogRecordOptions = {},
 ) {
-  const { sendToOtlp = true } = options
+  const { sendToOtlp = true, stdout = true } = options
 
-  logger[level](attributes, message)
+  if (stdout) {
+    logger[level](attributes, message)
+  }
 
   if (sendToOtlp) {
     getOtelLogger().emit({

--- a/server/src/lib/osm-presets.ts
+++ b/server/src/lib/osm-presets.ts
@@ -655,7 +655,7 @@ export function clearAllData(): void {
 }
 
 export function initializeOsmPresets(): void {
-  console.log('🏗️  Initializing OSM preset system...')
+  console.log('Initializing OSM preset system...')
   const start = Date.now()
 
   const presetData = loadPresets()
@@ -663,7 +663,7 @@ export function initializeOsmPresets(): void {
   buildIndex(presetData)
   createCache()
 
-  console.log(`✅ OSM preset system ready:`)
+  console.log(`OSM preset system ready:`)
   console.log(`   - ${Object.keys(presetData).length} presets`)
   console.log(`   - ${Object.keys(fieldData).length} fields`)
   console.log(`   - Geometry index built`)

--- a/server/src/lib/place-categories.ts
+++ b/server/src/lib/place-categories.ts
@@ -375,7 +375,7 @@ export function resolveIcon(presetIcon: string): { icon: string; iconPack: 'luci
   }
 
   // Last resort: use as maki name but log the miss
-  console.warn(`⚠️  Unmapped icon "${presetIcon}" → falling back to "${stripped}" (maki). Add to nonMakiFallbackMap.`)
+  console.warn(`Unmapped icon "${presetIcon}" → falling back to "${stripped}" (maki). Add to nonMakiFallbackMap.`)
   return { icon: stripped, iconPack: 'maki' }
 }
 
@@ -395,7 +395,7 @@ export function buildPlaceIcon(presetMatch: MatchResult | null): PlaceIcon | und
     const key = presetMatch.preset.id
     if (!loggedMissingIcons.has(key)) {
       loggedMissingIcons.add(key)
-      console.warn(`📍 No icon for preset "${key}" (raw: ${presetIcon || 'none'}). Will show MapPin.`)
+      console.warn(`No icon for preset "${key}" (raw: ${presetIcon || 'none'}). Will show MapPin.`)
     }
   }
 

--- a/server/src/middleware/logger.middleware.ts
+++ b/server/src/middleware/logger.middleware.ts
@@ -114,12 +114,46 @@ function payloadFromLogEvent(logEvent: LogEvent): Record<string, unknown> {
 }
 
 /**
+ * Attach debugging/analytics context to a failing request's log event:
+ * the authenticated user's non-sensitive id and the parsed request payload.
+ * Device info (user_agent, ip) is already captured on `logEvent.http`.
+ *
+ * `ctx` is the full Elysia request context; `user` and `body` are populated by
+ * downstream derives (auth middleware, body parser) and typed loosely here since
+ * they are not part of the logger plugin's own context type. Called only for
+ * failures (status >= 400) — successful requests are not logged.
+ */
+function attachDebugContext(logEvent: LogEvent, ctx: unknown): void {
+  const context = ctx as { user?: { id?: unknown }; body?: unknown }
+
+  const userId = context.user?.id
+  if (typeof userId === 'string') {
+    logEvent.user = { ...(logEvent.user ?? {}), id: userId }
+  }
+
+  // Include the parsed request body so errors can be reproduced. Redaction of
+  // sensitive keys and truncation happen later in payloadFromLogEvent.
+  if (context.body !== undefined && logEvent.request?.body === undefined) {
+    logEvent.request = { ...(logEvent.request ?? {}), body: context.body }
+  }
+}
+
+/**
  * Elysia plugin implementing the "wide event" / canonical log line pattern.
  *
- * - Every request is logged to stdout (pino).
- * - Only failed (status >= 400) or slow (> SLOW_REQUEST_THRESHOLD_MS) requests are sent to OTLP.
- * - Response body is NOT auto-logged. Handlers can set `logEvent.response.body` explicitly.
- * - Handlers can set `logEvent.request.body` to include the request body in failure logs.
+ * Logging is split by destination to keep stdout quiet while preserving analytics:
+ * - stdout (pino): ONLY server errors (status >= 500) and unhandled exceptions.
+ *   Successful (2xx/3xx) and routine client-error (4xx, e.g. 401 auth rejections)
+ *   requests produce no stdout line. Error lines carry full debug context:
+ *   stack trace, request payload, non-sensitive user (id) and device (user_agent,
+ *   ip) info, timing, request id, and trace correlation.
+ * - OTLP (e.g. Axiom): all failures (status >= 400) and slow requests
+ *   (> SLOW_REQUEST_THRESHOLD_MS) are exported as structured events for analytics,
+ *   even when they are kept out of stdout.
+ *
+ * Other behavior:
+ * - Request payload is auto-attached to failure logs (redacted + truncated).
+ * - Response body is NOT auto-logged. Handlers can set `logEvent.response.body`.
  * - Incoming `traceparent`/`tracestate` headers are respected for distributed tracing.
  * - `X-Request-Id` is returned in every response for client-side correlation.
  */
@@ -174,7 +208,8 @@ export const loggerMiddleware = new Elysia({ name: 'parchment-logger' })
     return { logEvent }
   })
 
-  .onAfterHandle({ as: 'global' }, ({ logEvent, set }) => {
+  .onAfterHandle({ as: 'global' }, (ctx) => {
+    const { logEvent, set } = ctx
     if (!logEvent) return
     const meta = (logEvent as LogEvent & { _meta: LogEventMeta })._meta
     if (meta.logged) return
@@ -191,14 +226,25 @@ export const loggerMiddleware = new Elysia({ name: 'parchment-logger' })
     meta.span.setStatus({ code: status >= 500 ? SpanStatusCode.ERROR : SpanStatusCode.OK })
     meta.span.end()
 
-    const level = status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info'
     const isFailure = status >= 400
+    const isServerError = status >= 500
     const isSlow = duration_ms > SLOW_REQUEST_THRESHOLD_MS
-    const payload = payloadFromLogEvent(logEvent)
-    emitLogRecord(level, 'request', payload, { sendToOtlp: isFailure || isSlow })
+
+    // Successful, fast requests are not logged at all.
+    if (!isFailure && !isSlow) return
+
+    if (isFailure) attachDebugContext(logEvent, ctx)
+
+    // stdout only for real server errors; 4xx and slow requests go to OTLP only.
+    const level = isServerError ? 'error' : status >= 400 ? 'warn' : 'info'
+    emitLogRecord(level, 'request', payloadFromLogEvent(logEvent), {
+      sendToOtlp: true,
+      stdout: isServerError,
+    })
   })
 
-  .onError({ as: 'global' }, ({ logEvent, error, code, set }) => {
+  .onError({ as: 'global' }, (ctx) => {
+    const { logEvent, error, code, set } = ctx
     if (!logEvent) return
     const meta = (logEvent as LogEvent & { _meta: LogEventMeta })._meta
     if (meta.logged) return
@@ -221,6 +267,14 @@ export const loggerMiddleware = new Elysia({ name: 'parchment-logger' })
     meta.span.setStatus({ code: SpanStatusCode.ERROR, message: logEvent.error.message })
     meta.span.end()
 
-    const payload = payloadFromLogEvent(logEvent)
-    emitLogRecord('error', 'request', payload, { sendToOtlp: true })
+    attachDebugContext(logEvent, ctx)
+
+    // Real server errors (5xx, incl. the default for thrown exceptions) print to
+    // stdout with full detail. Exceptions that map to a 4xx (validation, parse,
+    // not-found) are client errors — exported to OTLP only, kept out of stdout.
+    const isServerError = status >= 500
+    emitLogRecord(isServerError ? 'error' : 'warn', 'request', payloadFromLogEvent(logEvent), {
+      sendToOtlp: true,
+      stdout: isServerError,
+    })
   })

--- a/server/src/seed/seed.ts
+++ b/server/src/seed/seed.ts
@@ -10,7 +10,7 @@ import { syncPermissionsAndRoles } from './sync-permissions'
  */
 
 await syncPermissionsAndRoles()
-console.info('✅ Permissions and roles synced')
+console.info('Permissions and roles synced')
 
 // Insert initial user if none exist.
 const users = await db.select().from(usersSchema).limit(1)
@@ -32,14 +32,14 @@ if (users.length === 0) {
     })
     .returning()
 
-  console.info(`✅ Inserted user ${firstName} ${lastName}`)
+  console.info(`Inserted user ${firstName} ${lastName}`)
 
   await db.insert(usersToRoles).values({
     userId: user.id,
     roleId: 'admin',
   })
 
-  console.info(`✅ Assigned admin role to ${firstName} ${lastName}`)
+  console.info(`Assigned admin role to ${firstName} ${lastName}`)
 }
 
 console.log('Seed finished')

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -732,32 +732,61 @@ export class BarrelmanIntegration
     return (response.data || []).map((r: any) => this.adaptPlace(r))
   }
 
+  /**
+   * Search a POI category. Two tiers, both fast:
+   *  1. Viewport-scoped (lat/lng + radius) — barrelman orders browse results
+   *     nearest-first via the GiST KNN index, so this is quick at any zoom.
+   *  2. Widen — when the viewport is sparse (fewer than `minResults`), re-query
+   *     with NO radius. Barrelman then drives the scan from the category GIN
+   *     index and returns the nearest matches within a wide bbox, so a zoomed-in
+   *     search for a thin category (e.g. gas stations in Manhattan) still finds
+   *     the nearest ones (~1s) instead of coming back empty.
+   * Supports `offset` for scroll pagination — a sparse viewport widens at every
+   * offset, so pages stay consistent. No total count is computed (a COUNT over a
+   * broad category is itself expensive); the client paginates until a short page.
+   */
   async searchByCategory(
     presetId: string,
     bounds: MapBounds,
-    options?: { limit?: number; filterTags?: Record<string, string>; sort?: string; filter?: Record<string, any> },
+    options?: { limit?: number; offset?: number; minResults?: number; filterTags?: Record<string, string>; sort?: string; filter?: Record<string, any> },
   ): Promise<Place[]> {
     const lat = (bounds.north + bounds.south) / 2
     const lng = (bounds.east + bounds.west) / 2
     const latDiff = Math.abs(bounds.north - bounds.south)
     const lngDiff = Math.abs(bounds.east - bounds.west)
-    const radius = (Math.max(latDiff, lngDiff) * 111320) / 2
+    const radius = Math.min((Math.max(latDiff, lngDiff) * 111320) / 2, 50000)
 
-    const response = await barrelmanSearchHttp.post(
-      `${this.config.host}/search`,
-      {
-        lat,
-        lng,
-        radius: Math.min(radius, 50000),
-        categories: [presetId],
-        limit: options?.limit || 20,
-        ...(options?.filterTags ? { tags: options.filterTags } : {}),
-        ...(options?.sort ? { sort: options.sort } : {}),
-        ...(options?.filter ? { filter: options.filter } : {}),
-      },
-      { headers: this.headers, timeout: 10000 },
-    )
-    return (response.data || []).map((r: any) => this.adaptPlace(r))
+    const limit = options?.limit || 20
+    const offset = options?.offset || 0
+    const minResults = options?.minResults ?? 6
+
+    const post = (body: Record<string, any>) =>
+      barrelmanSearchHttp.post(`${this.config.host}/search`, body, {
+        headers: this.headers,
+        timeout: 10000,
+      })
+
+    const baseBody = {
+      lat,
+      lng,
+      categories: [presetId],
+      limit,
+      ...(offset ? { offset } : {}),
+      ...(options?.filterTags ? { tags: options.filterTags } : {}),
+      ...(options?.sort ? { sort: options.sort } : {}),
+      ...(options?.filter ? { filter: options.filter } : {}),
+    }
+
+    // Tier 1: viewport-scoped (bounded radius → KNN).
+    let rows: any[] = (await post({ ...baseBody, radius })).data || []
+
+    // Tier 2: widen when the viewport is sparse — omit the radius so barrelman
+    // uses the category-index scan (fast even for a thin category).
+    if (rows.length < minResults) {
+      rows = (await post(baseBody)).data || []
+    }
+
+    return rows.map((r: any) => this.adaptPlace(r))
   }
 
   // ── Brand catalog ──────────────────────────────────────────────────────

--- a/server/src/services/integrations/overpass-integration.ts
+++ b/server/src/services/integrations/overpass-integration.ts
@@ -468,7 +468,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
     const [osmType, rawId] = osmId.split('/')
     const numericId = parseInt(rawId, 10)
     if (!numericId || (osmType !== 'way' && osmType !== 'relation')) {
-      console.debug(`🚫 [Overpass/Area] Cannot create area from ${osmId} (only way/relation supported)`)
+      console.debug(`[Overpass/Area] Cannot create area from ${osmId} (only way/relation supported)`)
       return []
     }
 
@@ -496,7 +496,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
       out body geom ${maxResults};`.trim()
 
     try {
-      console.debug(`🌐 [Overpass/Area] Searching within area ${osmId} for ${presetIds.length} categories`)
+      console.debug(`[Overpass/Area] Searching within area ${osmId} for ${presetIds.length} categories`)
       const response = await axios.post(
         this.config.host,
         new URLSearchParams({ data: query }),
@@ -509,7 +509,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
       if (!response.data?.elements) return []
       return this.elementsToPlaces(response.data.elements.slice(0, maxResults))
     } catch (error) {
-      console.error(`❌ [Overpass/Area] Error executing area query for ${osmId}:`, error)
+      console.error(`[Overpass/Area] Error executing area query for ${osmId}:`, error)
       return []
     }
   }
@@ -543,7 +543,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
       out body geom ${maxResults};`.trim()
 
     try {
-      console.debug(`🌐 [Overpass/Bbox] Searching within bbox of ${osmId} for ${tagSets.length} categories`)
+      console.debug(`[Overpass/Bbox] Searching within bbox of ${osmId} for ${tagSets.length} categories`)
       const response = await axios.post(
         this.config.host,
         new URLSearchParams({ data: query }),
@@ -555,10 +555,10 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
 
       if (!response.data?.elements) return []
       const places = this.elementsToPlaces(response.data.elements.slice(0, maxResults))
-      console.debug(`✅ [Overpass/Bbox] Found ${places.length} places within ${osmId}`)
+      console.debug(`[Overpass/Bbox] Found ${places.length} places within ${osmId}`)
       return places
     } catch (error) {
-      console.error(`❌ [Overpass/Bbox] Error executing bbox query for ${osmId}:`, error)
+      console.error(`[Overpass/Bbox] Error executing bbox query for ${osmId}:`, error)
       return []
     }
   }
@@ -622,7 +622,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
           }
         })
     } catch (error) {
-      console.error('❌ [Overpass/IsIn] Error fetching containing areas:', error)
+      console.error('[Overpass/IsIn] Error fetching containing areas:', error)
       return []
     }
   }

--- a/server/src/services/integrations/transitland-integration.ts
+++ b/server/src/services/integrations/transitland-integration.ts
@@ -172,7 +172,7 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
     limit?: number
   }): Promise<TransitDeparture[]> {
     const startTime = Date.now()
-    console.log(`⏱️ [PERF] Transitland getDepartures: ${onestopId}`)
+    console.log(`[PERF] Transitland getDepartures: ${onestopId}`)
     
     this.ensureInitialized()
 
@@ -364,7 +364,7 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
    */
   async getStop(onestopId: string): Promise<any | null> {
     const startTime = Date.now()
-    console.log(`⏱️ [PERF] Transitland getStop: ${onestopId}`)
+    console.log(`[PERF] Transitland getStop: ${onestopId}`)
     
     this.ensureInitialized()
 
@@ -380,11 +380,11 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
       const fetchStart = Date.now()
       const response = await fetch(fullUrl)
       const fetchTime = Date.now() - fetchStart
-      console.log(`⏱️ [PERF] Transitland API fetch: ${fetchTime}ms`)
+      console.log(`[PERF] Transitland API fetch: ${fetchTime}ms`)
 
       if (!response.ok) {
         if (response.status === 404) {
-          console.log(`⏱️ [PERF] Transitland getStop (404): ${Date.now() - startTime}ms`)
+          console.log(`[PERF] Transitland getStop (404): ${Date.now() - startTime}ms`)
           return null
         }
         console.error('Transitland stop API error:', response.status, response.statusText)
@@ -394,19 +394,19 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
       const parseStart = Date.now()
       const data = await response.json()
       const parseTime = Date.now() - parseStart
-      console.log(`⏱️ [PERF] Transitland JSON parse: ${parseTime}ms`)
+      console.log(`[PERF] Transitland JSON parse: ${parseTime}ms`)
       
       // Transitland API returns stops in an array
       if (data.stops && data.stops.length > 0) {
         const totalTime = Date.now() - startTime
-        console.log(`⏱️ [PERF] Transitland getStop total: ${totalTime}ms`)
+        console.log(`[PERF] Transitland getStop total: ${totalTime}ms`)
         return data.stops[0]
       }
       
-      console.log(`⏱️ [PERF] Transitland getStop (no stops): ${Date.now() - startTime}ms`)
+      console.log(`[PERF] Transitland getStop (no stops): ${Date.now() - startTime}ms`)
       return null
     } catch (error) {
-      console.error(`❌ [PERF] Error fetching stop from Transitland (${Date.now() - startTime}ms):`, error)
+      console.error(`[PERF] Error fetching stop from Transitland (${Date.now() - startTime}ms):`, error)
       return null
     }
   }

--- a/server/src/services/place.service.ts
+++ b/server/src/services/place.service.ts
@@ -70,18 +70,18 @@ function isMissingAddressData(place: Place): boolean {
 async function enrichPlaceWithAddressData(place: Place): Promise<Place> {
   // Skip if we already have good address data
   if (!isMissingAddressData(place)) {
-    console.log('📍 Place already has address data, skipping address enrichment')
+    console.log('Place already has address data, skipping address enrichment')
     return place
   }
   
   // Skip if we don't have coordinates
   if (!place.geometry.value.center) {
-    console.log('📍 Place has no coordinates, cannot enrich address')
+    console.log('Place has no coordinates, cannot enrich address')
     return place
   }
   
   const startTime = Date.now()
-  console.log('📍 Place missing address data, attempting reverse geocoding enrichment...')
+  console.log('Place missing address data, attempting reverse geocoding enrichment...')
   
   try {
     const { lat, lng } = place.geometry.value.center
@@ -92,7 +92,7 @@ async function enrichPlaceWithAddressData(place: Place): Promise<Place> {
     )
     
     if (!geocodingIntegrations.length) {
-      console.log('📍 No geocoding integration available for address enrichment')
+      console.log('No geocoding integration available for address enrichment')
       return place
     }
     
@@ -102,7 +102,7 @@ async function enrichPlaceWithAddressData(place: Place): Promise<Place> {
       
       if (!integration?.capabilities.geocoding) continue
       
-      console.log(`📍 Trying address enrichment with ${integrationRecord.integrationId}...`)
+      console.log(`Trying address enrichment with ${integrationRecord.integrationId}...`)
       
       try {
         const results = await integration.capabilities.geocoding.reverseGeocode(lat, lng)
@@ -113,7 +113,7 @@ async function enrichPlaceWithAddressData(place: Place): Promise<Place> {
           // Only use the address if it has meaningful data
           const addr = geocodedAddress.value
           if (addr.street1 || addr.locality) {
-            console.log(`📍 Successfully enriched address from ${integrationRecord.integrationId}`)
+            console.log(`Successfully enriched address from ${integrationRecord.integrationId}`)
             place.address = geocodedAddress
             
             // Add to sources if not already present
@@ -126,20 +126,20 @@ async function enrichPlaceWithAddressData(place: Place): Promise<Place> {
             }
             
             const enrichTime = Date.now() - startTime
-            console.log(`⏱️ [PERF] Address enrichment: ${enrichTime}ms`)
+            console.log(`[PERF] Address enrichment: ${enrichTime}ms`)
             return place
           }
         }
       } catch (error) {
-        console.error(`📍 Error enriching address with ${integrationRecord.integrationId}:`, error)
+        console.error(`Error enriching address with ${integrationRecord.integrationId}:`, error)
         // Continue to next integration
       }
     }
     
-    console.log('📍 No geocoding integration returned useful address data')
+    console.log('No geocoding integration returned useful address data')
     return place
   } catch (error) {
-    console.error('📍 Error during address enrichment:', error)
+    console.error('Error during address enrichment:', error)
     return place
   }
 }
@@ -414,7 +414,7 @@ export async function lookupPlaceByNameAndLocation(
   },
 ): Promise<Place | null> {
   const startTime = Date.now()
-  console.log(`⏱️ [PERF] Third party place lookup: ${name} at ${coordinates.lat},${coordinates.lng}`)
+  console.log(`[PERF] Third party place lookup: ${name} at ${coordinates.lat},${coordinates.lng}`)
   
   try {
     const {
@@ -434,10 +434,10 @@ export async function lookupPlaceByNameAndLocation(
       language,
     })
     const searchTime = Date.now() - searchStart
-    console.log(`⏱️ [PERF] Multi-provider search: ${searchTime}ms (found ${places.length} places)`)
+    console.log(`[PERF] Multi-provider search: ${searchTime}ms (found ${places.length} places)`)
 
     if (places.length === 0) {
-      console.log(`⏱️ [PERF] Third party lookup (no results): ${Date.now() - startTime}ms`)
+      console.log(`[PERF] Third party lookup (no results): ${Date.now() - startTime}ms`)
       return null
     }
 
@@ -446,15 +446,15 @@ export async function lookupPlaceByNameAndLocation(
       // TODO: Where else do we need to add bookmark info?
       await addBookmarkInfo(places, userId)
       const bookmarkTime = Date.now() - bookmarkStart
-      console.log(`⏱️ [PERF] Third party bookmark info: ${bookmarkTime}ms`)
+      console.log(`[PERF] Third party bookmark info: ${bookmarkTime}ms`)
     }
 
     const totalTime = Date.now() - startTime
-    console.log(`⏱️ [PERF] Third party place lookup total: ${totalTime}ms`)
+    console.log(`[PERF] Third party place lookup total: ${totalTime}ms`)
 
     return places[0] || null
   } catch (error) {
-    console.error(`❌ [PERF] Error getting place by name and coordinates (${Date.now() - startTime}ms):`, error)
+    console.error(`[PERF] Error getting place by name and coordinates (${Date.now() - startTime}ms):`, error)
     return null
   }
 }
@@ -472,7 +472,7 @@ async function enrichPlaceWithWikiData(
   language: Language = 'en'
 ): Promise<Place> {
   const startTime = Date.now()
-  console.log(`⏱️ [PERF] Starting Wiki data enrichment`)
+  console.log(`[PERF] Starting Wiki data enrichment`)
   
   try {
     // First, try to find Wikidata ID via parent relations (especially for transit stops)
@@ -499,7 +499,7 @@ async function enrichPlaceWithWikiData(
         }
       }
       
-      console.log(`⏱️ [PERF] Wiki data enrichment (no Wikidata ID): ${Date.now() - startTime}ms`)
+      console.log(`[PERF] Wiki data enrichment (no Wikidata ID): ${Date.now() - startTime}ms`)
       return place
     }
 
@@ -524,11 +524,11 @@ async function enrichPlaceWithWikiData(
     const wikidataFetchStart = Date.now()
     const wikidataEntity = await wikidataIntegration.getEntityData(wikidataId, language)
     const wikidataFetchTime = Date.now() - wikidataFetchStart
-    console.log(`⏱️ [PERF] Wikidata entity fetch: ${wikidataFetchTime}ms`)
+    console.log(`[PERF] Wikidata entity fetch: ${wikidataFetchTime}ms`)
     
     if (!wikidataEntity) {
       console.log(`No Wikidata entity found for ID: ${wikidataId}`)
-      console.log(`⏱️ [PERF] Wiki data enrichment (no entity): ${Date.now() - startTime}ms`)
+      console.log(`[PERF] Wiki data enrichment (no entity): ${Date.now() - startTime}ms`)
       return place
     }
 
@@ -538,7 +538,7 @@ async function enrichPlaceWithWikiData(
     if (allOnestopIds.length > 0 && isPlaceTransitStop(place)) {
       const timestamp = new Date().toISOString()
       
-      console.debug(`🎯 [Transit] Wikidata → Transitland mapping successful:`)
+      console.debug(`[Transit] Wikidata → Transitland mapping successful:`)
       console.debug(`  - Wikidata ID: ${wikidataId}`)
       console.debug(`  - Onestop IDs: ${allOnestopIds.join(', ')}`)
       console.debug(`  - Source: Wikidata P11109 property`)
@@ -574,13 +574,13 @@ async function enrichPlaceWithWikiData(
     const wikidataPlaceStart = Date.now()
     const wikidataPlace = await wikidataIntegration.capabilities.placeInfo?.getPlaceInfo(wikidataId)
     const wikidataPlaceTime = Date.now() - wikidataPlaceStart
-    console.log(`⏱️ [PERF] Wikidata place info fetch: ${wikidataPlaceTime}ms`)
+    console.log(`[PERF] Wikidata place info fetch: ${wikidataPlaceTime}ms`)
     
     if (wikidataPlace) {
       const mergeStart = Date.now()
       place = mergePlaces(place, wikidataPlace)
       const mergeTime = Date.now() - mergeStart
-      console.log(`⏱️ [PERF] Wikidata place merge: ${mergeTime}ms`)
+      console.log(`[PERF] Wikidata place merge: ${mergeTime}ms`)
     }
 
     // Extract Wikipedia title from Wikidata entity
@@ -599,13 +599,13 @@ async function enrichPlaceWithWikiData(
           const wikipediaStart = Date.now()
           const wikipediaPlace = await wikipediaIntegration.capabilities.placeInfo?.getPlaceInfo(`${language}:${wikipediaTitle}`)
           const wikipediaTime = Date.now() - wikipediaStart
-          console.log(`⏱️ [PERF] Wikipedia fetch: ${wikipediaTime}ms`)
+          console.log(`[PERF] Wikipedia fetch: ${wikipediaTime}ms`)
           
           if (wikipediaPlace) {
             const mergeStart = Date.now()
             place = mergePlaces(place, wikipediaPlace)
             const mergeTime = Date.now() - mergeStart
-            console.log(`⏱️ [PERF] Wikipedia merge: ${mergeTime}ms`)
+            console.log(`[PERF] Wikipedia merge: ${mergeTime}ms`)
           }
         }
       }
@@ -635,7 +635,7 @@ async function enrichPlaceWithWikiData(
             const wikimediaStart = Date.now()
             const wikimediaPlace = await wikimediaIntegration.capabilities.placeInfo?.getPlaceInfo(wikimediaId)
             const wikimediaTime = Date.now() - wikimediaStart
-            console.log(`⏱️ [PERF] Wikimedia fetch: ${wikimediaTime}ms`)
+            console.log(`[PERF] Wikimedia fetch: ${wikimediaTime}ms`)
 
             if (wikimediaPlace && wikimediaPlace.photos.length > 0) {
               // Update photo priorities before merging
@@ -794,7 +794,7 @@ export async function lookupEnrichedPlaceById(
   },
 ): Promise<Place | null> {
   const startTime = Date.now()
-  console.log(`⏱️ [PERF] Starting enriched place lookup: source=${source}, id=${id}`)
+  console.log(`[PERF] Starting enriched place lookup: source=${source}, id=${id}`)
 
   try {
     const { userId, language = 'en', premiumData = false } = options || {}
@@ -803,10 +803,10 @@ export async function lookupEnrichedPlaceById(
     const step1Start = Date.now()
     let place = await lookupPlaceById(source, id)
     const step1Time = Date.now() - step1Start
-    console.log(`⏱️ [PERF] Step 1 - Base place lookup: ${step1Time}ms`)
+    console.log(`[PERF] Step 1 - Base place lookup: ${step1Time}ms`)
     
     if (!place) {
-      console.log(`⏱️ [PERF] Total time (no place found): ${Date.now() - startTime}ms`)
+      console.log(`[PERF] Total time (no place found): ${Date.now() - startTime}ms`)
       return null
     }
 
@@ -827,16 +827,16 @@ export async function lookupEnrichedPlaceById(
         },
       )
       const step2Time = Date.now() - step2Start
-      console.log(`⏱️ [PERF] Step 2 - Third party place lookup: ${step2Time}ms`)
+      console.log(`[PERF] Step 2 - Third party place lookup: ${step2Time}ms`)
 
       if (thirdPartyPlace) {
         const mergeStart = Date.now()
         place = mergePlaces(place, thirdPartyPlace)
         const mergeTime = Date.now() - mergeStart
-        console.log(`⏱️ [PERF] Step 2b - Place merge: ${mergeTime}ms`)
+        console.log(`[PERF] Step 2b - Place merge: ${mergeTime}ms`)
       }
     } else if (skipThirdPartySearch) {
-      console.log(`⏱️ [PERF] Step 2 - Skipped third party search for Transitland transit stop`)
+      console.log(`[PERF] Step 2 - Skipped third party search for Transitland transit stop`)
     }
 
     // Step 3 & 4: Enrich with Wiki data and address data in parallel
@@ -853,7 +853,7 @@ export async function lookupEnrichedPlaceById(
     // fills photos/hours/ratings that base + wiki + address lack)
     place = mergePlaces(wikiEnrichedPlace, addressEnrichedPlace, foursquareEnrichedPlace)
     const enrichmentTime = Date.now() - enrichmentStart
-    console.log(`⏱️ [PERF] Step 3-4 - Parallel enrichment (Wiki + Address): ${enrichmentTime}ms`)
+    console.log(`[PERF] Step 3-4 - Parallel enrichment (Wiki + Address): ${enrichmentTime}ms`)
 
     // Step 5: Resolve timezone from coordinates
     if (place.geometry?.value?.center) {
@@ -912,17 +912,17 @@ export async function lookupEnrichedPlaceById(
         place.collectionIds = bookmarkInfo.collectionIds
       }
       const step7Time = Date.now() - step7Start
-      console.log(`⏱️ [PERF] Step 7 - Bookmark info: ${step7Time}ms`)
+      console.log(`[PERF] Step 7 - Bookmark info: ${step7Time}ms`)
     }
 
     const totalTime = Date.now() - startTime
-    console.log(`⏱️ [PERF] Total enriched place lookup time: ${totalTime}ms`)
+    console.log(`[PERF] Total enriched place lookup time: ${totalTime}ms`)
 
     return place
   } catch (error) {
     const totalTime = Date.now() - startTime
     console.error(
-      `❌ [PERF] Error looking up and merging place data (${source}/${id}) after ${totalTime}ms:`,
+      `[PERF] Error looking up and merging place data (${source}/${id}) after ${totalTime}ms:`,
       error,
     )
     return null
@@ -948,7 +948,7 @@ export async function lookupEnrichedPlaceByCoordinates(
   },
 ): Promise<Place | null> {
   const startTime = Date.now()
-  console.log(`⏱️ [PERF] Starting coordinate-based place lookup: lat=${lat}, lng=${lng}`)
+  console.log(`[PERF] Starting coordinate-based place lookup: lat=${lat}, lng=${lng}`)
 
   try {
     const { userId, radius = 50, language = 'en', addressOnly = false, premiumData = false } = options || {}
@@ -973,10 +973,10 @@ export async function lookupEnrichedPlaceByCoordinates(
     const step1Start = Date.now()
     const results = await geocodingIntegration.capabilities.geocoding.reverseGeocode(lat, lng)
     const step1Time = Date.now() - step1Start
-    console.log(`⏱️ [PERF] Step 1 - Reverse geocoding: ${step1Time}ms`)
+    console.log(`[PERF] Step 1 - Reverse geocoding: ${step1Time}ms`)
     
     if (!results?.[0]) {
-      console.log(`⏱️ [PERF] Total time (no results): ${Date.now() - startTime}ms`)
+      console.log(`[PERF] Total time (no results): ${Date.now() - startTime}ms`)
       return null
     }
     
@@ -1022,7 +1022,7 @@ export async function lookupEnrichedPlaceByCoordinates(
       }
 
       const totalTime = Date.now() - startTime
-      console.log(`⏱️ [PERF] Total coordinate lookup time (address-only): ${totalTime}ms`)
+      console.log(`[PERF] Total coordinate lookup time (address-only): ${totalTime}ms`)
       return place
     }
 
@@ -1032,12 +1032,12 @@ export async function lookupEnrichedPlaceByCoordinates(
     // First, check if we have an OSM ID - if so, use the full enrichment pipeline
     const osmId = place.externalIds?.[SOURCE.OSM]
     if (osmId) {
-      console.log(`📍 Found OSM ID: ${osmId}, using full enrichment pipeline...`)
+      console.log(`Found OSM ID: ${osmId}, using full enrichment pipeline...`)
       
       const step2Start = Date.now()
       const enrichedPlace = await lookupEnrichedPlaceById(SOURCE.OSM, osmId, { userId, language, premiumData })
       const step2Time = Date.now() - step2Start
-      console.log(`⏱️ [PERF] Step 2 - Full enrichment by OSM ID: ${step2Time}ms`)
+      console.log(`[PERF] Step 2 - Full enrichment by OSM ID: ${step2Time}ms`)
       
       if (enrichedPlace) {
         // Override the coordinates with the exact clicked coordinates
@@ -1051,7 +1051,7 @@ export async function lookupEnrichedPlaceByCoordinates(
         }
         
         const totalTime = Date.now() - startTime
-        console.log(`⏱️ [PERF] Total coordinate lookup time (with OSM enrichment): ${totalTime}ms`)
+        console.log(`[PERF] Total coordinate lookup time (with OSM enrichment): ${totalTime}ms`)
         return enrichedPlace
       }
     }
@@ -1060,7 +1060,7 @@ export async function lookupEnrichedPlaceByCoordinates(
     // Fetch it to extract the OSM ID, then use OSM for full enrichment
     const geoapifyPlaceId = place.externalIds?.[SOURCE.GEOAPIFY]
     if (!osmId && geoapifyPlaceId) {
-      console.log(`📍 Found Geoapify place ID: ${geoapifyPlaceId}, extracting OSM ID...`)
+      console.log(`Found Geoapify place ID: ${geoapifyPlaceId}, extracting OSM ID...`)
       
       const step2Start = Date.now()
       
@@ -1079,10 +1079,10 @@ export async function lookupEnrichedPlaceByCoordinates(
             const extractedOsmId = geoapifyPlace?.externalIds?.[SOURCE.OSM]
             
             if (extractedOsmId) {
-              console.log(`📍 Extracted OSM ID from Geoapify: ${extractedOsmId}, using full OSM enrichment...`)
+              console.log(`Extracted OSM ID from Geoapify: ${extractedOsmId}, using full OSM enrichment...`)
               const enrichedPlace = await lookupEnrichedPlaceById(SOURCE.OSM, extractedOsmId, { userId, language, premiumData })
               const step2Time = Date.now() - step2Start
-              console.log(`⏱️ [PERF] Step 2 - Full enrichment via Geoapify→OSM: ${step2Time}ms`)
+              console.log(`[PERF] Step 2 - Full enrichment via Geoapify→OSM: ${step2Time}ms`)
               
               if (enrichedPlace) {
                 // Override the coordinates with the exact clicked coordinates
@@ -1095,7 +1095,7 @@ export async function lookupEnrichedPlaceByCoordinates(
                 }
                 
                 const totalTime = Date.now() - startTime
-                console.log(`⏱️ [PERF] Total coordinate lookup time (with Geoapify→OSM enrichment): ${totalTime}ms`)
+                console.log(`[PERF] Total coordinate lookup time (with Geoapify→OSM enrichment): ${totalTime}ms`)
                 return enrichedPlace
               }
             }
@@ -1106,12 +1106,12 @@ export async function lookupEnrichedPlaceByCoordinates(
       }
       
       const step2Time = Date.now() - step2Start
-      console.log(`⏱️ [PERF] Step 2 - Geoapify place lookup (no OSM ID found): ${step2Time}ms`)
+      console.log(`[PERF] Step 2 - Geoapify place lookup (no OSM ID found): ${step2Time}ms`)
     }
     
     // If no OSM ID but we have a name, try name+location search
     if (place.name?.value && place.geometry.value.center) {
-      console.log(`📍 Found place with name: ${place.name.value}, searching for full details...`)
+      console.log(`Found place with name: ${place.name.value}, searching for full details...`)
       
       const step2Start = Date.now()
       const fullPlace = await lookupPlaceByNameAndLocation(
@@ -1124,7 +1124,7 @@ export async function lookupEnrichedPlaceByCoordinates(
         }
       )
       const step2Time = Date.now() - step2Start
-      console.log(`⏱️ [PERF] Step 2 - Name+location search: ${step2Time}ms`)
+      console.log(`[PERF] Step 2 - Name+location search: ${step2Time}ms`)
       
       if (fullPlace) {
         // Override the coordinates with the exact clicked coordinates
@@ -1138,13 +1138,13 @@ export async function lookupEnrichedPlaceByCoordinates(
         }
         
         const totalTime = Date.now() - startTime
-        console.log(`⏱️ [PERF] Total coordinate lookup time (with name search): ${totalTime}ms`)
+        console.log(`[PERF] Total coordinate lookup time (with name search): ${totalTime}ms`)
         return fullPlace
       }
     }
     
     // Step 3: No place found or no name - return address-only data
-    console.log(`📍 No place found, returning address-only data`)
+    console.log(`No place found, returning address-only data`)
     
     // Override geocoded coordinates with the exact clicked coordinates
     place.geometry = {
@@ -1177,13 +1177,13 @@ export async function lookupEnrichedPlaceByCoordinates(
     // Note: No enrichment for address-only results since we've stripped all IDs and data
 
     const totalTime = Date.now() - startTime
-    console.log(`⏱️ [PERF] Total coordinate lookup time (basic enrichment): ${totalTime}ms`)
+    console.log(`[PERF] Total coordinate lookup time (basic enrichment): ${totalTime}ms`)
 
     return place
   } catch (error) {
     const totalTime = Date.now() - startTime
     console.error(
-      `❌ [PERF] Error looking up place by coordinates (${lat},${lng}) after ${totalTime}ms:`,
+      `[PERF] Error looking up place by coordinates (${lat},${lng}) after ${totalTime}ms:`,
       error,
     )
     return null

--- a/server/src/services/search.service.ts
+++ b/server/src/services/search.service.ts
@@ -458,6 +458,7 @@ export async function search(
 export interface CategorySearchOptions {
   bounds: MapBounds
   limit?: number
+  offset?: number
   sort?: 'relevance' | 'distance' | 'name'
   filter?: {
     access?: string[]
@@ -548,6 +549,7 @@ export async function searchByCategory(
 
   return await searchCapability.searchByCategory(categoryId, options.bounds, {
     limit: options.limit,
+    offset: options.offset,
     filterTags: Object.keys(mergedTags).length > 0 ? mergedTags : undefined,
     sort: options.sort,
     filter: options.filter,

--- a/server/src/services/street-imagery.service.ts
+++ b/server/src/services/street-imagery.service.ts
@@ -27,7 +27,7 @@ export async function fetchNearestStreetImage(
   try {
     return await mapillary.findNearestImage(lat, lng)
   } catch (error) {
-    console.error('❌ [StreetImagery] Mapillary lookup failed:', error)
+    console.error('[StreetImagery] Mapillary lookup failed:', error)
     return null
   }
 }

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -348,7 +348,7 @@ async function fetchTransitDepartures(
 
   const config = barrelmanRecord?.config as { host?: string; apiKey?: string } | undefined
   if (!config?.host) {
-    console.debug('🚫 [Widget/Transit] Barrelman not configured')
+    console.debug('[Widget/Transit] Barrelman not configured')
     return { departures: [], sources: [] }
   }
 
@@ -364,11 +364,11 @@ async function fetchTransitDepartures(
     const headers: Record<string, string> = {}
     if (config.apiKey) headers['Authorization'] = `Bearer ${config.apiKey}`
 
-    console.debug(`🌐 [Widget/Transit] Fetching departures from Barrelman at (${params.lat}, ${params.lng})`)
+    console.debug(`[Widget/Transit] Fetching departures from Barrelman at (${params.lat}, ${params.lng})`)
     const response = await fetch(`${config.host}/transit/departures?${queryParams}`, { headers })
 
     if (!response.ok) {
-      console.error(`❌ [Widget/Transit] Barrelman returned ${response.status}`)
+      console.error(`[Widget/Transit] Barrelman returned ${response.status}`)
       return { departures: [], sources: [] }
     }
 
@@ -442,7 +442,7 @@ async function fetchTransitDepartures(
       return timeA.localeCompare(timeB)
     })
 
-    console.debug(`✅ [Widget/Transit] Got ${allDepartures.length} departures from ${stopResults.length} stop(s)`)
+    console.debug(`[Widget/Transit] Got ${allDepartures.length} departures from ${stopResults.length} stop(s)`)
 
     const sources: SourceReference[] = allDepartures.length > 0
       ? [{ id: 'barrelman', name: 'GTFS Timetable' }]
@@ -490,7 +490,7 @@ async function fetchTransitDepartures(
       sources,
     }
   } catch (error) {
-    console.error('❌ [Widget/Transit] Barrelman departure fetch failed:', error)
+    console.error('[Widget/Transit] Barrelman departure fetch failed:', error)
     return { departures: [], sources: [] }
   }
 }
@@ -511,7 +511,7 @@ async function fetchBikeshareStatus(
 
   const config = barrelmanRecord?.config as { host?: string; apiKey?: string } | undefined
   if (!config?.host) {
-    console.debug('🚫 [Widget/Bikeshare] Barrelman not configured')
+    console.debug('[Widget/Bikeshare] Barrelman not configured')
     return { status: null, sources: [] }
   }
 
@@ -525,13 +525,13 @@ async function fetchBikeshareStatus(
     const headers: Record<string, string> = {}
     if (config.apiKey) headers['Authorization'] = `Bearer ${config.apiKey}`
 
-    console.debug(`🌐 [Widget/Bikeshare] Fetching station ${params.systemId ?? ''}:${params.stationId ?? ''} from Barrelman`)
+    console.debug(`[Widget/Bikeshare] Fetching station ${params.systemId ?? ''}:${params.stationId ?? ''} from Barrelman`)
     const response = await fetch(`${config.host}/gbfs/station?${queryParams}`, { headers })
 
     if (!response.ok) {
       // 404 just means this dock isn't in any known GBFS feed — not an error.
       if (response.status !== 404) {
-        console.error(`❌ [Widget/Bikeshare] Barrelman returned ${response.status}`)
+        console.error(`[Widget/Bikeshare] Barrelman returned ${response.status}`)
       }
       return { status: null, sources: [] }
     }
@@ -561,14 +561,14 @@ async function fetchBikeshareStatus(
       lastReported: s.lastReported ?? null,
     }
 
-    console.debug(`✅ [Widget/Bikeshare] ${status.name}: ${status.bikesAvailable + status.ebikesAvailable} bikes, ${status.docksAvailable} docks`)
+    console.debug(`[Widget/Bikeshare] ${status.name}: ${status.bikesAvailable + status.ebikesAvailable} bikes, ${status.docksAvailable} docks`)
 
     return {
       status,
       sources: [{ id: 'gbfs', name: status.systemName || status.operator || 'GBFS' }],
     }
   } catch (error) {
-    console.error('❌ [Widget/Bikeshare] Barrelman station fetch failed:', error)
+    console.error('[Widget/Bikeshare] Barrelman station fetch failed:', error)
     return { status: null, sources: [] }
   }
 }
@@ -830,27 +830,27 @@ async function fetchChildrenInArea(
   const barrelman = getBarrelmanInstance()
   if (barrelman) {
     try {
-      console.debug(`🌐 [Widget/RelatedPlaces] Fetching children via Barrelman for ${osmId} (limit=${limit}, offset=${offset})`)
+      console.debug(`[Widget/RelatedPlaces] Fetching children via Barrelman for ${osmId} (limit=${limit}, offset=${offset})`)
       const children = await barrelman.getChildren(osmId, presetIds, limit + 1, offset, centerLat, centerLng)
       if (children.length || offset > 0) {
         const hasMore = children.length > limit
         const page = children.slice(0, limit).filter((p) => p.id !== excludePlaceId)
-        console.debug(`✅ [Widget/RelatedPlaces] Barrelman returned ${page.length} children (hasMore=${hasMore})`)
+        console.debug(`[Widget/RelatedPlaces] Barrelman returned ${page.length} children (hasMore=${hasMore})`)
         return { children: page, hasMore }
       }
     } catch (error) {
-      console.debug('⚠️ [Widget/RelatedPlaces] Barrelman children query failed, falling back to Overpass:', error)
+      console.debug('[Widget/RelatedPlaces] Barrelman children query failed, falling back to Overpass:', error)
     }
   }
 
   // Fallback: Overpass
   const overpass = getOverpassInstance()
   if (!overpass) {
-    console.debug('🚫 [Widget/RelatedPlaces] Overpass integration not configured')
+    console.debug('[Widget/RelatedPlaces] Overpass integration not configured')
     return { children: [], hasMore: false }
   }
 
-  console.debug(`🌐 [Widget/RelatedPlaces] Fetching children in ${osmId} for ${presetIds.length} categories via Overpass (bbox: ${bbox ? 'yes' : 'no'})`)
+  console.debug(`[Widget/RelatedPlaces] Fetching children in ${osmId} for ${presetIds.length} categories via Overpass (bbox: ${bbox ? 'yes' : 'no'})`)
   const places = await overpass.searchByCategoryInArea(osmId, presetIds, { limit: 50, bbox })
 
   const ranked = scoreAndRankChildren(places, excludePlaceId, presetIds, centerLat, centerLng)
@@ -878,7 +878,7 @@ async function fetchParentPlaces(
     const barrelman = getBarrelmanContainsInstance()
     if (barrelman) {
       try {
-        console.debug(`🌐 [Widget/Parent] Finding containers via Barrelman for (${lat},${lng})`)
+        console.debug(`[Widget/Parent] Finding containers via Barrelman for (${lat},${lng})`)
         const containers = await barrelman.getContainingAreas(lat, lng, osmId)
         if (containers.length) {
           // Filter self-references: c.id is "osm/way/123", osmId is "way/123"
@@ -888,7 +888,7 @@ async function fetchParentPlaces(
                 return cOsmId !== osmId && c.id !== osmId && c.id !== `osm/${osmId}`
               })
             : containers
-          console.debug(`✅ [Widget/Parent] Barrelman returned ${nonSelf.length} containers`)
+          console.debug(`[Widget/Parent] Barrelman returned ${nonSelf.length} containers`)
           if (nonSelf.length) {
             return nonSelf.map((c) => ({
               id: c.id,
@@ -899,7 +899,7 @@ async function fetchParentPlaces(
           }
         }
       } catch (error) {
-        console.debug('⚠️ [Widget/Parent] Barrelman contains query failed, falling back:', error)
+        console.debug('[Widget/Parent] Barrelman contains query failed, falling back:', error)
       }
     }
   }
@@ -909,7 +909,7 @@ async function fetchParentPlaces(
     const overpass = getOverpassInstance()
     if (overpass && lat && lng) {
       try {
-        console.debug(`🌐 [Widget/Parent] Finding containers for (${lat},${lng}) via Overpass is_in`)
+        console.debug(`[Widget/Parent] Finding containers for (${lat},${lng}) via Overpass is_in`)
         const containers = await overpass.findContainingAreas(lat, lng)
         if (containers.length) {
           // Filter out self-reference and building parts
@@ -918,7 +918,7 @@ async function fetchParentPlaces(
             if (c.tags?.['building:part']) return false
             return true
           })
-          console.debug(`✅ [Widget/Parent] Found ${nonSelf.length} containers via is_in (${containers.length - nonSelf.length} self-refs removed)`)
+          console.debug(`[Widget/Parent] Found ${nonSelf.length} containers via is_in (${containers.length - nonSelf.length} self-refs removed)`)
           if (nonSelf.length) {
             return nonSelf.map((c) => ({
               id: c.id,
@@ -930,7 +930,7 @@ async function fetchParentPlaces(
           }
         }
       } catch (error) {
-        console.error('❌ [Widget/Parent] is_in query failed, falling back to Nominatim:', error)
+        console.error('[Widget/Parent] is_in query failed, falling back to Nominatim:', error)
       }
     }
   }
@@ -938,7 +938,7 @@ async function fetchParentPlaces(
   // Admin strategy (or is_in fallback): use Nominatim hierarchy
   const nominatimIntegration = integrationManager.getIntegration('nominatim')
   if (!nominatimIntegration) {
-    console.debug('🚫 [Widget/RelatedPlaces] Nominatim integration not configured')
+    console.debug('[Widget/RelatedPlaces] Nominatim integration not configured')
     return []
   }
 
@@ -973,7 +973,7 @@ async function fetchParentPlaces(
 
     return parents
   } catch (error) {
-    console.error('❌ [Widget/RelatedPlaces] Error fetching parent places:', error)
+    console.error('[Widget/RelatedPlaces] Error fetching parent places:', error)
     return []
   }
 }

--- a/server/src/types/integration.types.ts
+++ b/server/src/types/integration.types.ts
@@ -183,11 +183,21 @@ export interface MapBounds {
 }
 
 export interface SearchCategoryCapability {
+  /**
+   * Search a POI category, nearest-first. Viewport-scoped, then widened (nearest
+   * matches within a wide area) when the viewport holds fewer than `minResults`,
+   * so a thin category still returns nearby results. Supports `offset` for scroll
+   * pagination.
+   */
   searchByCategory(
     presetId: string,
     bounds: MapBounds,
     options?: {
       limit?: number
+      /** Results to skip, for scroll pagination. */
+      offset?: number
+      /** Below this in-viewport count, widen to the nearest matches. Defaults to 6. */
+      minResults?: number
       /** Extra OSM tag key/value pairs to filter results beyond the primary category. */
       filterTags?: Record<string, string>
       sort?: 'relevance' | 'distance' | 'name'

--- a/web/src/components/palette/Palette.vue
+++ b/web/src/components/palette/Palette.vue
@@ -30,7 +30,6 @@ import {
   XIcon,
   LoaderIcon,
   SettingsIcon,
-  ClockIcon,
 } from 'lucide-vue-next'
 import { ItemIcon } from '@/components/ui/item-icon'
 import { Badge } from '@/components/ui/badge'
@@ -126,12 +125,22 @@ const filteredArgumentOptions = computed(() => {
     : argumentOptions.value
 })
 
-const SEARCH_GROUP_ORDER = ['frequents', 'fullSearch', 'brands', 'categories', 'places'] as const
+const SEARCH_GROUP_ORDER = [
+  'frequents',
+  'suggestedCategories',
+  'fullSearch',
+  'recents',
+  'brands',
+  'categories',
+  'places',
+] as const
 
-// Layout per group. Most groups render as a vertical list; a few (Frequents)
-// render as a horizontal row of tile cards. Extend this map to add more.
-const GROUP_LAYOUT: Record<string, 'list' | 'tiles'> = {
+// Layout per group. Most groups render as a vertical list; Frequents renders as
+// a horizontal row of tile cards, and the common-categories browse shortcuts as
+// a two-column grid of chips. Extend this map to add more.
+const GROUP_LAYOUT: Record<string, 'list' | 'tiles' | 'chips'> = {
   frequents: 'tiles',
+  suggestedCategories: 'chips',
 }
 
 const groupedArgumentOptions = computed(() => {
@@ -140,7 +149,7 @@ const groupedArgumentOptions = computed(() => {
   const groups: {
     key: string
     heading: string
-    layout: 'list' | 'tiles'
+    layout: 'list' | 'tiles' | 'chips'
     items: CommandArgumentOption[]
   }[] = []
   for (const groupKey of SEARCH_GROUP_ORDER) {
@@ -533,6 +542,30 @@ const filterFunction = computed(() => {
                 </button>
               </div>
 
+              <!-- Chip layout: two-row, horizontally scrolling browse shortcuts (Categories). -->
+              <div
+                v-else-if="group.layout === 'chips'"
+                class="grid grid-rows-2 grid-flow-col auto-cols-max gap-2 overflow-x-auto scrollbar-hidden px-1 pb-1"
+              >
+                <button
+                  v-for="argumentOption in group.items"
+                  :key="argumentOption.value"
+                  type="button"
+                  class="flex items-center gap-1.5 rounded-full border bg-card hover:bg-secondary/40 transition-colors pl-1 pr-2.5 py-1 text-left"
+                  @click="onArgumentSelected(argumentOption.value)"
+                >
+                  <ItemIcon
+                    :icon="argumentOption.iconName"
+                    :icon-pack="argumentOption.iconPack"
+                    :custom-color="argumentOption.iconColor"
+                    shape="circle"
+                    variant="solid"
+                    size="xs"
+                  />
+                  <span class="text-sm font-medium whitespace-nowrap">{{ argumentOption.name }}</span>
+                </button>
+              </div>
+
               <!-- Default list layout. -->
               <CommandItem
                 v-for="argumentOption in group.layout === 'list' ? group.items : []"
@@ -565,11 +598,6 @@ const filterFunction = computed(() => {
                     {{ argumentOption.description }}
                   </span>
                 </div>
-                <!-- Recency badge: item stays in its own group, clock marks it recent. -->
-                <ClockIcon
-                  v-if="argumentOption.isRecent"
-                  class="size-4 shrink-0 self-center text-muted-foreground opacity-60"
-                />
               </CommandItem>
             </CommandGroup>
           </template>
@@ -629,11 +657,12 @@ const filterFunction = computed(() => {
             </CommandItem>
           </CommandGroup>
 
-          <!-- Settings entries are surfaced even when the palette is in
-               search mode, so users can find a setting without first
-               backing out of the search command. -->
+          <!-- Settings entries are surfaced for argument-taking commands, but
+               NOT for place search — a place query ("park") shouldn't turn up
+               settings pages ("My Vehicles"). Settings are still reachable by
+               typing in the idle palette (the top-level list above). -->
           <CommandGroup
-            v-if="filteredSettings.length"
+            v-if="!isSearch && filteredSettings.length"
             :heading="t('settings.title')"
           >
             <CommandItem

--- a/web/src/components/place/Place.vue
+++ b/web/src/components/place/Place.vue
@@ -349,9 +349,12 @@ function handleBrandLogoError() {
                     :style="{ top: 'calc(-1 * var(--sheet-sticky-top, 3rem))' }"
                     :class="stuck ? 'opacity-100' : 'opacity-0'"
                   />
+                  <!-- overflow-y-hidden: the triggers' -mb-px underline overlap
+                       is 1px of vertical overflow; without this, overflow-x-auto
+                       promotes overflow-y to auto and shows a stray y-scrollbar. -->
                   <TabsList
                     variant="linear"
-                    class="relative px-3 pt-2 overflow-x-auto scrollbar-hidden"
+                    class="relative px-3 pt-2 overflow-x-auto overflow-y-hidden scrollbar-hidden"
                   >
                     <TabsTrigger variant="linear" value="overview">
                       {{ t('place.tabs.overview') }}

--- a/web/src/components/place/sources/PlaceSources.vue
+++ b/web/src/components/place/sources/PlaceSources.vue
@@ -6,7 +6,30 @@ const props = defineProps<{
   place: Partial<Place>
 }>()
 
-const sources = computed(() => props.place.sources ?? [])
+// Only sources that have a display name, deduped by id (falling back to name)
+// so a source contributed by multiple integrations isn't listed twice — and a
+// malformed nameless source can't leave a dangling "and" separator.
+const sources = computed(() => {
+  const seen = new Set<string>()
+  const result: { key: string; name: string; url?: string }[] = []
+  for (const source of props.place.sources ?? []) {
+    const name = source.name?.trim()
+    if (!name) continue
+    const key = source.id ?? name
+    if (seen.has(key)) continue
+    seen.add(key)
+    result.push({ key, name, url: source.url })
+  }
+  return result
+})
+
+// Separator before the source at index `i`: nothing for the first, " and "
+// before the last, ", " otherwise. Reads correctly for any number of sources.
+function separatorBefore(i: number): string {
+  if (i === 0) return ''
+  if (i === sources.value.length - 1) return ' and '
+  return ', '
+}
 </script>
 
 <template>
@@ -15,9 +38,8 @@ const sources = computed(() => props.place.sources ?? [])
     class="px-3.5 py-2.5 rounded-lg border text-xs text-muted-foreground"
   >
     Data from
-    <template v-for="(source, i) in sources" :key="source.id">
-      <template v-if="i > 0 && i < sources.length - 1">, </template>
-      <template v-if="i > 0 && i === sources.length - 1"> and </template>
+    <template v-for="(source, i) in sources" :key="source.key">
+      <template v-if="i > 0">{{ separatorBefore(i) }}</template>
       <a
         v-if="source.url"
         :href="source.url"

--- a/web/src/constants/layers/core-layers.ts
+++ b/web/src/constants/layers/core-layers.ts
@@ -38,9 +38,9 @@ export const SEARCH_RESULTS_LAYER_CONFIG: Omit<
     id: SEARCH_RESULTS_LABELS_LAYER_ID,
     type: MapboxLayerType.SYMBOL,
     source: SEARCH_RESULTS_SOURCE_ID,
-    // Labels only appear when zoomed in close enough; at city-level zoom the
-    // dot markers alone are sufficient and labels would create clutter.
-    minzoom: 14,
+    // No minzoom: labels show at every zoom. The engine's built-in collision
+    // (text-allow-overlap: false, below) hides any label that would overlap
+    // another, so clutter is prevented without a hard zoom cutoff.
     filter: ['has', 'name'],
     layout: {
       'symbol-z-elevate': true,
@@ -53,7 +53,9 @@ export const SEARCH_RESULTS_LAYER_CONFIG: Omit<
       'text-anchor': 'top',
       'text-allow-overlap': false,
       'text-ignore-placement': false,
-      'symbol-sort-key': 1000,
+      // Per-result rank (0 = nearest/best). Lower sort keys are placed first, so
+      // the top results win collisions and their labels stay visible.
+      'symbol-sort-key': ['get', 'sortKey'],
     },
     paint: {
       'text-halo-width': 1,

--- a/web/src/lib/common-categories.ts
+++ b/web/src/lib/common-categories.ts
@@ -1,0 +1,46 @@
+/**
+ * Curated "common categories" surfaced in the search palette when the input is
+ * empty — the browse shortcuts a user reaches for most (restaurants, coffee,
+ * gas, parking …), Apple-Maps style.
+ *
+ * WHY hand-curate instead of reading the category registry? The client registry
+ * (`category.store`) is capped at 1000 presets and the server sorts multi-tag
+ * presets first, so the single-tag everyday categories — Restaurant, Supermarket,
+ * Parking, Park — actually fall *past* the cap and aren't reliably present.
+ * Curating also lets us pick clean labels and icons and control the ordering.
+ *
+ * Ordering here is the "most useful first" ranking. The value is a `category:<id>`
+ * so the palette's existing category action navigates without any registry
+ * lookup; enrichment (if the registry does have the preset) is layered on top.
+ *
+ * Extension point: to personalize this (e.g. reorder by the user's own usage),
+ * sort this list against a usage signal before rendering.
+ */
+
+import type { PlaceCategory } from '@/types/place.types'
+
+export interface CommonCategory {
+  /** OSM preset id, e.g. 'amenity/restaurant'. Drives navigation as `category:<id>`. */
+  id: string
+  /** i18n key for the display label. */
+  labelKey: string
+  /** Lucide icon glyph name. */
+  icon: string
+  /** Category class — drives the icon colour via getCategoryColor, matching the rest of the app. */
+  category: PlaceCategory
+}
+
+export const COMMON_CATEGORIES: CommonCategory[] = [
+  { id: 'amenity/restaurant', labelKey: 'palette.commands.search.commonCategories.restaurants', icon: 'Utensils', category: 'food_and_drink' },
+  { id: 'amenity/cafe', labelKey: 'palette.commands.search.commonCategories.coffee', icon: 'Coffee', category: 'food_and_drink' },
+  { id: 'amenity/fast_food', labelKey: 'palette.commands.search.commonCategories.fastFood', icon: 'Sandwich', category: 'food_and_drink' },
+  { id: 'shop/supermarket', labelKey: 'palette.commands.search.commonCategories.groceries', icon: 'ShoppingCart', category: 'store' },
+  { id: 'amenity/fuel', labelKey: 'palette.commands.search.commonCategories.gas', icon: 'Fuel', category: 'commercial_services' },
+  { id: 'amenity/parking', labelKey: 'palette.commands.search.commonCategories.parking', icon: 'SquareParking', category: 'commercial_services' },
+  { id: 'amenity/pharmacy', labelKey: 'palette.commands.search.commonCategories.pharmacy', icon: 'Pill', category: 'medical' },
+  { id: 'tourism/hotel', labelKey: 'palette.commands.search.commonCategories.hotels', icon: 'Hotel', category: 'commercial_services' },
+  { id: 'amenity/bar', labelKey: 'palette.commands.search.commonCategories.bars', icon: 'Beer', category: 'food_and_drink' },
+  { id: 'leisure/park', labelKey: 'palette.commands.search.commonCategories.parks', icon: 'Trees', category: 'park' },
+  { id: 'amenity/hospital', labelKey: 'palette.commands.search.commonCategories.hospitals', icon: 'Cross', category: 'medical' },
+  { id: 'amenity/atm', labelKey: 'palette.commands.search.commonCategories.atms', icon: 'Landmark', category: 'commercial_services' },
+]

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -175,10 +175,26 @@
         },
         "groups": {
           "frequents": "Frequents",
+          "suggestedCategories": "Categories",
           "fullSearch": "Search",
+          "recents": "Recents",
           "brands": "Brands",
           "categories": "Categories",
           "places": "Places"
+        },
+        "commonCategories": {
+          "restaurants": "Restaurants",
+          "coffee": "Coffee",
+          "fastFood": "Fast Food",
+          "groceries": "Groceries",
+          "gas": "Gas",
+          "parking": "Parking",
+          "pharmacy": "Pharmacy",
+          "hotels": "Hotels",
+          "bars": "Bars",
+          "parks": "Parks",
+          "hospitals": "Hospitals",
+          "atms": "ATMs"
         },
         "brand": {
           "seeAll": "See all locations",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -173,10 +173,26 @@
         },
         "groups": {
           "frequents": "Frecuentes",
+          "suggestedCategories": "Categorías",
           "fullSearch": "Buscar",
+          "recents": "Recientes",
           "brands": "Marcas",
           "categories": "Categorías",
           "places": "Lugares"
+        },
+        "commonCategories": {
+          "restaurants": "Restaurantes",
+          "coffee": "Café",
+          "fastFood": "Comida rápida",
+          "groceries": "Supermercados",
+          "gas": "Gasolina",
+          "parking": "Aparcamiento",
+          "pharmacy": "Farmacia",
+          "hotels": "Hoteles",
+          "bars": "Bares",
+          "parks": "Parques",
+          "hospitals": "Hospitales",
+          "atms": "Cajeros"
         },
         "brand": {
           "seeAll": "Ver todas las ubicaciones",

--- a/web/src/services/layers/features/search-results-layer.service.ts
+++ b/web/src/services/layers/features/search-results-layer.service.ts
@@ -258,7 +258,7 @@ export function useSearchResultsLayerService() {
   function createResultsGeoJSON(places: Place[]) {
     const features = places
       .filter(place => place.geometry?.value?.center)
-      .map(place => {
+      .map((place, index) => {
         const { lat, lng } = place.geometry.value.center
         const hasName =
           place.name.value && place.name.value !== place.placeType.value
@@ -276,6 +276,10 @@ export function useSearchResultsLayerService() {
             placeType: place.placeType.value,
             category: place.icon?.category ?? 'default',
             hasLabel: hasName,
+            // Collision priority for the label layer's symbol-sort-key: results
+            // are distance/relevance-ordered, so index 0 (nearest/best) is placed
+            // first and wins overlaps.
+            sortKey: index,
             sizerank: 10,
             class: 'place_like',
           },

--- a/web/src/services/search.service.ts
+++ b/web/src/services/search.service.ts
@@ -24,6 +24,7 @@ interface AdvancedSearchResponse {
 interface CategorySearchOptions {
   bounds?: MapBounds
   maxResults?: number
+  offset?: number
   sort?: string
   filter?: Record<string, any>
   tags?: Record<string, string>
@@ -42,7 +43,7 @@ interface CategorySearchResponse {
   presetId: string
   results: Place[]
   fieldDefinitions?: CategoryFieldDefinition[]
-  totalCount: number
+  hasMore: boolean
   executedAt: string
 }
 
@@ -163,7 +164,7 @@ function searchService() {
   async function searchByCategory(
     presetId: string,
     options: CategorySearchOptions = {},
-  ): Promise<{ results: Place[]; fieldDefinitions: CategoryFieldDefinition[] }> {
+  ): Promise<{ results: Place[]; fieldDefinitions: CategoryFieldDefinition[]; hasMore: boolean }> {
     loading.value = true
     error.value = null
 
@@ -173,7 +174,8 @@ function searchService() {
         {
           presetId,
           bounds: options.bounds,
-          maxResults: options.maxResults || 100,
+          maxResults: options.maxResults || 30,
+          ...(options.offset ? { offset: options.offset } : {}),
           ...(options.sort ? { sort: options.sort } : {}),
           ...(options.filter ? { filter: options.filter } : {}),
           ...(options.tags ? { tags: options.tags } : {}),
@@ -183,6 +185,7 @@ function searchService() {
       return {
         results: response.data.results,
         fieldDefinitions: response.data.fieldDefinitions || [],
+        hasMore: response.data.hasMore ?? false,
       }
     } catch (err) {
       console.error('Error in category search:', err)

--- a/web/src/stores/command.store.ts
+++ b/web/src/stores/command.store.ts
@@ -33,9 +33,11 @@ import { getCategoryColor } from '@/lib/place-colors'
 import type { PlaceCategory } from '@/types/place.types'
 import { useCategoryStore } from '@/stores/category.store'
 import { useRecentsStore } from '@/stores/recents.store'
+import type { RecentSearchEntry, RecentPlaceEntry } from '@/lib/recents'
 import { useBookmarksStore } from '@/stores/library/bookmarks.store'
 import { getBookmarkPlaceId } from '@/lib/place.utils'
 import { frequentChipMeta } from '@/lib/frequents'
+import { COMMON_CATEGORIES } from '@/lib/common-categories'
 import { appEventBus } from '@/lib/eventBus'
 
 import { AppRoute } from '@/router'
@@ -184,15 +186,103 @@ export const useCommandStore = defineStore('command', () => {
               const { currentSearchQuery } = useCommandService()
               const searchText = currentSearchQuery.value
 
-              // Recent searches (client-side, end-to-end encrypted). Recency is
-              // shown inline in each entity's own group, not a separate section:
-              //  - text queries live in the Search group with a History icon
-              //  - category recents badge the matching live category with a clock
+              // Recent searches + places (client-side, end-to-end encrypted).
+              // They surface in a dedicated "Recents" section, deduped from the
+              // live result groups so the same entity never appears twice.
               // Hydration is a no-op after the first load.
               const recentsStore = useRecentsStore()
               const q = searchText.trim().toLowerCase()
 
-              // ── Empty query → surface recents + shortcuts, no server round-trip. ──
+              // A recent, ready to render, plus the metadata used to order and
+              // dedupe it: `at` (recency) and `identity` (stable entity key).
+              type RecentEntry = {
+                option: CommandArgumentOption
+                at: number
+                identity: string
+              }
+
+              const recentSearchToEntry = (e: RecentSearchEntry): RecentEntry => {
+                if (e.kind === 'category' && e.categoryId) {
+                  return {
+                    at: e.at,
+                    identity: `category:${e.categoryId}`,
+                    option: {
+                      value: `category:${e.categoryId}`,
+                      name: e.query,
+                      iconName: e.iconName || 'MapPin',
+                      iconPack: (e.iconPack || 'lucide') as 'lucide' | 'maki',
+                      iconColor: getCategoryColor(
+                        (e.iconCategory || 'default') as PlaceCategory,
+                        isDark.value,
+                      ),
+                      group: 'recents',
+                    },
+                  }
+                }
+                if (e.kind === 'brand' && e.brandKey) {
+                  return {
+                    at: e.at,
+                    identity: `brand:${e.brandKey}`,
+                    option: {
+                      value: `brand:${encodeURIComponent(
+                        JSON.stringify({ key: e.brandKey, name: e.brandName || e.query }),
+                      )}`,
+                      name: e.query,
+                      iconName: e.iconName || 'Store',
+                      iconPack: (e.iconPack || 'lucide') as 'lucide' | 'maki',
+                      iconColor: getCategoryColor('default', isDark.value),
+                      imageUrl: e.brandLogoUrl,
+                      group: 'recents',
+                    },
+                  }
+                }
+                return {
+                  at: e.at,
+                  identity: `text:${e.query.trim().toLowerCase()}`,
+                  option: {
+                    value: `recent-search:${e.query}`,
+                    name: e.query,
+                    iconName: 'History',
+                    iconColor: getCategoryColor('default', isDark.value),
+                    group: 'recents',
+                  },
+                }
+              }
+
+              const recentPlaceToEntry = (e: RecentPlaceEntry): RecentEntry => ({
+                at: e.at,
+                identity: `place:${e.id}`,
+                option: {
+                  value: e.id,
+                  name: e.title,
+                  description: e.subtitle,
+                  iconName: e.icon || 'MapPin',
+                  iconPack: (e.iconPack || 'lucide') as 'lucide' | 'maki',
+                  iconColor: getCategoryColor(
+                    (e.category || 'default') as PlaceCategory,
+                    isDark.value,
+                  ),
+                  group: 'recents',
+                },
+              })
+
+              // Merge every recent kind, keep the ones matching `predicate`,
+              // order newest-first, and cap the section.
+              const buildRecents = (
+                predicate: (label: string) => boolean,
+              ): RecentEntry[] =>
+                [
+                  ...recentsStore.searches
+                    .filter(e => predicate(e.query))
+                    .map(recentSearchToEntry),
+                  ...recentsStore.places
+                    .filter(e => predicate(e.title) || predicate(e.subtitle || ''))
+                    .map(recentPlaceToEntry),
+                ]
+                  .sort((a, b) => b.at - a.at)
+                  .slice(0, 8)
+
+              // ── Empty query → frequents, common categories, recents. ──
               if (!q) {
                 await Promise.all([
                   recentsStore.ensureSearchesHydrated(),
@@ -218,113 +308,42 @@ export const useCommandStore = defineStore('command', () => {
                   })
                   .filter(item => item.value)
 
-                // Recent text searches → Search group, History icon. Category
-                // and brand recents live in their own groups, so exclude them.
-                const emptyTextItems = recentsStore.searches
-                  .filter(e => e.kind !== 'category' && e.kind !== 'brand')
-                  .slice(0, 5)
-                  .map(e => ({
-                    value: `recent-search:${e.query}`,
-                    name: e.query,
-                    iconName: 'History',
-                    iconColor: getCategoryColor('default', isDark.value),
-                    group: 'fullSearch',
-                  }))
+                const recentEntries = buildRecents(() => true)
 
-                // Recent categories → Categories group, own icon + clock badge.
-                const emptyCategoryItems = recentsStore.searches
-                  .filter(e => e.kind === 'category' && e.categoryId)
-                  .slice(0, 5)
-                  .map(e => ({
-                    value: `category:${e.categoryId}`,
-                    name: e.query,
-                    iconName: e.iconName || 'MapPin',
-                    iconPack: (e.iconPack || 'lucide') as 'lucide' | 'maki',
-                    iconColor: getCategoryColor(
-                      (e.iconCategory || 'default') as PlaceCategory,
-                      isDark.value,
-                    ),
-                    group: 'categories',
-                    isRecent: true,
-                  }))
-
-                // Recent brands → Brands group, own icon + clock badge.
-                const emptyBrandItems = recentsStore.searches
-                  .filter(e => e.kind === 'brand' && e.brandKey)
-                  .slice(0, 5)
-                  .map(e => ({
-                    value: `brand:${encodeURIComponent(
-                      JSON.stringify({ key: e.brandKey, name: e.brandName || e.query }),
-                    )}`,
-                    name: e.query,
-                    iconName: e.iconName || 'Store',
-                    iconPack: (e.iconPack || 'lucide') as 'lucide' | 'maki',
-                    iconColor: getCategoryColor('default', isDark.value),
-                    imageUrl: e.brandLogoUrl,
-                    group: 'brands',
-                    isRecent: true,
-                  }))
-
-                // Recently viewed places → Places group, own icon + clock badge.
-                const emptyPlaceItems = recentsStore.places
-                  .slice(0, 5)
-                  .map(e => ({
-                    value: e.id,
-                    name: e.title,
-                    description: e.subtitle,
-                    iconName: e.icon || 'MapPin',
-                    iconPack: (e.iconPack || 'lucide') as 'lucide' | 'maki',
-                    iconColor: getCategoryColor(
-                      (e.category || 'default') as PlaceCategory,
-                      isDark.value,
-                    ),
-                    group: 'places',
-                    isRecent: true,
-                  }))
+                // Common categories: a fixed, curated set of browse shortcuts.
+                // Always shown in full — it's a stable menu, so using one doesn't
+                // make it disappear (it may also appear under Recents, which is
+                // fine: the menu and your history mean different things).
+                const suggestedCategoryItems = COMMON_CATEGORIES.map(c => ({
+                  value: `category:${c.id}`,
+                  name: t(c.labelKey),
+                  iconName: c.icon,
+                  iconPack: 'lucide' as const,
+                  iconColor: getCategoryColor(c.category, isDark.value),
+                  group: 'suggestedCategories',
+                }))
 
                 return [
                   ...frequentItems,
-                  ...emptyTextItems,
-                  ...emptyCategoryItems,
-                  ...emptyBrandItems,
-                  ...emptyPlaceItems,
+                  ...suggestedCategoryItems,
+                  ...recentEntries.map(r => r.option),
                 ]
               }
 
-              // ── Typed query → server autocomplete + recents annotations. ──
-              await recentsStore.ensureSearchesHydrated()
-              const matchesQuery = (label: string) => {
+              // ── Typed query → server autocomplete + matching recents. ──
+              await Promise.all([
+                recentsStore.ensureSearchesHydrated(),
+                recentsStore.ensurePlacesHydrated(),
+              ])
+
+              // Matching recents → their own section; also used to dedupe the
+              // same entity out of the live brands/categories/places groups.
+              const recentEntries = buildRecents(label => {
                 const l = label.toLowerCase()
                 return l.includes(q) && l !== q
-              }
-
-              // Text-query recents → shown in the Search (fullSearch) group.
-              // Category and brand recents live in their own groups (and badge
-              // the live result), so they're excluded here.
-              const recentTextItems = recentsStore.searches
-                .filter(e => e.kind !== 'category' && e.kind !== 'brand' && matchesQuery(e.query))
-                .slice(0, 5)
-                .map(e => ({
-                  value: `recent-search:${e.query}`,
-                  name: e.query,
-                  iconName: 'History',
-                  iconColor: getCategoryColor('default', isDark.value),
-                  group: 'fullSearch',
-                }))
-
-              // Category recents → used to badge live category results.
-              const recentCategoryIds = new Set(
-                recentsStore.searches
-                  .filter(e => e.kind === 'category' && e.categoryId)
-                  .map(e => e.categoryId as string),
-              )
-
-              // Brand recents → used to badge live brand results with a clock.
-              const recentBrandKeys = new Set(
-                recentsStore.searches
-                  .filter(e => e.kind === 'brand' && e.brandKey)
-                  .map(e => e.brandKey as string),
-              )
+              })
+              const recentIdentities = new Set(recentEntries.map(r => r.identity))
+              const recentItems = recentEntries.map(r => r.option)
 
               const fullSearchItem = searchText.trim()
                 ? [
@@ -364,54 +383,62 @@ export const useCommandStore = defineStore('command', () => {
                     lat,
                     lng,
                   }, signal)
-                const results = searchResults.map(result => {
-                  // Brand suggestion ("See all McDonald's locations"): encode the
-                  // key + name so the action can browse it; own group + icon.
-                  if (result.type === 'brand' && result.brand) {
-                    const payload = encodeURIComponent(
-                      JSON.stringify({ key: result.brand.brandKey, name: result.brand.name }),
-                    )
-                    return {
-                      value: `brand:${payload}`,
-                      name: result.title,
-                      description: result.brand.locationCount != null
-                        ? t('palette.commands.search.brand.locationsCount', { count: result.brand.locationCount })
-                        : t('palette.commands.search.brand.seeAll'),
-                      iconName: result.icon || 'Store',
-                      iconPack: (result.iconPack || 'lucide') as 'lucide' | 'maki',
-                      iconColor: getCategoryColor('default', isDark.value),
-                      imageUrl: result.brand.logoUrl,
-                      group: 'brands',
-                      // Badge a brand the user has browsed before with a clock.
-                      isRecent: recentBrandKeys.has(result.brand.brandKey),
+                const results = searchResults
+                  .map(result => {
+                    // Brand suggestion ("See all McDonald's locations"): encode the
+                    // key + name so the action can browse it; own group + icon.
+                    if (result.type === 'brand' && result.brand) {
+                      const payload = encodeURIComponent(
+                        JSON.stringify({ key: result.brand.brandKey, name: result.brand.name }),
+                      )
+                      return {
+                        identity: `brand:${result.brand.brandKey}`,
+                        option: {
+                          value: `brand:${payload}`,
+                          name: result.title,
+                          description: result.brand.locationCount != null
+                            ? t('palette.commands.search.brand.locationsCount', { count: result.brand.locationCount })
+                            : t('palette.commands.search.brand.seeAll'),
+                          iconName: result.icon || 'Store',
+                          iconPack: (result.iconPack || 'lucide') as 'lucide' | 'maki',
+                          iconColor: getCategoryColor('default', isDark.value),
+                          imageUrl: result.brand.logoUrl,
+                          group: 'brands',
+                        },
+                      }
                     }
-                  }
 
-                  const itemValue = result.type === 'category'
-                    ? `category:${result.id}`
-                    : result.id
-                  const iconCategory = (result.iconCategory || 'default') as PlaceCategory
-                  return {
-                    value: itemValue,
-                    name: result.title,
-                    description: result.description && !/^\S+=\S+$/.test(result.description)
-                      ? result.description
-                      : undefined,
-                    iconName: result.icon || 'MapPin',
-                    iconPack: result.iconPack || 'lucide',
-                    iconColor: getCategoryColor(iconCategory, isDark.value),
-                    group: result.type === 'category' ? 'categories' : 'places',
-                    // Badge a category the user has searched before with a clock.
-                    isRecent:
-                      result.type === 'category' && recentCategoryIds.has(result.id),
-                  }
-                })
+                    const itemValue = result.type === 'category'
+                      ? `category:${result.id}`
+                      : result.id
+                    const iconCategory = (result.iconCategory || 'default') as PlaceCategory
+                    return {
+                      identity:
+                        result.type === 'category'
+                          ? `category:${result.id}`
+                          : `place:${result.id}`,
+                      option: {
+                        value: itemValue,
+                        name: result.title,
+                        description: result.description && !/^\S+=\S+$/.test(result.description)
+                          ? result.description
+                          : undefined,
+                        iconName: result.icon || 'MapPin',
+                        iconPack: result.iconPack || 'lucide',
+                        iconColor: getCategoryColor(iconCategory, isDark.value),
+                        group: result.type === 'category' ? 'categories' : 'places',
+                      },
+                    }
+                  })
+                  // Drop live results already surfaced in the Recents section.
+                  .filter(r => !recentIdentities.has(r.identity))
+                  .map(r => r.option)
 
-                return [...fullSearchItem, ...recentTextItems, ...results]
+                return [...fullSearchItem, ...recentItems, ...results]
               } catch (error) {
                 console.error('Error loading search suggestions:', error)
                 // Still surface recents even when the server search fails.
-                return [...fullSearchItem, ...recentTextItems]
+                return [...fullSearchItem, ...recentItems]
               }
             },
           },

--- a/web/src/stores/search.store.ts
+++ b/web/src/stores/search.store.ts
@@ -156,6 +156,14 @@ export const useSearchStore = defineStore('search', () => {
     searchError.value = null
   }
 
+  /** Append a page of results (scroll pagination), de-duplicated by id. */
+  function appendSearchResults(places: Place[]) {
+    const seen = new Set(searchResults.value.map(p => p.id))
+    const fresh = places.filter(p => !seen.has(p.id))
+    if (fresh.length) searchResults.value = [...searchResults.value, ...fresh]
+    lastResultCount.value = searchResults.value.length
+  }
+
   function setCategoryFields(fields: FieldDefinition[]) {
     categoryFields.value = fields
   }
@@ -274,6 +282,7 @@ export const useSearchStore = defineStore('search', () => {
 
     // Actions
     setSearchResults,
+    appendSearchResults,
     setCategoryFields,
     clearSearchResults,
     setSearchLoading,

--- a/web/src/types/command.types.ts
+++ b/web/src/types/command.types.ts
@@ -46,11 +46,4 @@ export type CommandArgumentOption = PaletteItem & {
   color?: ThemeColor
   /** When true, the option is shown but gated behind a premium subscription. */
   premium?: boolean
-  /**
-   * When true, the item is one the user visited/searched before. Rendered with
-   * a trailing clock badge so recency is shown inline in the item's own group
-   * instead of a separate "recents" section. The pattern for all recent-able
-   * entities (categories, places, …).
-   */
-  isRecent?: boolean
 }

--- a/web/src/views/search/Search.vue
+++ b/web/src/views/search/Search.vue
@@ -45,6 +45,16 @@ const NEARBY_RADIUS_KM = 5
 const BRAND_MAX_RESULTS = 100 // how many locations to load + plot as markers
 const BRAND_FIT_COUNT = 12 // how many of the nearest to frame the camera around
 
+// Category results load one page at a time and paginate as the user scrolls.
+const CATEGORY_PAGE_SIZE = 30
+// When a fresh category search comes back with fewer than CATEGORY_MIN_RESULTS
+// inside the viewport, the server has widened a thin category to the nearest
+// matches beyond it — frame the camera to the nearest CATEGORY_FIT_COUNT so the
+// user actually sees them (they'd otherwise be off-screen). Keep in sync with
+// the server widen threshold (barrelman-integration.searchByCategory).
+const CATEGORY_MIN_RESULTS = 6
+const CATEGORY_FIT_COUNT = 12
+
 let lastRefreshBounds: MapBounds | null = null
 // While a programmatic camera move is in flight (e.g. the brand browse framing
 // its results), moveend events must NOT trigger an auto-refresh — otherwise the
@@ -148,6 +158,12 @@ const brandHeader = ref<BrandHeader | null>(null)
 const brandTitle = computed(
   () => brandHeader.value?.name || (route.query.brandName as string) || '',
 )
+
+// Scroll pagination (category searches). `hasMoreResults` tracks whether the
+// last page came back full (so another page may exist); `isLoadingMore` guards
+// against firing overlapping page loads while one is in flight.
+const hasMoreResults = ref(false)
+const isLoadingMore = ref(false)
 
 const categoryStore = useCategoryStore()
 const themeStore = useThemeStore()
@@ -263,6 +279,23 @@ function handleSearchResultClick(place: Place, event: any) {
   }
 }
 
+// Frame the camera around the nearest `count` results (results come back
+// distance-sorted from the viewport centre). Suppresses moveend auto-refresh
+// while the programmatic move animates so it can't feed back into another search.
+function frameNearestResults(places: Place[], count: number) {
+  let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity
+  for (const p of places.slice(0, count)) {
+    const c = p.geometry?.value?.center
+    if (!c) continue
+    minLat = Math.min(minLat, c.lat); maxLat = Math.max(maxLat, c.lat)
+    minLng = Math.min(minLng, c.lng); maxLng = Math.max(maxLng, c.lng)
+  }
+  if (Number.isFinite(minLat)) {
+    programmaticMoveUntil = Date.now() + 2000
+    mapService.fitBounds({ minLat, minLng, maxLat, maxLng }, { maxZoom: 15 })
+  }
+}
+
 async function performSearch(opts: { refit?: boolean } = {}) {
   // `refit` frames the camera to a brand's nearest locations. Only true for a
   // fresh brand search — a map-move re-search must NOT re-fit, or the user could
@@ -315,17 +348,19 @@ async function performSearch(opts: { refit?: boolean } = {}) {
         })
       }
 
-      const { results, fieldDefinitions } = await searchService.searchByCategory(
+      const { results, fieldDefinitions, hasMore } = await searchService.searchByCategory(
         route.query.categoryId as string,
         {
           bounds: bounds || undefined,
-          maxResults,
+          maxResults: CATEGORY_PAGE_SIZE,
+          offset: 0,
           sort,
           filter,
           tags,
         },
       )
       places = results
+      hasMoreResults.value = hasMore
       searchStore.setCategoryFields(fieldDefinitions)
     } else if (searchType.value === 'brand') {
       // Record the brand search into (encrypted) recents so it re-runs the
@@ -378,23 +413,29 @@ async function performSearch(opts: { refit?: boolean } = {}) {
     searchStore.setLastSearchBounds(bounds)
     lastRefreshBounds = bounds
 
-    // Brand browse: frame the camera around only the NEAREST few locations
-    // (results are distance-sorted) so a big chain stays usefully local — while
-    // still plotting every loaded location as a marker. Only on a fresh search;
-    // a map-move re-search must not re-fit (else the user can't zoom out).
-    if (searchType.value === 'brand' && refit && places.length > 0) {
-      let minLat = Infinity, minLng = Infinity, maxLat = -Infinity, maxLng = -Infinity
-      for (const p of places.slice(0, BRAND_FIT_COUNT)) {
-        const c = p.geometry?.value?.center
-        if (!c) continue
-        minLat = Math.min(minLat, c.lat); maxLat = Math.max(maxLat, c.lat)
-        minLng = Math.min(minLng, c.lng); maxLng = Math.max(maxLng, c.lng)
-      }
-      if (Number.isFinite(minLat)) {
-        // Suppress moveend auto-refresh while this fit (and any settle re-fit)
-        // animates, so it can't feed back into another search.
-        programmaticMoveUntil = Date.now() + 2000
-        mapService.fitBounds({ minLat, minLng, maxLat, maxLng }, { maxZoom: 15 })
+    // Frame the camera around the nearest results on a fresh search when it helps
+    // (every loaded place is still plotted as a marker regardless). A map-move
+    // re-search must not re-fit, or the user could never zoom back out.
+    //  - brand: always — a big chain stays usefully local (nearest dozen).
+    //  - category: only when the viewport was sparse, i.e. the server widened a
+    //    thin category (e.g. gas stations) to nearby matches that are off-screen.
+    if (refit && places.length > 0) {
+      if (searchType.value === 'brand') {
+        frameNearestResults(places, BRAND_FIT_COUNT)
+      } else if (searchType.value === 'category' && bounds) {
+        const inView = places.filter(p => {
+          const c = p.geometry?.value?.center
+          return (
+            !!c &&
+            c.lat <= bounds.north &&
+            c.lat >= bounds.south &&
+            c.lng <= bounds.east &&
+            c.lng >= bounds.west
+          )
+        }).length
+        if (inView < CATEGORY_MIN_RESULTS) {
+          frameNearestResults(places, CATEGORY_FIT_COUNT)
+        }
       }
     }
 
@@ -414,6 +455,44 @@ async function performSearch(opts: { refit?: boolean } = {}) {
     searchStore.setSearchResults([])
   } finally {
     searchStore.setSearchLoading(false)
+  }
+}
+
+// Load the next page of category results and append them. Paginates against the
+// bounds the search was run with (not the live viewport), so the nearest-first
+// ordering stays consistent as the user scrolls.
+async function loadMoreResults() {
+  if (searchType.value !== 'category') return
+  if (!hasMoreResults.value || isLoadingMore.value || searchStore.isLoading) return
+
+  isLoadingMore.value = true
+  try {
+    const { sort, filter, tags } = searchStore.serverFilterParams
+    const { results, hasMore } = await searchService.searchByCategory(
+      route.query.categoryId as string,
+      {
+        bounds: searchStore.lastSearchBounds || undefined,
+        maxResults: CATEGORY_PAGE_SIZE,
+        offset: searchStore.searchResults.length,
+        sort,
+        filter,
+        tags,
+      },
+    )
+    searchStore.appendSearchResults(results)
+    hasMoreResults.value = hasMore
+  } catch (error) {
+    console.error('Load more error:', error)
+  } finally {
+    isLoadingMore.value = false
+  }
+}
+
+// Infinite scroll: pull the next page when the list nears the bottom.
+function onResultsScroll(e: Event) {
+  const el = e.target as HTMLElement
+  if (el.scrollHeight - el.scrollTop - el.clientHeight < 400) {
+    loadMoreResults()
   }
 }
 
@@ -538,12 +617,10 @@ watch(
           <span v-else>Search Results</span>
         </h2>
         <div class="flex items-center gap-2 text-sm text-muted-foreground">
+          <!-- Brands have a real, cheap total; category/text results paginate on
+               scroll with no count (a true COUNT is expensive and not shown). -->
           <span v-if="searchType === 'brand' && brandHeader?.locationCount != null">
             {{ t('place.brand.locationsCount', { count: brandHeader.locationCount.toLocaleString() }) }}
-          </span>
-          <span v-else>
-            {{ searchStore.filteredSearchResults.length.toLocaleString() }}
-            {{ searchStore.filteredSearchResults.length === 1 ? 'result' : 'results' }}
           </span>
           <!-- Premium: auto-refresh spinner -->
           <div
@@ -591,6 +668,7 @@ watch(
     <div
       v-if="searchStore.hasResults || searchStore.isLoading"
       class="flex-1 overflow-auto"
+      @scroll.passive="onResultsScroll"
     >
       <div class="max-w-4xl mx-auto">
         <PlaceList
@@ -599,6 +677,10 @@ watch(
           @place-hover="searchStore.setHoveredPlace($event)"
           @place-leave="searchStore.setHoveredPlace(null)"
         />
+        <!-- Scroll-pagination spinner -->
+        <div v-if="isLoadingMore" class="flex justify-center py-4">
+          <div class="w-4 h-4 border-2 border-muted-foreground/30 border-t-muted-foreground rounded-full animate-spin" />
+        </div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
## Search palette
- Dedicated **Recents** section (unified text/category/brand/place, deduped from live results) and a curated **Categories** browse row (two-row horizontal chips). The Categories menu is stable — using a chip no longer makes it disappear.
- Settings pages no longer leak into the place-search command.

## Category search: reliably fast at any zoom
- **Barrelman browse now orders by the GiST KNN operator** (`centroid <-> point`) instead of `ST_Distance(::geography)` over every row — dense categories went from ~18s to ~0.3s. (Companion PR in the barrelman repo.)
- **Two-tier search**: viewport-scoped first; when the viewport is sparse it **widens** with no radius, driven by the category GIN index (unlocked via an explicit `categories <> '{}'` predicate) bounded to a wide bbox. Searching "gas stations" zoomed into lower Manhattan now returns the nearest stations (~2km) in ~0.2s instead of nothing. Dense categories in an empty area stay bounded (parking, 134k rows → ~1.7s).
- **Scroll pagination + no result count**: results load a page at a time on scroll (`offset`/`hasMore`); the misleading hard "N results" count is gone (a true COUNT over a broad category is itself expensive).
- Camera reframes to the nearest results when a category widened, so off-screen matches are actually visible.

## Search result labels
- Removed the `minzoom: 14` cutoff so labels show at every zoom; the engine's built-in collision (`text-allow-overlap: false`) hides overlaps, and `symbol-sort-key` now ranks by result order so the nearest labels win.

## Cleanup (pre-existing working-tree changes, included per request)
- Strip emojis from log statements.
- Request logging: quiet stdout to server errors, export failures/slow requests to OTLP with debug context.
- Place panel: hide a stray tab scrollbar; dedupe the source list.