### PR TITLE
Fix iOS App Store upload: build with the iOS 26 SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -260,7 +260,10 @@ jobs:
   build-ios:
     needs: [test]
     name: Build iOS app
-    runs-on: macos-15
+    # macos-latest ships Xcode 26 (iOS 26 SDK). macos-15 defaults to Xcode 16
+    # (iOS 18.5 SDK), which App Store Connect now rejects on upload (error 90725:
+    # apps must be built with the iOS 26 SDK or later). Match the upload runner.
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Problem

The `v0.5.1` release run failed on one job: **Upload to App Store**. Apple rejected the build:

> Error 90725: This app was built with the iOS 18.5 SDK. All iOS/iPadOS apps must be built with the iOS 26 SDK or later (Xcode 26+).

Everything else succeeded (Docker images, all desktop builds, iOS/Android builds, Google Play upload, GitHub Release).

## Cause

The iOS **build** job ran on `macos-15` (default Xcode 16 → iOS 18.5 SDK), while the **upload** job runs on `macos-latest` (Xcode 26.5 → iOS 26 SDK). So the app was compiled against an SDK Apple no longer accepts.

## Fix

Move `build-ios` to `runs-on: macos-latest` — the same runner the upload job already uses, whose default Xcode is 26.5. One-line change (plus an explanatory comment).

Only verifiable by cutting a release; safe to ride along on the next `v0.5.x` bump.