### PR TITLE
Wire prod billing: embed license public key + compose env passthrough

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ dist
 .env.test
 # E2E env with secrets – do not commit
 web/e2e/env.test
+# Infisical CLI project link (local dev convenience; keeps repo provider-agnostic)
+.infisical.json
 
 # Playwright
 playwright-report/

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -62,11 +62,17 @@ services:
       # Generate each with: openssl rand -base64 32
       SERVER_IDENTITY_PRIVATE_KEY: ${SERVER_IDENTITY_PRIVATE_KEY}
       PARCHMENT_INTEGRATION_ENCRYPTION_KEY: ${PARCHMENT_INTEGRATION_ENCRYPTION_KEY}
+      # Registration mode: 'invite' (admin creates users) or 'open' (self-register)
+      REGISTRATION_MODE: ${REGISTRATION_MODE:-invite}
+      # Self-hosted mode: grant all users full permissions without a subscription.
+      # Only effective when billing is not configured.
+      PARCHMENT_SELF_HOSTED: ${PARCHMENT_SELF_HOSTED:-false}
       # Billing (optional — omit to run in self-hosted mode)
       PARCHMENT_LICENSE: ${PARCHMENT_LICENSE:-}
       POLAR_ACCESS_TOKEN: ${POLAR_ACCESS_TOKEN:-}
       POLAR_WEBHOOK_SECRET: ${POLAR_WEBHOOK_SECRET:-}
       POLAR_ORGANIZATION_ID: ${POLAR_ORGANIZATION_ID:-}
+      POLAR_BASIC_PRODUCT_ID: ${POLAR_BASIC_PRODUCT_ID:-}
       POLAR_PREMIUM_PRODUCT_ID: ${POLAR_PREMIUM_PRODUCT_ID:-}
       POLAR_SANDBOX: ${POLAR_SANDBOX:-false}
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -41,6 +41,20 @@ services:
       # In production the server refuses to boot without these.
       SERVER_IDENTITY_PRIVATE_KEY: ${SERVER_IDENTITY_PRIVATE_KEY}
       PARCHMENT_INTEGRATION_ENCRYPTION_KEY: ${PARCHMENT_INTEGRATION_ENCRYPTION_KEY}
+      # Registration mode: 'invite' (admin creates users) or 'open' (self-register)
+      REGISTRATION_MODE: ${REGISTRATION_MODE:-invite}
+      # Self-hosted mode: grant all users full permissions without a subscription.
+      # Only effective when billing is not configured.
+      PARCHMENT_SELF_HOSTED: ${PARCHMENT_SELF_HOSTED:-false}
+      # Billing (optional) — requires BOTH a valid PARCHMENT_LICENSE and Polar
+      # credentials. POLAR_WEBHOOK_SECRET is required when billing is enabled.
+      PARCHMENT_LICENSE: ${PARCHMENT_LICENSE:-}
+      POLAR_ACCESS_TOKEN: ${POLAR_ACCESS_TOKEN:-}
+      POLAR_WEBHOOK_SECRET: ${POLAR_WEBHOOK_SECRET:-}
+      POLAR_ORGANIZATION_ID: ${POLAR_ORGANIZATION_ID:-}
+      POLAR_BASIC_PRODUCT_ID: ${POLAR_BASIC_PRODUCT_ID:-}
+      POLAR_PREMIUM_PRODUCT_ID: ${POLAR_PREMIUM_PRODUCT_ID:-}
+      POLAR_SANDBOX: ${POLAR_SANDBOX:-false}
     ports:
       - "5000:5000"
     volumes:

--- a/server/src/lib/license.ts
+++ b/server/src/lib/license.ts
@@ -5,7 +5,8 @@ ed.hashes.sha512 = (...m) => sha512(ed.etc.concatBytes(...m))
 
 // Ed25519 public key for license verification. Only Parchment's
 // official build pipeline holds the corresponding private key.
-const LICENSE_PUBLIC_KEY = 'a]placeholder-replace-with-real-key'
+const LICENSE_PUBLIC_KEY =
+  'cf8d2d32bd78e1f58649ca9c1b6af18ba66e2e5559a91ba65c2f9b15e39d7d46'
 
 export type LicensePayload = {
   org: string


### PR DESCRIPTION
## What

Prepares production for subscription billing (Polar) — the two code/config blockers from PAR-141 / PAR-140.

- **Embed the license public key** in `server/src/lib/license.ts` (replaces the `'a]placeholder-…'` stub). Billing is gated on a signed `PARCHMENT_LICENSE`; with the placeholder key, verification could never succeed in production. The matching private key is held offline (never in the repo).
- **Compose env passthrough** (`docker-compose.prod.yml`, `docker-compose.dev.yml`): pass `PARCHMENT_LICENSE`, `POLAR_*`, `REGISTRATION_MODE`, and `PARCHMENT_SELF_HOSTED` through to the server. Prod referenced none of these before; also fixes a missing `POLAR_BASIC_PRODUCT_ID` in dev. All use `${VAR:-}` defaults — self-hosters are unaffected and billing stays off unless fully configured.
- **Gitignore `.infisical.json`** (local Infisical CLI link; keeps the repo secrets-provider-agnostic).

## Verification

- The real `verifyLicense()` now accepts the production token → `{"org":"parchment","features":["billing"]}`.
- `docker compose config` passes for both prod and dev compose files.
- Pre-commit web test suite passed on each commit.

## Not in this PR (follow-up)

- Cut a `v0.5.1` release tag so CI rebuilds `:latest` with the embedded key.
- vega7 deploy wiring (source secrets from Infisical, drop the plaintext `.env`) + Polar dashboard webhook verification.

Refs PAR-140, PAR-141.
