### PR TITLE
Steer self-hosters to PARCHMENT_SELF_HOSTED; mark Polar vars Cloud-only

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -41,20 +41,24 @@ SMTP_PASS=
 SMTP_FROM=Parchment <noreply@yourdomain.com>
 APP_TESTER_EMAIL=your_test_email@gmail.com
 
-# Self-hosted mode: set to 'true' to grant all users full permissions
-# without requiring a subscription. Only effective when billing is not configured.
-PARCHMENT_SELF_HOSTED=false
+# Self-hosting: grant every user full permissions without a subscription.
+# Keep this 'true' when self-hosting — it is the supported way to unlock
+# the full app. (Only takes effect when billing is not configured below.)
+PARCHMENT_SELF_HOSTED=true
 
-# Polar billing (optional — omit to disable subscription features)
-# Billing requires BOTH a valid PARCHMENT_LICENSE and Polar credentials.
-# POLAR_WEBHOOK_SECRET is REQUIRED when billing is enabled.
-PARCHMENT_LICENSE=
-POLAR_ACCESS_TOKEN=
-POLAR_WEBHOOK_SECRET=
-POLAR_ORGANIZATION_ID=
-POLAR_BASIC_PRODUCT_ID=
-POLAR_PREMIUM_PRODUCT_ID=
-POLAR_SANDBOX=false
+# Subscription billing (Parchment Cloud only — not for self-hosting).
+# The hosted service at parchment.app uses Polar for subscriptions. Enabling
+# billing requires a signed PARCHMENT_LICENSE issued only by the official
+# Parchment build, so these variables have no effect on a self-hosted
+# instance — leave them unset and use PARCHMENT_SELF_HOSTED above. They are
+# listed here (commented out) only to document the interface.
+# PARCHMENT_LICENSE=
+# POLAR_ACCESS_TOKEN=
+# POLAR_WEBHOOK_SECRET=
+# POLAR_ORGANIZATION_ID=
+# POLAR_BASIC_PRODUCT_ID=
+# POLAR_PREMIUM_PRODUCT_ID=
+# POLAR_SANDBOX=false
 
 # Registration mode: 'invite' (default, requires admin to create users) or 'open'
 REGISTRATION_MODE=invite

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -46,8 +46,10 @@ services:
       # Self-hosted mode: grant all users full permissions without a subscription.
       # Only effective when billing is not configured.
       PARCHMENT_SELF_HOSTED: ${PARCHMENT_SELF_HOSTED:-false}
-      # Billing (optional) — requires BOTH a valid PARCHMENT_LICENSE and Polar
-      # credentials. POLAR_WEBHOOK_SECRET is required when billing is enabled.
+      # Subscription billing — Parchment Cloud only. Requires a signed
+      # PARCHMENT_LICENSE that self-hosted instances cannot obtain, so these
+      # have no effect when self-hosting (use PARCHMENT_SELF_HOSTED above).
+      # POLAR_WEBHOOK_SECRET is required when billing is enabled.
       PARCHMENT_LICENSE: ${PARCHMENT_LICENSE:-}
       POLAR_ACCESS_TOKEN: ${POLAR_ACCESS_TOKEN:-}
       POLAR_WEBHOOK_SECRET: ${POLAR_WEBHOOK_SECRET:-}


### PR DESCRIPTION
## What

Follow-up to #328. Self-hosters can't obtain a `PARCHMENT_LICENSE` (only the official Parchment build issues one), so presenting them fillable `POLAR_*` / `PARCHMENT_LICENSE` fields is a dead end. This reframes the self-host-facing config so they're pointed at the path that actually works:

- **`.env.example`**: default `PARCHMENT_SELF_HOSTED=true` (the supported way to unlock the full app when self-hosting) and comment out the Polar/license vars, clearly labeled "Parchment Cloud only — not for self-hosting."
- **`docker-compose.prod.yml`**: tighten the billing-block comment to say it's Cloud-only and has no effect when self-hosting.

No behavior change: the vars still default empty in compose, and billing stays gated on a valid license.

## Note

The docs-site content (docs.parchment.app — getting-started / environment / self-hosting pages) is **not committed to this repo** — only `docs/app/docs/[[...slug]]/page.tsx` and internal design docs are tracked. If those live pages list the Polar vars for self-hosters, they'll need the same edit wherever that content actually lives.

Refs PAR-140.
