### PR TITLE
Pass MARTIN_HOST through to parchment-server (barrelman tile proxy)

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,6 +26,8 @@ services:
     image: alexwohlbruck/parchment-server:latest
     environment:
       NODE_ENV: production
+      # Barrelman Martin tile server (host:port reachable from this container)
+      MARTIN_HOST: ${MARTIN_HOST:-}
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@parchment-db:5432/${POSTGRES_DB}
       SERVER_ORIGIN: ${SERVER_ORIGIN}
       CLIENT_ORIGIN: ${CLIENT_ORIGIN}


### PR DESCRIPTION
The barrelman tile proxy (`/proxy/barrelman/:source/:z/:x/:y`) resolves the Martin tile server from `process.env.MARTIN_HOST` (the barrelman integration config no longer carries a martinHost). The prod compose `environment:` block whitelists vars and didn't pass `MARTIN_HOST`, so it fell back to a dead `localhost:5002` → tiles 500. This adds the passthrough so setting `MARTIN_HOST` in the deploy env actually reaches the container.

Set `MARTIN_HOST` in the prod `.env` (e.g. `http://<martin-host>:5002`). Left unset it stays empty and the code default applies.

Note: the vega2 Martin config (pmtiles `basemap` source, `id_column` drop for PostGIS 3.6) and the `basemap.pmtiles` file are host/volume artifacts, not in this repo.