### PR TITLE
Release 0.5.1 — billing groundwork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,17 +1,5 @@
-### Added
-
-* Air quality & wildfire map layers — new Air Quality and Wildfire layer groups powered by OpenAQ and NASA FIRMS, with live readouts that follow each region's own AQI standard and aggregate nearby monitoring stations
-* Look Around street imagery — peek at street-level imagery right from a place's detail view, opening full-screen with smoother navigation and mobile polish
-* Brand search — find every location of a chain with real brand logos and browse them on the map
-* Reorganized search — dedicated Recents and Categories sections, results that page as you scroll and reframe the map as they widen, ranked nearest-first
-* Transit departure board — a transit-style board with live countdown cards, and interchangeable routes merged into a single trip (e.g. "4 or 5")
-* Smarter trip planning — better handling of shared vehicles, parking, and walking time in multimodal directions
-* Redesigned place detail — routable tabs, with home, work, and school presets across the dashboard, collections, and directions
-* Richer place info from Foursquare — reviews, cuisine, and more
-* Map rotation snapping — snap the map to north or to a city's street grid as you rotate
-
 ### Changed
 
-* Reorganized settings into clearer Behavior and Appearance sections, with full-screen dialogs on mobile and a consistent close button
-* More resilient third-party integrations with automatic background retries
-* Quieter, cleaner server logging, plus assorted performance and reliability improvements
+* Subscription billing groundwork — license verification and Polar billing configuration wired up for the hosted service (no change for self-hosted instances)
+* Clearer self-hosting setup — the example environment file now points self-hosters to full-access mode and marks billing variables as hosted-only
+* Assorted fixes and internal improvements

--- a/RELEASE_TITLE
+++ b/RELEASE_TITLE
@@ -1,1 +1,1 @@
-Air quality & Look Around
+Billing groundwork

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build:emails": "cd emails && bun install && npx maizzle build production",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Version bump to trigger the CI image build carrying the embedded license public key — the blocker for enabling prod billing.

Bumps the 4 version files + CHANGELOG/RELEASE_TITLE per the release convention (Cargo.lock left untouched, matching the v0.5.0 release).

Contents since v0.5.0: billing wiring (#328), self-host env docs (#329), plus prior dev merges and fixes. No user-facing feature changes.

Merging to main auto-creates the `v0.5.1` tag and builds/publishes the release. Safe to deploy: billing stays off until the vega7 env is wired (Phase 3).