### PR TITLE
Release 0.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,4 @@
 ### Changed
 
-* Subscription billing groundwork — license verification and Polar billing configuration wired up for the hosted service (no change for self-hosted instances)
-* Clearer self-hosting setup — the example environment file now points self-hosters to full-access mode and marks billing variables as hosted-only
-* Assorted fixes and internal improvements
+* More reliable error reporting — server-side errors and crashes now consistently reach the observability pipeline, including a live-reconfigure path when logging settings change
+* Hosted-deployment fixes for basemap map tiles

--- a/RELEASE_TITLE
+++ b/RELEASE_TITLE
@@ -1,1 +1,1 @@
-Billing groundwork
+Logging & tile fixes

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -26,6 +26,8 @@ services:
     image: alexwohlbruck/parchment-server:latest
     environment:
       NODE_ENV: production
+      # Barrelman Martin tile server (host:port reachable from this container)
+      MARTIN_HOST: ${MARTIN_HOST:-}
       DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@parchment-db:5432/${POSTGRES_DB}
       SERVER_ORIGIN: ${SERVER_ORIGIN}
       CLIENT_ORIGIN: ${CLIENT_ORIGIN}

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build:emails": "cd emails && bun install && npx maizzle build production",

--- a/server/src/controllers/directions.controller.ts
+++ b/server/src/controllers/directions.controller.ts
@@ -12,6 +12,7 @@ import {
   WaypointType,
   EnergyType,
 } from '../types/trip.types'
+import { logError } from '../lib/logger'
 
 // Validation schemas for multimodal trip planning
 const CoordinateSchema = t.Object({
@@ -207,7 +208,7 @@ app.post(
 
       return result
     } catch (error) {
-      console.error('Multimodal trip planning error:', error)
+      logError('Multimodal trip planning error', error)
       throw new Error(
         `Failed to plan trip: ${
           error instanceof Error ? error.message : 'Unknown error'

--- a/server/src/controllers/geocoding.controller.ts
+++ b/server/src/controllers/geocoding.controller.ts
@@ -2,6 +2,7 @@ import { Elysia, t } from 'elysia'
 import { requireAuth } from '../middleware/auth.middleware'
 import { integrationManager } from '../services/integrations'
 import { IntegrationCapabilityId } from '../types/integration.types'
+import { logError } from '../lib/logger'
 
 const geocodingRouter = new Elysia({ prefix: '/geocoding' })
   .use(requireAuth)
@@ -62,7 +63,7 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
           integration: integrationRecord.integrationId,
         }
       } catch (err) {
-        console.error('Error performing forward geocoding:', err)
+        logError('Error performing forward geocoding', err)
         return status(500, {
           message:
             err instanceof Error ? err.message : 'Failed to perform geocoding',
@@ -166,7 +167,7 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
           integration: integrationRecord.integrationId,
         }
       } catch (err) {
-        console.error('Error performing reverse geocoding:', err)
+        logError('Error performing reverse geocoding', err)
         return status(500, {
           message:
             err instanceof Error

--- a/server/src/controllers/integration.controller.ts
+++ b/server/src/controllers/integration.controller.ts
@@ -25,6 +25,7 @@ import { requireAuth, getSession } from '../middleware/auth.middleware'
 import { PermissionId } from '../types/auth.types'
 import { hasPermission, getPermissions } from '../services/auth.service'
 import { logger } from '../lib/logger'
+import { refreshObservability } from '../services/observability.config'
 
 const app = new Elysia({ prefix: '/integrations' })
 
@@ -350,6 +351,10 @@ app.post(
         effectiveScheme,
       )
 
+      // Apply logging config live so the Axiom integration starts exporting
+      // without a server restart.
+      if (integrationId === IntegrationId.AXIOM) await refreshObservability()
+
       return integration
     } catch (err: unknown) {
       if (err instanceof IntegrationSchemeConflictError) {
@@ -463,6 +468,13 @@ app.put(
       }
 
       const updatedIntegration = await updateIntegration(id, userId, updates)
+
+      // Apply logging config live (enable/disable, token/dataset change) so the
+      // Axiom integration takes effect without a server restart.
+      if (integration!.integrationId === IntegrationId.AXIOM) {
+        await refreshObservability()
+      }
+
       return updatedIntegration
     } catch (err: unknown) {
       if (err instanceof Error) {
@@ -623,6 +635,11 @@ app.delete(
       const userId: string | undefined = systemIntegration ? undefined : user.id
 
       await deleteIntegration(id, userId)
+
+      // Stop live log export when the Axiom integration is removed.
+      if (integration!.integrationId === IntegrationId.AXIOM) {
+        await refreshObservability()
+      }
 
       set.status = 204
       return null

--- a/server/src/controllers/osm-oauth.controller.ts
+++ b/server/src/controllers/osm-oauth.controller.ts
@@ -15,6 +15,7 @@ import {
 import { IntegrationId } from '../types/integration.types'
 import { getOsmConfig } from '../config/osm.config'
 import { generateId } from '../util'
+import { logError } from '../lib/logger'
 
 const OSM_SCOPES = ['read_prefs', 'write_notes', 'write_api'] // read_prefs needed to fetch display name during OAuth callback
 
@@ -196,7 +197,7 @@ app.get(
 
       return oauthCallbackPage({ status: 'connected' })
     } catch (error: any) {
-      console.error('OSM OAuth2 callback error:', error)
+      logError('OSM OAuth2 callback error', error)
       const message =
         error instanceof arctic.OAuth2RequestError
           ? `OAuth2 error: ${error.code}`

--- a/server/src/controllers/place.controller.ts
+++ b/server/src/controllers/place.controller.ts
@@ -12,6 +12,7 @@ import { SOURCE } from '../lib/constants.js'
 import { WidgetType } from '../types/place.types'
 import { fetchWidgetData } from '../services/widget.service'
 import { fetchNearestStreetImage } from '../services/street-imagery.service'
+import { logError } from '../lib/logger'
 
 const app = new Elysia({ prefix: '/places' })
   .use(getSession)
@@ -145,7 +146,7 @@ app.get(
 
       return place
     } catch (err) {
-      console.error('Error in place lookup:', err)
+      logError('Error in place lookup', err)
       return status(500, {
         message: t('errors.place.retrievalError'),
       })
@@ -188,7 +189,7 @@ app.get(
       const result = await fetchWidgetData(widgetType, query as Record<string, string>)
       return result
     } catch (err) {
-      console.error(`Error fetching widget data (${widgetType}):`, err)
+      logError(`Error fetching widget data (${widgetType})`, err)
       return status(500, {
         message: err instanceof Error ? err.message : 'Error fetching widget data',
       })
@@ -225,7 +226,7 @@ app.get(
       const preview = await fetchNearestStreetImage(lat, lng)
       return { preview }
     } catch (err) {
-      console.error('Error fetching street imagery:', err)
+      logError('Error fetching street imagery', err)
       return status(500, {
         message: err instanceof Error ? err.message : 'Error fetching street imagery',
       })

--- a/server/src/controllers/proxy.controller.ts
+++ b/server/src/controllers/proxy.controller.ts
@@ -5,6 +5,7 @@ import {
   IntegrationCapabilityId,
   IntegrationId,
 } from '../types/integration.types'
+import { logError } from '../lib/logger'
 
 const app = new Elysia({ prefix: '/proxy' })
 
@@ -90,9 +91,7 @@ async function proxyTileRequest(
     const response = await fetch(targetUrl)
 
     if (!response.ok) {
-      console.error(
-        `${errorContext}: ${response.status} ${response.statusText}`,
-      )
+      logError(`${errorContext}: ${response.status} ${response.statusText}`)
       return new Response('Upstream error', { status: response.status })
     }
 
@@ -105,7 +104,7 @@ async function proxyTileRequest(
       },
     })
   } catch (error) {
-    console.error(`${errorContext} proxy error:`, error, 'params:', params)
+    logError(`${errorContext} proxy error`, error, { params })
     return new Response('Proxy error', { status: 500 })
   }
 }
@@ -135,7 +134,7 @@ app.get(
         },
       })
     } catch (error) {
-      console.error('Proxy error:', error)
+      logError('Proxy error', error)
       return new Response('Proxy error', { status: 500 })
     }
   },
@@ -236,7 +235,7 @@ app.get(
       const response = await fetch(tileUrl.toString())
 
       if (!response.ok) {
-        console.error(
+        logError(
           `Barrelman tile proxy: ${response.status} ${response.statusText}`,
         )
         return new Response('Upstream error', { status: response.status })
@@ -253,7 +252,7 @@ app.get(
         },
       })
     } catch (error) {
-      console.error('Barrelman tile proxy error:', error, 'params:', params)
+      logError('Barrelman tile proxy error', error, { params })
       return new Response('Proxy error', { status: 500 })
     }
   },

--- a/server/src/controllers/search.controller.ts
+++ b/server/src/controllers/search.controller.ts
@@ -12,6 +12,7 @@ import { OverpassIntegration } from '../services/integrations/overpass-integrati
 import { categoryService } from '../services/category.service'
 import { categoryPalette } from '../lib/place-categories'
 import { getPresetById, getPresetFields } from '../lib/osm-presets'
+import { logError } from '../lib/logger'
 
 const searchRouter = new Elysia({ prefix: '/search' })
   .use(optionalAuth)
@@ -139,7 +140,7 @@ const searchRouter = new Elysia({ prefix: '/search' })
           executedAt: new Date().toISOString(),
         }
       } catch (err) {
-        console.error('Error executing route search:', err)
+        logError('Error executing route search', err)
         return status(500, {
           message:
             err instanceof Error
@@ -200,7 +201,7 @@ const searchRouter = new Elysia({ prefix: '/search' })
           executedAt: new Date().toISOString(),
         }
       } catch (err) {
-        console.error('Error executing category search:', err)
+        logError('Error executing category search', err)
         return status(500, {
           message:
             err instanceof Error
@@ -264,7 +265,7 @@ const searchRouter = new Elysia({ prefix: '/search' })
           executedAt: new Date().toISOString(),
         }
       } catch (err) {
-        console.error('Error executing brand search:', err)
+        logError('Error executing brand search', err)
         return status(500, {
           message:
             err instanceof Error ? err.message : 'Failed to execute brand search',
@@ -324,7 +325,7 @@ const searchRouter = new Elysia({ prefix: '/search' })
           totalCount: categories.length,
         }
       } catch (err) {
-        console.error('Error loading categories:', err)
+        logError('Error loading categories', err)
         return status(500, {
           message: t('errors.search.categoriesLoadFailed'),
         })
@@ -356,7 +357,7 @@ const searchRouter = new Elysia({ prefix: '/search' })
 
         return category
       } catch (err) {
-        console.error('Error getting category:', err)
+        logError('Error getting category', err)
         return status(500, {
           message: t('errors.search.categoryFailed'),
         })

--- a/server/src/controllers/weather.controller.ts
+++ b/server/src/controllers/weather.controller.ts
@@ -3,6 +3,7 @@ import { integrationManager } from '../services/integrations'
 import { IntegrationCapabilityId } from '../types/integration.types'
 import { getLanguageCode } from '../lib/i18n'
 import { getNearestStationAirQuality } from '../services/air-quality.service'
+import { logError, logWarn } from '../lib/logger'
 
 const weatherRouter = new Elysia({ prefix: '/weather' })
   /**
@@ -66,12 +67,12 @@ const weatherRouter = new Elysia({ prefix: '/weather' })
             weatherData.aqiComponents = nearest.components
           }
         } catch (e) {
-          console.warn('OpenAQ lookup failed; omitting air quality:', e)
+          logWarn('OpenAQ lookup failed; omitting air quality', e)
         }
 
         return weatherData
       } catch (err: any) {
-        console.error('Error fetching weather:', err)
+        logError('Error fetching weather', err)
         return status(500, {
           message: err.message || t('errors.weather.fetchFailed'),
         })

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,13 +1,13 @@
 process.env.TZ = 'UTC'
 
 import { getObservabilityConfig } from './services/observability.config'
-import { initOtel } from './lib/otel'
+import { initOtel, flushOtel } from './lib/otel'
 import { Elysia } from 'elysia'
 import { swagger } from '@elysiajs/swagger'
 import { cors } from '@elysiajs/cors'
 import { i18next } from 'elysia-i18next'
 import { cors as corsConfig, swagger as swaggerConfig } from './config'
-import { logger } from './lib/logger'
+import { logger, logError } from './lib/logger'
 import { loggerMiddleware } from './middleware/logger.middleware'
 import {
   healthCheck as healthCheckController,
@@ -70,6 +70,17 @@ async function main() {
     process.exit(1)
   }
 
+  // Capture top-level failures that never reach the request middleware so they
+  // still land in Axiom. uncaughtException is fatal — flush the OTLP batch
+  // before exiting so the record isn't lost in the buffer.
+  process.on('uncaughtException', (error) => {
+    logError('Uncaught exception', error, { fatal: true })
+    flushOtel().finally(() => process.exit(1))
+  })
+  process.on('unhandledRejection', (reason) => {
+    logError('Unhandled promise rejection', reason)
+  })
+
   const app = new Elysia()
 
   app.use(loggerMiddleware)
@@ -123,7 +134,7 @@ async function main() {
 
   app.onError(({ code, error }) => {
     if (code === 'NOT_FOUND') return 'Route not found :(' // TODO: i18n, proper error
-    logger.error({ err: error, code }, 'Request error')
+    logError('Request error', error, { code })
     return new Response(
       JSON.stringify({ error: 'Internal server error', code }),
       { status: 500, headers: { 'Content-Type': 'application/json' } },
@@ -156,11 +167,11 @@ async function main() {
     await initializeIntegrations()
     logger.info('Integrations initialized')
   } catch (error) {
-    logger.error({ err: error }, 'Failed to initialize services')
+    logError('Failed to initialize services', error)
   }
 }
 
 main().catch((err) => {
-  logger.error({ err }, 'Unhandled error in main')
-  process.exit(1)
+  logError('Unhandled error in main', err, { fatal: true })
+  flushOtel().finally(() => process.exit(1))
 })

--- a/server/src/lib/graphhopper-custom-model.ts
+++ b/server/src/lib/graphhopper-custom-model.ts
@@ -26,6 +26,7 @@
  */
 
 import { TravelMode, RoutingPreferences } from '../types/unified-routing.types'
+import { logWarn } from './logger'
 
 export interface CustomModelRule {
   if: string
@@ -123,10 +124,9 @@ function computeGraphHopperCustomModel(
       if (keys.every((k) => allowedKeys.has(k))) {
         return parsed
       }
-      console.warn(
-        'customModelOverride contained disallowed keys:',
-        keys.filter((k) => !allowedKeys.has(k)),
-      )
+      logWarn('customModelOverride contained disallowed keys', undefined, {
+        disallowedKeys: keys.filter((k) => !allowedKeys.has(k)),
+      })
     } catch {
       // Fall through to auto-generation
     }

--- a/server/src/lib/logger.ts
+++ b/server/src/lib/logger.ts
@@ -82,6 +82,58 @@ export function emitLogRecord(
 }
 
 /**
+ * Serialize an unknown thrown value into structured attributes. Extracts the
+ * name/message/stack from Error instances so the stack survives export (raw
+ * Error objects would otherwise be stringified to "[object Error]").
+ */
+export function serializeError(err: unknown): Record<string, unknown> {
+  if (err instanceof Error) {
+    return {
+      error: {
+        type: err.name,
+        message: err.message,
+        ...(err.stack && { stack: err.stack }),
+      },
+    }
+  }
+  return { error: { type: 'Unknown', message: String(err) } }
+}
+
+/**
+ * Log a handled error to stdout AND export it to OTLP (Axiom).
+ *
+ * Use this for caught, gracefully-handled errors in services/controllers —
+ * the ones that never reach the request middleware's onError and would
+ * otherwise be invisible in Axiom. Prefer this over `console.error`.
+ */
+export function logError(
+  message: string,
+  err?: unknown,
+  context: Record<string, unknown> = {},
+) {
+  emitLogRecord(
+    'error',
+    message,
+    { ...(err !== undefined ? serializeError(err) : {}), ...context },
+    { sendToOtlp: true, stdout: true },
+  )
+}
+
+/** Like {@link logError} but at warn level (expected/recoverable conditions). */
+export function logWarn(
+  message: string,
+  err?: unknown,
+  context: Record<string, unknown> = {},
+) {
+  emitLogRecord(
+    'warn',
+    message,
+    { ...(err !== undefined ? serializeError(err) : {}), ...context },
+    { sendToOtlp: true, stdout: true },
+  )
+}
+
+/**
  * OTel log attributes must be primitives or arrays of primitives.
  * Flatten nested objects to dot-notation strings for compatibility.
  */

--- a/server/src/lib/osm-presets.ts
+++ b/server/src/lib/osm-presets.ts
@@ -1,6 +1,7 @@
 import type { Language } from './i18n'
 import { getLanguageCode } from './i18n'
 import { getChipLabel } from './display-chips'
+import { logWarn } from './logger'
 
 export type GeometryType = 'point' | 'line' | 'area' | 'vertex' | 'relation'
 
@@ -133,7 +134,7 @@ function loadPresets(): Record<string, PresetDefinition> {
     const rawData = require('@openstreetmap/id-tagging-schema/dist/translations/en.json')
     presetNames = rawData.en?.presets?.presets || {}
   } catch (error) {
-    console.warn('Could not load preset translations')
+    logWarn('Could not load preset translations', error)
   }
 
   presets = {}

--- a/server/src/lib/otel.ts
+++ b/server/src/lib/otel.ts
@@ -1,7 +1,11 @@
 /**
  * OpenTelemetry SDK bootstrap.
- * Call initOtel(config) once at app startup (after resolving observability config).
- * Config can come from env (OTEL_*) or from the Axiom system integration.
+ *
+ * Call initOtel(config) once at app startup. The OTLP exporters are ALWAYS
+ * attached (wrapped in a DynamicExporter that no-ops until configured), so the
+ * export target can be set — or changed — at runtime via setObservabilityConfig
+ * without a process restart. This is what lets configuring the Axiom
+ * integration in the UI take effect immediately instead of on next boot.
  */
 import { NodeSDK } from '@opentelemetry/sdk-node'
 import { OTLPLogExporter } from '@opentelemetry/exporter-logs-otlp-http'
@@ -11,12 +15,61 @@ import {
   ATTR_SERVICE_NAME,
   ATTR_SERVICE_VERSION,
 } from '@opentelemetry/semantic-conventions'
-import { BatchLogRecordProcessor } from '@opentelemetry/sdk-logs'
-import { BatchSpanProcessor } from '@opentelemetry/sdk-trace-node'
+import {
+  BatchLogRecordProcessor,
+  type LogRecordExporter,
+  type ReadableLogRecord,
+} from '@opentelemetry/sdk-logs'
+import {
+  BatchSpanProcessor,
+  type SpanExporter,
+  type ReadableSpan,
+} from '@opentelemetry/sdk-trace-node'
+import { type ExportResult, ExportResultCode } from '@opentelemetry/core'
 import type { ObservabilityConfig } from '../services/observability.config'
+
+/**
+ * An exporter whose inner OTLP target can be swapped (or cleared) at runtime.
+ * When no inner exporter is configured, export() succeeds immediately and drops
+ * the batch — so the batch processors never buffer unbounded and never hit the
+ * network before a target exists.
+ */
+class DynamicExporter<T> {
+  private inner:
+    | { export(items: T[], cb: (r: ExportResult) => void): void; shutdown(): Promise<void> }
+    | null = null
+
+  setInner(inner: { export(items: T[], cb: (r: ExportResult) => void): void; shutdown(): Promise<void> }) {
+    const previous = this.inner
+    this.inner = inner
+    previous?.shutdown().catch(() => {})
+  }
+
+  clear() {
+    const previous = this.inner
+    this.inner = null
+    previous?.shutdown().catch(() => {})
+  }
+
+  export(items: T[], resultCallback: (r: ExportResult) => void): void {
+    if (!this.inner) {
+      resultCallback({ code: ExportResultCode.SUCCESS })
+      return
+    }
+    this.inner.export(items, resultCallback)
+  }
+
+  shutdown(): Promise<void> {
+    return this.inner?.shutdown() ?? Promise.resolve()
+  }
+}
+
+const logExporter = new DynamicExporter<ReadableLogRecord>()
+const spanExporter = new DynamicExporter<ReadableSpan>()
 
 let sdk: NodeSDK
 let initialized = false
+let currentEndpoint: string | null = null
 
 export async function initOtel(config: ObservabilityConfig | null): Promise<void> {
   if (initialized) return
@@ -29,35 +82,62 @@ export async function initOtel(config: ObservabilityConfig | null): Promise<void
     'deployment.environment': process.env.NODE_ENV ?? 'development',
   })
 
-  const enableExport = config != null && config.endpoint?.trim().length > 0
-
   sdk = new NodeSDK({
     resource,
-    ...(enableExport && {
-      spanProcessors: [
-        new BatchSpanProcessor(
-          new OTLPTraceExporter({
-            url: `${config!.endpoint.replace(/\/$/, '')}/v1/traces`,
-            headers: parseHeaders(config!.headers),
-          }),
-        ),
-      ],
-      logRecordProcessors: [
-        new BatchLogRecordProcessor(
-          new OTLPLogExporter({
-            url: `${config!.endpoint.replace(/\/$/, '')}/v1/logs`,
-            headers: parseHeaders(config!.headers),
-          }),
-        ),
-      ],
-    }),
+    spanProcessors: [new BatchSpanProcessor(spanExporter as SpanExporter)],
+    logRecordProcessors: [
+      new BatchLogRecordProcessor(logExporter as LogRecordExporter),
+    ],
   })
 
   sdk.start()
 
+  // Point the exporters at the resolved target (if any). Later calls to
+  // setObservabilityConfig can change or clear it live.
+  setObservabilityConfig(config)
+
   const shutdown = () => sdk.shutdown().finally(() => process.exit(0))
   process.on('SIGTERM', shutdown)
   process.on('SIGINT', shutdown)
+}
+
+/**
+ * Set — or change, or clear — the OTLP export target at runtime. Returns true
+ * when export is now active. Called at boot and again whenever the Axiom
+ * integration is saved/enabled/disabled/deleted, so config changes apply
+ * without a restart.
+ */
+export function setObservabilityConfig(config: ObservabilityConfig | null): boolean {
+  const endpoint = config?.endpoint?.trim()
+  if (!endpoint) {
+    if (currentEndpoint) {
+      logExporter.clear()
+      spanExporter.clear()
+      currentEndpoint = null
+    }
+    return false
+  }
+
+  const base = endpoint.replace(/\/$/, '')
+  const headers = parseHeaders(config!.headers)
+  logExporter.setInner(new OTLPLogExporter({ url: `${base}/v1/logs`, headers }))
+  spanExporter.setInner(new OTLPTraceExporter({ url: `${base}/v1/traces`, headers }))
+  currentEndpoint = base
+  return true
+}
+
+/**
+ * Force-flush pending log/span batches to the OTLP exporter. Called from the
+ * uncaughtException handler before the process exits so the fatal record
+ * actually reaches Axiom instead of dying in the batch buffer.
+ */
+export async function flushOtel(): Promise<void> {
+  if (!initialized || !sdk) return
+  try {
+    await sdk.shutdown()
+  } catch {
+    // Best-effort: we're already crashing, don't mask the original error.
+  }
 }
 
 function parseHeaders(headerString: string): Record<string, string> {

--- a/server/src/lib/place-categories.ts
+++ b/server/src/lib/place-categories.ts
@@ -1,5 +1,6 @@
 import type { PlaceCategory, PlaceIcon } from '../types/place.types'
 import type { MatchResult } from './osm-presets'
+import { logWarn } from './logger'
 
 // ─── Category palette ────────────────────────────────────────────────────────
 
@@ -375,7 +376,7 @@ export function resolveIcon(presetIcon: string): { icon: string; iconPack: 'luci
   }
 
   // Last resort: use as maki name but log the miss
-  console.warn(`Unmapped icon "${presetIcon}" → falling back to "${stripped}" (maki). Add to nonMakiFallbackMap.`)
+  logWarn(`Unmapped icon "${presetIcon}" → falling back to "${stripped}" (maki). Add to nonMakiFallbackMap.`)
   return { icon: stripped, iconPack: 'maki' }
 }
 
@@ -395,7 +396,7 @@ export function buildPlaceIcon(presetMatch: MatchResult | null): PlaceIcon | und
     const key = presetMatch.preset.id
     if (!loggedMissingIcons.has(key)) {
       loggedMissingIcons.add(key)
-      console.warn(`No icon for preset "${key}" (raw: ${presetIcon || 'none'}). Will show MapPin.`)
+      logWarn(`No icon for preset "${key}" (raw: ${presetIcon || 'none'}). Will show MapPin.`)
     }
   }
 

--- a/server/src/lib/place.utils.ts
+++ b/server/src/lib/place.utils.ts
@@ -4,6 +4,7 @@ import {
   getPlaceType as getOSMPlaceType,
   type GeometryType,
 } from './osm-presets'
+import { logError } from './logger'
 
 export function getPlaceType(
   tags: Record<string, string>,
@@ -89,7 +90,7 @@ export function parseOpeningHoursForUnifiedFormat(
 
     return result.length > 0 ? result : null
   } catch (error) {
-    console.error('Error parsing opening hours:', error)
+    logError('Error parsing opening hours', error)
     return null
   }
 }

--- a/server/src/scripts/delete-stale.ts
+++ b/server/src/scripts/delete-stale.ts
@@ -1,6 +1,7 @@
 import { db } from '../db'
 import { encryptedLocations } from '../schema/location.schema'
 import { eq } from 'drizzle-orm'
+import { logError } from '../lib/logger'
 
 async function main() {
   const result = await db
@@ -12,4 +13,4 @@ async function main() {
   process.exit(0)
 }
 
-main().catch(console.error)
+main().catch((error) => logError('Failed to delete stale location', error))

--- a/server/src/services/air-quality.service.ts
+++ b/server/src/services/air-quality.service.ts
@@ -13,6 +13,7 @@
  */
 
 import { computeAirQuality, type AqiComponents } from '../lib/aqi'
+import { logWarn } from '../lib/logger'
 import { IntegrationId, type AirQuality } from '../types/integration.types'
 import { integrationManager } from './integrations'
 
@@ -190,7 +191,7 @@ async function takeToken(): Promise<void> {
 let circuitOpenUntil = 0
 function openCircuit(ms: number, reason: string) {
   circuitOpenUntil = Math.max(circuitOpenUntil, Date.now() + ms)
-  console.warn(`[openaq] pausing requests ${Math.round(ms / 1000)}s (${reason})`)
+  logWarn(`[openaq] pausing requests ${Math.round(ms / 1000)}s (${reason})`)
 }
 
 function headerNum(res: Response, name: string): number {

--- a/server/src/services/category.service.ts
+++ b/server/src/services/category.service.ts
@@ -2,6 +2,7 @@ import { CategoryResult } from '../types/search.types'
 import type { Language } from '../lib/i18n/i18n.types'
 import { getLanguageCode } from '../lib/i18n'
 import { getPlaceCategory, resolveIcon } from '../lib/place-categories'
+import { logWarn } from '../lib/logger'
 
 /**
  * Custom aliases for common colloquial / alternative names not in the iD schema.
@@ -184,7 +185,7 @@ export class CategoryService {
             translations = enTranslations.en || {}
             presetTranslations = translations?.presets?.presets || {}
           } catch (enError) {
-            console.warn('Could not load translations for', apiLang)
+            logWarn('Could not load translations for', undefined, { apiLang })
           }
         }
       }

--- a/server/src/services/integration.service.ts
+++ b/server/src/services/integration.service.ts
@@ -21,7 +21,7 @@ import {
   encryptIntegrationConfig,
   decryptIntegrationConfig,
 } from '../lib/integration-encryption'
-import { logger } from '../lib/logger'
+import { logger, logError } from '../lib/logger'
 import { getPersonalBlobsByTypePrefix } from './personal-blob.service'
 
 // Personal-blob type namespace for user-e2ee integration configs.
@@ -483,8 +483,8 @@ async function reconcileSystemCapabilities(
         `[integrations] Added new capabilit${missing.length === 1 ? 'y' : 'ies'} to ${record.integrationId}: ${missing.join(', ')}`,
       )
     } catch (err) {
-      console.error(
-        `[integrations] Failed to reconcile capabilities for ${record.integrationId}:`,
+      logError(
+        `Failed to reconcile capabilities for ${record.integrationId}`,
         err,
       )
     }
@@ -517,8 +517,8 @@ export async function initializeIntegrations() {
     for (let i = 0; i < systemResults.length; i++) {
       const result = systemResults[i]
       if (result.status === 'rejected') {
-        console.error(
-          `Failed to initialize system integration ${systemIntegrations[i].integrationId}:`,
+        logError(
+          `Failed to initialize system integration ${systemIntegrations[i].integrationId}`,
           result.reason,
         )
       }
@@ -569,8 +569,8 @@ export async function initializeIntegrations() {
         for (let i = 0; i < results.length; i++) {
           const result = results[i]
           if (result.status === 'rejected') {
-            console.error(
-              `Failed to initialize integration ${serverKeyIntegrations[i].integrationId} for user ${user.id}:`,
+            logError(
+              `Failed to initialize integration ${serverKeyIntegrations[i].integrationId} for user ${user.id}`,
               result.reason,
             )
           }
@@ -580,8 +580,8 @@ export async function initializeIntegrations() {
     for (let i = 0; i < userResults.length; i++) {
       const result = userResults[i]
       if (result.status === 'rejected') {
-        console.error(
-          `Failed to get integrations for user ${allUsers[i].id}:`,
+        logError(
+          `Failed to get integrations for user ${allUsers[i].id}`,
           result.reason,
         )
       }
@@ -589,7 +589,7 @@ export async function initializeIntegrations() {
 
     console.log('Integration initialization completed')
   } catch (error) {
-    console.error('Failed to initialize integrations:', error)
+    logError('Failed to initialize integrations', error)
     throw error
   }
 }

--- a/server/src/services/integrations/adapters/geoapify-adapter.ts
+++ b/server/src/services/integrations/adapters/geoapify-adapter.ts
@@ -19,6 +19,7 @@ import { matchTags } from '../../../lib/osm-presets'
 import { buildPlaceIcon } from '../../../lib/place-categories'
 import { SOURCE } from '../../../lib/constants'
 import { getPresetFromGeoapifyCategory } from '../mappings/geoapify-preset-mapping'
+import { logError } from '../../../lib/logger'
 
 export interface GeoapifyFeature {
   type: string
@@ -245,7 +246,7 @@ export class GeoapifyAdapter {
 
       return place
     } catch (error) {
-      console.error('Error adapting Geoapify data:', error)
+      logError('Error adapting Geoapify data', error)
 
       const fallbackExternalIds: Record<string, string> = {}
       if (feature.properties?.place_id) {

--- a/server/src/services/integrations/adapters/google-adapter.ts
+++ b/server/src/services/integrations/adapters/google-adapter.ts
@@ -11,6 +11,7 @@ import {
   SOURCE,
 } from '../../../lib/constants'
 import { parseGoogleHours } from '../../../lib/hours.utils'
+import { logError } from '../../../lib/logger'
 
 // TODO: Move this type def
 export interface GooglePlaceDetails {
@@ -269,7 +270,7 @@ export class GoogleAdapter {
         })
       })
     } catch (error) {
-      console.error('Error processing Google photos:', error)
+      logError('Error processing Google photos', error)
     }
 
     return photos
@@ -384,7 +385,7 @@ export class GoogleAdapter {
         sourceId: SOURCE.GOOGLE,
       }
     } catch (error) {
-      console.error('Error processing Google opening hours:', error)
+      logError('Error processing Google opening hours', error)
       return null
     }
   }

--- a/server/src/services/integrations/adapters/nominatim-adapter.ts
+++ b/server/src/services/integrations/adapters/nominatim-adapter.ts
@@ -13,6 +13,7 @@ import { buildPlaceIcon } from '../../../lib/place-categories'
 import { SOURCE } from '../../../lib/constants'
 import { parseOpeningHoursForUnifiedFormat } from '../../../lib/place.utils'
 import { extractTransitIdentifiers, isTransitStopType, isTransitStop, createTransitInfo } from '../../../lib/transit-utils'
+import { logError } from '../../../lib/logger'
 
 /**
  * Interface for Nominatim hierarchy response (parent relations)
@@ -540,7 +541,7 @@ export class NominatimAdapter {
           tags: item.extratags || {}
         }))
     } catch (error) {
-      console.error('Error looking up parent relations:', error)
+      logError('Error looking up parent relations', error)
       return []
     }
   }

--- a/server/src/services/integrations/adapters/pelias-adapter.ts
+++ b/server/src/services/integrations/adapters/pelias-adapter.ts
@@ -10,6 +10,7 @@ import { matchTags } from '../../../lib/osm-presets'
 import { buildPlaceIcon } from '../../../lib/place-categories'
 import { SOURCE } from '../../../lib/constants'
 import { parseOsmHours } from '../../../lib/hours.utils'
+import { logError } from '../../../lib/logger'
 
 // TODO: Check all SOURCE.PELIAS and SOURCE.OSM references. Idk what to do with these yet. Pelias can use various sources.
 
@@ -171,7 +172,7 @@ export class PeliasAdapter {
         opening_hours: osmData.opening_hours,
       })
     } catch (error) {
-      console.error('Error processing Pelias opening hours:', error)
+      logError('Error processing Pelias opening hours', error)
       return null
     }
   }
@@ -320,7 +321,7 @@ export class PeliasAdapter {
 
       return unifiedPlace
     } catch (error) {
-      console.error('Error adapting Pelias data:', error)
+      logError('Error adapting Pelias data', error)
 
       // Determine the actual source for error case
       const actualSource =

--- a/server/src/services/integrations/adapters/wikidata-adapter.ts
+++ b/server/src/services/integrations/adapters/wikidata-adapter.ts
@@ -4,6 +4,7 @@ import type {
   PlacePhoto,
 } from '../../../types/place.types'
 import { SOURCE } from '../../../lib/constants'
+import { logError } from '../../../lib/logger'
 
 /**
  * Interface for Wikidata entity data
@@ -341,7 +342,7 @@ export class WikidataAdapter {
       const encodedFilename = encodeURIComponent(cleanFilename)
       return `https://commons.wikimedia.org/wiki/Special:FilePath/${encodedFilename}?width=800`
     } catch (error) {
-      console.error('Error converting Wikimedia filename to URL:', error)
+      logError('Error converting Wikimedia filename to URL', error)
       return null
     }
   }

--- a/server/src/services/integrations/foursquare-integration.ts
+++ b/server/src/services/integrations/foursquare-integration.ts
@@ -16,6 +16,7 @@ import {
   type FoursquarePlace,
   type FoursquareTip,
 } from './adapters/foursquare-adapter'
+import { logError } from '../../lib/logger'
 
 export interface FoursquareConfig extends IntegrationConfig {
   apiKey: string
@@ -118,7 +119,7 @@ export class FoursquareIntegration
       }
       return { success: true }
     } catch (error: any) {
-      console.error('Foursquare test connection error:', error)
+      logError('Foursquare test connection error', error)
       return {
         success: false,
         message: error?.message || 'Failed to connect to Foursquare',
@@ -180,7 +181,7 @@ export class FoursquareIntegration
         signal: options?.signal ?? AbortSignal.timeout(10_000),
       })
       if (!response.ok) {
-        console.error(`Foursquare search HTTP error: ${response.status}`)
+        logError(`Foursquare search HTTP error: ${response.status}`)
         return []
       }
 
@@ -194,7 +195,7 @@ export class FoursquareIntegration
       return places
     } catch (error) {
       if (this.isAbort(error)) return []
-      console.error('Foursquare search error:', error)
+      logError('Foursquare search error', error)
       return []
     }
   }
@@ -224,7 +225,7 @@ export class FoursquareIntegration
       })
       if (!response.ok) {
         if (response.status !== 404) {
-          console.error(`Foursquare details HTTP error: ${response.status}`)
+          logError(`Foursquare details HTTP error: ${response.status}`)
         }
         return null
       }
@@ -239,7 +240,7 @@ export class FoursquareIntegration
       return place
     } catch (error) {
       if (this.isAbort(error)) return null
-      console.error('Foursquare details error:', error)
+      logError('Foursquare details error', error)
       return null
     }
   }
@@ -264,7 +265,7 @@ export class FoursquareIntegration
       })
       if (!response.ok) {
         if (response.status !== 404) {
-          console.error(`Foursquare tips HTTP error: ${response.status}`)
+          logError(`Foursquare tips HTTP error: ${response.status}`)
         }
         return []
       }
@@ -272,7 +273,7 @@ export class FoursquareIntegration
       return Array.isArray(data) ? (data as FoursquareTip[]) : []
     } catch (error) {
       if (this.isAbort(error)) return []
-      console.error('Foursquare tips error:', error)
+      logError('Foursquare tips error', error)
       return []
     }
   }
@@ -309,7 +310,7 @@ export class FoursquareIntegration
       // 404 = no confident match; treat as "no twin", not an error.
       if (response.status === 404) return null
       if (!response.ok) {
-        console.error(`Foursquare match HTTP error: ${response.status}`)
+        logError(`Foursquare match HTTP error: ${response.status}`)
         return null
       }
 
@@ -324,7 +325,7 @@ export class FoursquareIntegration
       return { fsqPlaceId, matchRate }
     } catch (error) {
       if (this.isAbort(error)) return null
-      console.error('Foursquare match error:', error)
+      logError('Foursquare match error', error)
       return null
     }
   }

--- a/server/src/services/integrations/geoapify-integration.ts
+++ b/server/src/services/integrations/geoapify-integration.ts
@@ -13,6 +13,7 @@ import {
   MapBounds,
 } from '../../types/integration.types'
 import { Place } from '../../types/place.types'
+import { logError } from '../../lib/logger'
 import {
   RouteRequest,
   UnifiedRoute,
@@ -145,7 +146,7 @@ export class GeoapifyIntegration implements Integration<GeoapifyConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing Geoapify API:', error)
+      logError('Error testing Geoapify API', error)
       return {
         success: false,
         message: error.response?.data?.message || error.message || 'Failed to connect to Geoapify API',
@@ -188,7 +189,7 @@ export class GeoapifyIntegration implements Integration<GeoapifyConfig> {
         this.adapter.adaptPlaceDetails(feature),
       )
     } catch (error) {
-      console.error('Error searching Geoapify places:', error)
+      logError('Error searching Geoapify places', error)
       return []
     }
   }
@@ -250,7 +251,7 @@ export class GeoapifyIntegration implements Integration<GeoapifyConfig> {
         this.adapter.adaptPlaceDetails(feature),
       )
     } catch (error) {
-      console.error('Error getting Geoapify autocomplete:', error)
+      logError('Error getting Geoapify autocomplete', error)
       return []
     }
   }
@@ -298,7 +299,7 @@ export class GeoapifyIntegration implements Integration<GeoapifyConfig> {
         this.adapter.adaptPlaceDetails(feature),
       )
     } catch (error) {
-      console.error('Error geocoding with Geoapify:', error)
+      logError('Error geocoding with Geoapify', error)
       return []
     }
   }
@@ -336,7 +337,7 @@ export class GeoapifyIntegration implements Integration<GeoapifyConfig> {
         this.adapter.adaptPlaceDetails(feature),
       )
     } catch (error) {
-      console.error('Error reverse geocoding with Geoapify:', error)
+      logError('Error reverse geocoding with Geoapify', error)
       return []
     }
   }
@@ -368,7 +369,7 @@ export class GeoapifyIntegration implements Integration<GeoapifyConfig> {
 
       return this.adapter.adaptPlaceDetails(response.data.features[0])
     } catch (error) {
-      console.error('[Geoapify] Error getting place details:', error)
+      logError('[Geoapify] Error getting place details', error)
       return null
     }
   }

--- a/server/src/services/integrations/google-maps-integration.ts
+++ b/server/src/services/integrations/google-maps-integration.ts
@@ -16,6 +16,7 @@ import type { Place } from '../../types/place.types'
 import { GoogleAdapter } from './adapters/google-adapter'
 import { SOURCE } from '../../lib/constants'
 import { getLanguageCode } from '../../lib/i18n'
+import { logError, logWarn } from '../../lib/logger'
 
 // TODO: Use official Google client SDK for requests
 
@@ -96,7 +97,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
 
       return { success: true }
     } catch (error: any) {
-      console.error('Error testing Google Maps API:', error)
+      logError('Error testing Google Maps API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Google Maps API',
@@ -148,9 +149,9 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
       })
 
       if (!response.ok) {
-        console.error(`Google Place Details HTTP error: ${response.status}`)
+        logError(`Google Place Details HTTP error: ${response.status}`)
         if (response.status === 404) {
-          console.warn(`Place not found: ${placeId}`)
+          logWarn(`Place not found: ${placeId}`)
           return null
         }
         throw new Error(`Google API error: ${response.status}`)
@@ -158,7 +159,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
 
       const data = await response.json()
       if (data.error) {
-        console.error('Google Place Details API error:', data.error)
+        logError('Google Place Details API error', data.error)
         return null
       }
 
@@ -170,7 +171,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
       )
       return this.adapter.placeInfo.adaptPlaceDetails(data)
     } catch (error) {
-      console.error('Google place details error:', error)
+      logError('Google place details error', error)
       return null
     }
   }
@@ -252,7 +253,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
         }),
       )
     } catch (error) {
-      console.error('Google geocoding error:', error)
+      logError('Google geocoding error', error)
       return []
     }
   }
@@ -334,7 +335,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
         }),
       )
     } catch (error) {
-      console.error('Google reverse geocoding error:', error)
+      logError('Google reverse geocoding error', error)
       return []
     }
   }
@@ -358,7 +359,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
     },
   ): Promise<Place[]> {
     if (!this.config.apiKey) {
-      console.error('Google Maps API key not configured')
+      logError('Google Maps API key not configured')
       return []
     }
 
@@ -406,7 +407,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
       })
 
       if (!response.ok) {
-        console.error(
+        logError(
           `Google Places Text Search HTTP error: ${response.status}`,
         )
         throw new Error(`Google API error: ${response.status}`)
@@ -414,7 +415,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
 
       const data = await response.json()
       if (data.error) {
-        console.error('Google Places Text Search API error:', data.error)
+        logError('Google Places Text Search API error', data.error)
         return []
       }
 
@@ -432,7 +433,7 @@ export class GoogleMapsIntegration implements Integration<GoogleMapsConfig> {
 
       return places
     } catch (error) {
-      console.error('Google Places Text Search error:', error)
+      logError('Google Places Text Search error', error)
       return []
     }
   }

--- a/server/src/services/integrations/graphhopper-integration.ts
+++ b/server/src/services/integrations/graphhopper-integration.ts
@@ -31,6 +31,7 @@ import type {
   GraphHopperErrorResponse,
 } from '../../types/graphhopper.types'
 import { GraphHopperAdapter } from './adapters/graphhopper-adapter'
+import { logError, logWarn } from '../../lib/logger'
 
 /**
  * GraphHopper integration for routing
@@ -209,7 +210,7 @@ export class GraphHopperIntegration implements Integration<GraphHopperConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing GraphHopper API:', error)
+      logError('Error testing GraphHopper API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to GraphHopper server',
@@ -321,7 +322,10 @@ export class GraphHopperIntegration implements Integration<GraphHopperConfig> {
 
       if (!response.ok) {
         const errorText = await response.text()
-        console.error('GraphHopper error response:', response.status, errorText)
+        logError('GraphHopper error response', undefined, {
+          status: response.status,
+          errorText,
+        })
 
         let errorMessage = `GraphHopper routing error: ${response.status}`
         try {
@@ -394,7 +398,7 @@ export class GraphHopperIntegration implements Integration<GraphHopperConfig> {
 
     if (customModel) {
       if (!isSelfHosted) {
-        console.warn(
+        logWarn(
           'GraphHopper: Custom model features require paid plan or self-hosted instance. Skipping custom_model.',
         )
       } else {

--- a/server/src/services/integrations/integration-manager.service.ts
+++ b/server/src/services/integrations/integration-manager.service.ts
@@ -9,6 +9,7 @@ import {
 import { IntegrationRegistry } from './integration-registry'
 import { Source, INTEGRATION_PRIORITIES } from '../../lib/constants'
 import { initializeWithTest } from '../../lib/integration.utils'
+import { logWarn } from '../../lib/logger'
 
 /**
  * Cached integration that combines database record with integration instance
@@ -291,7 +292,7 @@ export class IntegrationManagerService {
   ): IntegrationCapabilityId[] {
     const integration = this.registry.getIntegration(integrationId)
     if (!integration) {
-      console.warn(`Integration with ID ${integrationId} not found`)
+      logWarn(`Integration with ID ${integrationId} not found`)
       return []
     }
     return integration.capabilityIds

--- a/server/src/services/integrations/mapbox-integration.ts
+++ b/server/src/services/integrations/mapbox-integration.ts
@@ -6,6 +6,7 @@ import {
   Integration,
   MapEngineCapability,
 } from '../../types/integration.types'
+import { logError } from '../../lib/logger'
 
 export interface MapboxConfig extends IntegrationConfig {
   accessToken: string
@@ -98,7 +99,7 @@ export class MapboxIntegration implements Integration<MapboxConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing Mapbox API:', error)
+      logError('Error testing Mapbox API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Mapbox API',

--- a/server/src/services/integrations/nominatim-integration.ts
+++ b/server/src/services/integrations/nominatim-integration.ts
@@ -11,6 +11,7 @@ import {
 import { SOURCE } from '../../lib/constants'
 import { NominatimAdapter } from './adapters/nominatim-adapter'
 import type { Place } from '../../types/place.types'
+import { logError } from '../../lib/logger'
 
 // Get version from package.json
 const packageJson = require('../../../package.json')
@@ -131,7 +132,7 @@ export class NominatimIntegration implements Integration<NominatimConfig> {
 
       return { success: true }
     } catch (error: any) {
-      console.error('Error testing Nominatim API:', error)
+      logError('Error testing Nominatim API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Nominatim API',
@@ -271,7 +272,7 @@ export class NominatimIntegration implements Integration<NominatimConfig> {
       // Adapt the result to Place format
       return [this.adapter.placeInfo.adaptPlaceDetails(response.data)]
     } catch (error) {
-      console.error('Error reverse geocoding with Nominatim:', error)
+      logError('Error reverse geocoding with Nominatim', error)
       return []
     }
   }
@@ -307,7 +308,7 @@ export class NominatimIntegration implements Integration<NominatimConfig> {
 
       // Validate OSM type
       if (osmType && !['node', 'way', 'relation'].includes(osmType)) {
-        console.error(`Invalid OSM type: ${osmType}`)
+        logError(`Invalid OSM type: ${osmType}`)
         return null
       }
 
@@ -349,7 +350,7 @@ export class NominatimIntegration implements Integration<NominatimConfig> {
       const result = response.data[0]
       return this.adapter.placeInfo.adaptPlaceDetails(result)
     } catch (error) {
-      console.error('Error getting place details from Nominatim:', error)
+      logError('Error getting place details from Nominatim', error)
       return null
     }
   }

--- a/server/src/services/integrations/openweathermap-integration.ts
+++ b/server/src/services/integrations/openweathermap-integration.ts
@@ -7,6 +7,7 @@ import {
   WeatherCapability,
   WeatherData,
 } from '../../types/integration.types'
+import { logError } from '../../lib/logger'
 
 export interface OpenWeatherMapConfig extends IntegrationConfig {
   apiKey: string
@@ -98,7 +99,7 @@ export class OpenWeatherMapIntegration implements Integration<OpenWeatherMapConf
 
       return { success: true }
     } catch (error: any) {
-      console.error('Error testing OpenWeatherMap API:', error)
+      logError('Error testing OpenWeatherMap API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to OpenWeatherMap API',
@@ -165,7 +166,7 @@ export class OpenWeatherMapIntegration implements Integration<OpenWeatherMapConf
 
       return result
     } catch (error: any) {
-      console.error('Error fetching weather data:', error)
+      logError('Error fetching weather data', error)
       throw new Error(error.message || 'Failed to fetch weather data')
     }
   }

--- a/server/src/services/integrations/overpass-integration.ts
+++ b/server/src/services/integrations/overpass-integration.ts
@@ -16,6 +16,7 @@ import type { Place } from '../../types/place.types'
 import { OverpassAdapter } from './adapters/overpass-adapter'
 import { SOURCE } from '../../lib/constants'
 import { calculateOSMCenter } from '../../util/geometry-conversion'
+import { logError } from '../../lib/logger'
 
 // TODO: Remove overpass integration
 // TODO: Overpass is designed for OSM editors to edit the map, not for backend search
@@ -81,7 +82,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing Overpass API:', error)
+      logError('Error testing Overpass API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Overpass API',
@@ -112,7 +113,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
     _options?: { language?: string },
   ): Promise<Place | null> {
     if (!this.config.host) {
-      console.error('Overpass integration not properly configured')
+      logError('Overpass integration not properly configured')
       return null
     }
 
@@ -137,7 +138,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
       )
 
       if (!response.data.elements || response.data.elements.length === 0) {
-        console.error('No place found with ID:', id)
+        logError('No place found with ID', undefined, { id })
         return null
       }
 
@@ -151,7 +152,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
       // Use the adapter to convert to standardized Place format
       return this.adapter.placeInfo.adaptPlaceDetails(place)
     } catch (error) {
-      console.error('Error fetching place from Overpass:', error)
+      logError('Error fetching place from Overpass', error)
       return null
     }
   }
@@ -228,7 +229,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
     radius?: number,
   ): Promise<any[]> {
     if (!this.config.host) {
-      console.error('Overpass integration not properly configured')
+      logError('Overpass integration not properly configured')
       return []
     }
 
@@ -264,7 +265,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
 
       return places
     } catch (error) {
-      console.error('Error searching places with Overpass:', error)
+      logError('Error searching places with Overpass', error)
       return []
     }
   }
@@ -315,13 +316,13 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
             places.push(place)
           }
         } catch (error) {
-          console.error('Error converting Overpass element to Place:', error)
+          logError('Error converting Overpass element to Place', error)
         }
       }
 
       return places
     } catch (error) {
-      console.error('Error executing Overpass query:', error)
+      logError('Error executing Overpass query', error)
       throw new Error(
         `Failed to execute Overpass query: ${
           error instanceof Error ? error.message : 'Unknown error'
@@ -336,7 +337,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
     options?: { limit?: number },
   ): Promise<Place[]> {
     if (!this.config.host) {
-      console.error('Overpass integration not properly configured')
+      logError('Overpass integration not properly configured')
       return []
     }
 
@@ -377,13 +378,13 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
             places.push(place)
           }
         } catch (error) {
-          console.error('Error converting Overpass element to Place:', error)
+          logError('Error converting Overpass element to Place', error)
         }
       }
 
       return places
     } catch (error) {
-      console.error('Error executing Overpass category query:', error)
+      logError('Error executing Overpass category query', error)
       return []
     }
   }
@@ -446,7 +447,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
     },
   ): Promise<Place[]> {
     if (!this.config.host) {
-      console.error('Overpass integration not properly configured')
+      logError('Overpass integration not properly configured')
       return []
     }
 
@@ -509,7 +510,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
       if (!response.data?.elements) return []
       return this.elementsToPlaces(response.data.elements.slice(0, maxResults))
     } catch (error) {
-      console.error(`[Overpass/Area] Error executing area query for ${osmId}:`, error)
+      logError(`[Overpass/Area] Error executing area query for ${osmId}`, error)
       return []
     }
   }
@@ -558,7 +559,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
       console.debug(`[Overpass/Bbox] Found ${places.length} places within ${osmId}`)
       return places
     } catch (error) {
-      console.error(`[Overpass/Bbox] Error executing bbox query for ${osmId}:`, error)
+      logError(`[Overpass/Bbox] Error executing bbox query for ${osmId}`, error)
       return []
     }
   }
@@ -622,7 +623,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
           }
         })
     } catch (error) {
-      console.error('[Overpass/IsIn] Error fetching containing areas:', error)
+      logError('[Overpass/IsIn] Error fetching containing areas', error)
       return []
     }
   }
@@ -698,7 +699,7 @@ export class OverpassIntegration implements Integration<OverpassConfig> {
           places.push(place)
         }
       } catch (error) {
-        console.error('Error converting Overpass element to Place:', error)
+        logError('Error converting Overpass element to Place', error)
       }
     }
     return places

--- a/server/src/services/integrations/pelias-integration.ts
+++ b/server/src/services/integrations/pelias-integration.ts
@@ -11,6 +11,7 @@ import {
 import { Place, Address } from '../../types/place.types'
 import { SOURCE } from '../../lib/constants'
 import { PeliasAdapter, PeliasFeature } from './adapters/pelias-adapter'
+import { logError, logWarn } from '../../lib/logger'
 
 // TODO: Check all SOURCE.PELIAS and SOURCE.OSM references. Idk what to do with these yet. Pelias can use various sources.
 
@@ -123,7 +124,7 @@ export class PeliasIntegration implements Integration<PeliasConfig> {
 
       return { success: true }
     } catch (error: any) {
-      console.error('Error testing Pelias API:', error)
+      logError('Error testing Pelias API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Pelias API',
@@ -258,22 +259,21 @@ export class PeliasIntegration implements Integration<PeliasConfig> {
       const response = await fetch(url.toString())
 
       if (!response.ok) {
-        console.error(
-          'Pelias autocomplete error:',
-          response.status,
-          response.statusText,
-        )
+        logError('Pelias autocomplete error', undefined, {
+          status: response.status,
+          statusText: response.statusText,
+        })
         return []
       }
 
       const data = await response.json()
 
       if (data.geocoding?.warnings) {
-        console.warn('Pelias warnings:', data.geocoding.warnings)
+        logWarn('Pelias warnings', undefined, { warnings: data.geocoding.warnings })
       }
 
       if (data.geocoding?.errors) {
-        console.error('Pelias errors:', data.geocoding.errors)
+        logError('Pelias errors', undefined, { errors: data.geocoding.errors })
         return []
       }
 
@@ -288,7 +288,7 @@ export class PeliasIntegration implements Integration<PeliasConfig> {
 
       return places
     } catch (error) {
-      console.error('Pelias autocomplete error:', error)
+      logError('Pelias autocomplete error', error)
       return []
     }
   }
@@ -356,7 +356,7 @@ export class PeliasIntegration implements Integration<PeliasConfig> {
       const feature = response.data.features[0] as PeliasFeature
       return this.adapter.placeInfo.adaptPlaceDetails(feature)
     } catch (error) {
-      console.error('Error getting place details from Pelias:', error)
+      logError('Error getting place details from Pelias', error)
       return null
     }
   }

--- a/server/src/services/integrations/transitland-integration.ts
+++ b/server/src/services/integrations/transitland-integration.ts
@@ -9,6 +9,7 @@ import {
 } from '../../types/integration.types'
 import { TransitDeparture, Place } from '../../types/place.types'
 import { SOURCE } from '../../lib/constants'
+import { logError } from '../../lib/logger'
 
 const TRANSITLAND_API_BASE_URL = 'https://transit.land/api/v2/rest'
 
@@ -157,7 +158,7 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
       const data = await response.json()
       return data.stops || []
     } catch (error) {
-      console.error('Error searching stops in Transitland:', error)
+      logError('Error searching stops in Transitland', error)
       return []
     }
   }
@@ -222,7 +223,7 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
 
       return this.transformDepartures(collected)
     } catch (error) {
-      console.error('Error fetching departures from Transitland:', error)
+      logError('Error fetching departures from Transitland', error)
       return []
     }
   }
@@ -387,7 +388,10 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
           console.log(`[PERF] Transitland getStop (404): ${Date.now() - startTime}ms`)
           return null
         }
-        console.error('Transitland stop API error:', response.status, response.statusText)
+        logError('Transitland stop API error', undefined, {
+          status: response.status,
+          statusText: response.statusText,
+        })
         return null
       }
 
@@ -406,7 +410,7 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
       console.log(`[PERF] Transitland getStop (no stops): ${Date.now() - startTime}ms`)
       return null
     } catch (error) {
-      console.error(`[PERF] Error fetching stop from Transitland (${Date.now() - startTime}ms):`, error)
+      logError(`[PERF] Error fetching stop from Transitland (${Date.now() - startTime}ms)`, error)
       return null
     }
   }
@@ -427,7 +431,7 @@ export class TransitlandIntegration implements Integration<TransitlandConfig> {
       // Convert Transitland stop to unified Place format
       return this.adaptStopToPlace(stop)
     } catch (error) {
-      console.error('Error getting place info from Transitland:', error)
+      logError('Error getting place info from Transitland', error)
       return null
     }
   }

--- a/server/src/services/integrations/valhalla-integration.ts
+++ b/server/src/services/integrations/valhalla-integration.ts
@@ -25,6 +25,7 @@ import type {
   ValhallaManeuver,
 } from '../../types/valhalla.types'
 import { ValhallaAdapter } from './adapters/valhalla-adapter'
+import { logError } from '../../lib/logger'
 
 /**
  * Valhalla integration for routing
@@ -154,7 +155,7 @@ export class ValhallaIntegration implements Integration<ValhallaConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing Valhalla API:', error)
+      logError('Error testing Valhalla API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Valhalla server',
@@ -223,7 +224,10 @@ export class ValhallaIntegration implements Integration<ValhallaConfig> {
 
       if (!response.ok) {
         const errorText = await response.text()
-        console.error('Valhalla error response:', response.status, errorText)
+        logError('Valhalla error response', undefined, {
+          status: response.status,
+          errorText,
+        })
         throw new Error(
           `Valhalla routing error: ${response.status} - ${errorText}`,
         )

--- a/server/src/services/integrations/wikidata-integration.ts
+++ b/server/src/services/integrations/wikidata-integration.ts
@@ -12,6 +12,7 @@ import {
 import type { Place, PlacePhoto } from '../../types/place.types'
 import { WikidataAdapter } from './adapters/wikidata-adapter'
 import { SOURCE } from '../../lib/constants'
+import { logError } from '../../lib/logger'
 
 // Get version from package.json
 const packageJson = require('../../../package.json')
@@ -77,7 +78,7 @@ export class WikidataIntegration implements Integration<WikidataConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing Wikidata API:', error)
+      logError('Error testing Wikidata API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Wikidata API',
@@ -132,7 +133,7 @@ export class WikidataIntegration implements Integration<WikidataConfig> {
 
       // Validate that this looks like a Wikidata Q ID
       if (!wikidataId.match(/^Q\d+$/)) {
-        console.error(`Invalid Wikidata ID format: ${wikidataId}`)
+        logError(`Invalid Wikidata ID format: ${wikidataId}`)
         return null
       }
 
@@ -150,7 +151,7 @@ export class WikidataIntegration implements Integration<WikidataConfig> {
       )
 
       if (!response.data?.entities?.[wikidataId]) {
-        console.error('No entity found with ID:', wikidataId)
+        logError('No entity found with ID', undefined, { wikidataId })
         return null
       }
 
@@ -159,7 +160,7 @@ export class WikidataIntegration implements Integration<WikidataConfig> {
       // Use the adapter to convert to standardized Place format
       return this.adapter.placeInfo.adaptPlaceDetails(entity, wikidataId)
     } catch (error) {
-      console.error('Error fetching place from Wikidata:', error)
+      logError('Error fetching place from Wikidata', error)
       return null
     }
   }
@@ -188,7 +189,7 @@ export class WikidataIntegration implements Integration<WikidataConfig> {
 
       return response.data?.entities?.[wikidataId] || null
     } catch (error) {
-      console.error('Error fetching entity from Wikidata:', error)
+      logError('Error fetching entity from Wikidata', error)
       return null
     }
   }

--- a/server/src/services/integrations/wikimedia-integration.ts
+++ b/server/src/services/integrations/wikimedia-integration.ts
@@ -12,6 +12,7 @@ import {
 import type { Place } from '../../types/place.types'
 import { WikimediaAdapter } from './adapters/wikimedia-adapter'
 import { SOURCE } from '../../lib/constants'
+import { logError, logWarn } from '../../lib/logger'
 
 // Get version from package.json
 const packageJson = require('../../../package.json')
@@ -83,7 +84,7 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing Wikimedia Commons API:', error)
+      logError('Error testing Wikimedia Commons API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Wikimedia Commons API',
@@ -192,7 +193,7 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
         createdAt: timestamp,
       }
     } catch (error) {
-      console.error('Error fetching place from Wikimedia Commons:', error)
+      logError('Error fetching place from Wikimedia Commons', error)
       return null
     }
   }
@@ -272,10 +273,10 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
 
       // TODO: Implement geographic search by coordinates
       // This would require using a geographic search API or service
-      console.warn('Geographic image search not yet implemented for Wikimedia Commons')
+      logWarn('Geographic image search not yet implemented for Wikimedia Commons')
       return []
     } catch (error) {
-      console.error('Error fetching imagery from Wikimedia Commons:', error)
+      logError('Error fetching imagery from Wikimedia Commons', error)
       return []
     }
   }
@@ -317,7 +318,7 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
       )
 
       if (!response.data?.query?.pages) {
-        console.warn(`No images found in category: ${categoryName}`)
+        logWarn(`No images found in category: ${categoryName}`)
         return []
       }
 
@@ -331,7 +332,7 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
 
       return images
     } catch (error) {
-      console.error('Error fetching images from Wikimedia Commons category:', error)
+      logError('Error fetching images from Wikimedia Commons category', error)
       return []
     }
   }
@@ -410,7 +411,7 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
 
       return images
     } catch (error) {
-      console.error('Error fetching images from Wikimedia Commons gallery:', error)
+      logError('Error fetching images from Wikimedia Commons gallery', error)
       return []
     }
   }
@@ -436,7 +437,7 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
 
       return fileNames
     } catch (error) {
-      console.warn('Error parsing gallery content:', error)
+      logWarn('Error parsing gallery content', error)
       return []
     }
   }
@@ -484,7 +485,7 @@ export class WikimediaIntegration implements Integration<WikimediaConfig> {
 
       return images
     } catch (error) {
-      console.error('Error searching Wikimedia Commons images:', error)
+      logError('Error searching Wikimedia Commons images', error)
       return []
     }
   }

--- a/server/src/services/integrations/wikipedia-integration.ts
+++ b/server/src/services/integrations/wikipedia-integration.ts
@@ -12,6 +12,7 @@ import {
 import type { Place } from '../../types/place.types'
 import { WikipediaAdapter } from './adapters/wikipedia-adapter'
 import { SOURCE } from '../../lib/constants'
+import { logError, logWarn } from '../../lib/logger'
 
 // Get version from package.json
 const packageJson = require('../../../package.json')
@@ -82,7 +83,7 @@ export class WikipediaIntegration implements Integration<WikipediaConfig> {
         }
       }
     } catch (error: any) {
-      console.error('Error testing Wikipedia API:', error)
+      logError('Error testing Wikipedia API', error)
       return {
         success: false,
         message: error.message || 'Failed to connect to Wikipedia API',
@@ -140,7 +141,7 @@ export class WikipediaIntegration implements Integration<WikipediaConfig> {
       const title = titleParts.join(':')
 
       if (!language || !title) {
-        console.error(`Invalid Wikipedia page identifier: ${pageInfo}`)
+        logError(`Invalid Wikipedia page identifier: ${pageInfo}`)
         return null
       }
 
@@ -152,7 +153,7 @@ export class WikipediaIntegration implements Integration<WikipediaConfig> {
       // Use the adapter to convert to standardized Place format
       return this.adapter.placeInfo.adaptPlaceDetails(pageData, title, language)
     } catch (error) {
-      console.error('Error fetching place from Wikipedia:', error)
+      logError('Error fetching place from Wikipedia', error)
       return null
     }
   }
@@ -193,7 +194,7 @@ export class WikipediaIntegration implements Integration<WikipediaConfig> {
       const page = pages[pageId]
 
       if (!page || page.missing !== undefined) {
-        console.error(`Wikipedia page not found: ${language}:${title}`)
+        logError(`Wikipedia page not found: ${language}:${title}`)
         return null
       }
 
@@ -221,7 +222,7 @@ export class WikipediaIntegration implements Integration<WikipediaConfig> {
           }
         }
       } catch (error) {
-        console.warn('Failed to get infobox data for Wikipedia page:', title, error)
+        logWarn('Failed to get infobox data for Wikipedia page', error, { title })
       }
 
       return {
@@ -230,7 +231,7 @@ export class WikipediaIntegration implements Integration<WikipediaConfig> {
         language,
       }
     } catch (error) {
-      console.error('Error fetching Wikipedia page data:', error)
+      logError('Error fetching Wikipedia page data', error)
       return null
     }
   }
@@ -277,7 +278,7 @@ export class WikipediaIntegration implements Integration<WikipediaConfig> {
       
       return Object.keys(infobox).length > 0 ? infobox : null
     } catch (error) {
-      console.warn('Error parsing infobox:', error)
+      logWarn('Error parsing infobox', error)
       return null
     }
   }

--- a/server/src/services/library/bookmarks.service.ts
+++ b/server/src/services/library/bookmarks.service.ts
@@ -19,6 +19,7 @@ import {
 } from '../../util/geometry-conversion'
 import { createBookmarkSearchCondition } from '../../util/text-search.util'
 import { emit } from '../realtime/emit'
+import { logWarn } from '../../lib/logger'
 
 // Automatically generate select fields with geometry conversion - no manual field listing needed!
 const bookmarkSelectFields = createSelectFieldsWithGeometry(bookmarks)
@@ -321,7 +322,7 @@ export async function removeBookmarkFromCollections(
   // Verify the bookmark belongs to the user before proceeding
   const bookmark = await getBookmarkById(bookmarkId, userId)
   if (!bookmark) {
-    console.warn(
+    logWarn(
       `Bookmark ${bookmarkId} not found for user ${userId}. Cannot remove from collections.`,
     )
     return false // Bookmark not found or doesn't belong to user

--- a/server/src/services/observability.config.ts
+++ b/server/src/services/observability.config.ts
@@ -1,6 +1,8 @@
 import { getConfiguredIntegrations } from './integration.service'
 import { IntegrationId } from '../types/integration.enums'
 import type { IntegrationRecord } from '../schema/integrations.schema'
+import { setObservabilityConfig } from '../lib/otel'
+import { logger } from '../lib/logger'
 
 export interface ObservabilityConfig {
   endpoint: string
@@ -38,6 +40,21 @@ export async function getObservabilityConfig(): Promise<ObservabilityConfig | nu
   ].join(',')
 
   return { endpoint, headers, serviceName: process.env.OTEL_SERVICE_NAME ?? undefined }
+}
+
+/**
+ * Re-resolve the observability config and apply it to the live OTLP exporters.
+ * Call after the Axiom integration is created/updated/enabled/disabled/deleted
+ * so logging changes take effect immediately, without a server restart.
+ */
+export async function refreshObservability(): Promise<void> {
+  try {
+    const config = await getObservabilityConfig()
+    const active = setObservabilityConfig(config)
+    logger.info({ exporting: active }, 'Observability export config refreshed')
+  } catch (error) {
+    logger.error({ err: error }, 'Failed to refresh observability config')
+  }
 }
 
 function getObservabilityConfigFromEnv(): ObservabilityConfig | null {

--- a/server/src/services/place.service.ts
+++ b/server/src/services/place.service.ts
@@ -14,6 +14,7 @@ import { WikipediaIntegration } from './integrations/wikipedia-integration'
 import { WikimediaIntegration } from './integrations/wikimedia-integration'
 import { dedupeWikiPhotos } from './integrations/wiki-utils'
 import { isTransitStop, extractAllOnestopIdsFromWikidata } from '../lib/transit-utils'
+import { logError, logWarn } from '../lib/logger'
 
 /** True for an aborted/cancelled request (axios CanceledError or DOM AbortError). */
 function isAbortError(error: unknown): boolean {
@@ -131,7 +132,7 @@ async function enrichPlaceWithAddressData(place: Place): Promise<Place> {
           }
         }
       } catch (error) {
-        console.error(`Error enriching address with ${integrationRecord.integrationId}:`, error)
+        logError(`Error enriching address with ${integrationRecord.integrationId}`, error)
         // Continue to next integration
       }
     }
@@ -139,7 +140,7 @@ async function enrichPlaceWithAddressData(place: Place): Promise<Place> {
     console.log('No geocoding integration returned useful address data')
     return place
   } catch (error) {
-    console.error('Error during address enrichment:', error)
+    logError('Error during address enrichment', error)
     return place
   }
 }
@@ -181,7 +182,7 @@ async function enrichPlaceWithParentRelations(place: Place): Promise<void> {
       }
     }
   } catch (error) {
-    console.error('Error looking up parent relations:', error)
+    logError('Error looking up parent relations', error)
   }
 }
 
@@ -239,7 +240,7 @@ async function addBookmarkInfo(places: Place[], userId: string): Promise<void> {
       }
     }
   } catch (error) {
-    console.error('Error adding bookmark information:', error)
+    logError('Error adding bookmark information', error)
   }
 }
 
@@ -285,7 +286,7 @@ export async function lookupPlaceById(
       )) ?? null
     )
   } catch (error) {
-    console.error(`[lookupPlaceById] Error:`, error)
+    logError(`[lookupPlaceById] Error`, error)
     return null
   }
 }
@@ -388,7 +389,7 @@ export async function lookupPlacesByNameAndLocation(
     // CanceledError. That's expected control flow, not a failure — return
     // quietly without logging noise.
     if (isAbortError(error)) return []
-    console.error('Error looking up places by name and coordinates:', error)
+    logError('Error looking up places by name and coordinates', error)
     return []
   }
 }
@@ -454,7 +455,7 @@ export async function lookupPlaceByNameAndLocation(
 
     return places[0] || null
   } catch (error) {
-    console.error(`[PERF] Error getting place by name and coordinates (${Date.now() - startTime}ms):`, error)
+    logError(`[PERF] Error getting place by name and coordinates (${Date.now() - startTime}ms)`, error)
     return null
   }
 }
@@ -652,7 +653,7 @@ async function enrichPlaceWithWikiData(
               place = mergePlaces(place, wikimediaPlace)
             }
           } catch (error) {
-            console.warn('Error fetching Wikimedia Commons images:', error)
+            logWarn('Error fetching Wikimedia Commons images', error)
           }
         }
       } else {
@@ -694,7 +695,7 @@ async function enrichPlaceWithWikiData(
             }
           }
         } catch (fallbackErr) {
-          console.warn('Wikimedia Commons fallback failed:', fallbackErr)
+          logWarn('Wikimedia Commons fallback failed', fallbackErr)
         }
       }
     }
@@ -704,7 +705,7 @@ async function enrichPlaceWithWikiData(
 
     return place
   } catch (error) {
-    console.error('Error enriching place with Wiki data:', error)
+    logError('Error enriching place with Wiki data', error)
     return place // Return original place if enrichment fails
   }
 }
@@ -770,7 +771,7 @@ async function enrichPlaceWithFoursquareData(
     return mergePlaces(place, fsqPlace)
   } catch (error) {
     if (isAbortError(error)) return place
-    console.error('Error enriching place with Foursquare data:', error)
+    logError('Error enriching place with Foursquare data', error)
     return place
   }
 }
@@ -921,8 +922,8 @@ export async function lookupEnrichedPlaceById(
     return place
   } catch (error) {
     const totalTime = Date.now() - startTime
-    console.error(
-      `[PERF] Error looking up and merging place data (${source}/${id}) after ${totalTime}ms:`,
+    logError(
+      `[PERF] Error looking up and merging place data (${source}/${id}) after ${totalTime}ms`,
       error,
     )
     return null
@@ -959,14 +960,14 @@ export async function lookupEnrichedPlaceByCoordinates(
     )
     
     if (!geocodingIntegrations.length) {
-      console.error('No geocoding integration available')
+      logError('No geocoding integration available')
       return null
     }
     
     const geocodingIntegration = integrationManager.getCachedIntegrationInstance(geocodingIntegrations[0])
     
     if (!geocodingIntegration?.capabilities.geocoding) {
-      console.error('Geocoding capability not available')
+      logError('Geocoding capability not available')
       return null
     }
     
@@ -1100,7 +1101,7 @@ export async function lookupEnrichedPlaceByCoordinates(
               }
             }
           } catch (error) {
-            console.error('Error fetching Geoapify place for OSM ID extraction:', error)
+            logError('Error fetching Geoapify place for OSM ID extraction', error)
           }
         }
       }
@@ -1182,8 +1183,8 @@ export async function lookupEnrichedPlaceByCoordinates(
     return place
   } catch (error) {
     const totalTime = Date.now() - startTime
-    console.error(
-      `[PERF] Error looking up place by coordinates (${lat},${lng}) after ${totalTime}ms:`,
+    logError(
+      `[PERF] Error looking up place by coordinates (${lat},${lng}) after ${totalTime}ms`,
       error,
     )
     return null

--- a/server/src/services/routing.service.ts
+++ b/server/src/services/routing.service.ts
@@ -9,6 +9,7 @@ import {
   RouteWaypoint,
   RoutingPreferences,
 } from '../types/unified-routing.types'
+import { logError, logWarn } from '../lib/logger'
 
 export class RoutingService {
   /**
@@ -44,7 +45,7 @@ export class RoutingService {
       if (preferredIntegration) {
         routingIntegrationRecord = preferredIntegration
       } else {
-        console.warn(
+        logWarn(
           `Preferred routing engine ${preferences.routingEngine} not found, using default`,
         )
       }
@@ -129,7 +130,7 @@ export class RoutingService {
       // The result is now already in unified format
       return result
     } catch (error) {
-      console.error('Routing integration error:', error)
+      logError('Routing integration error', error)
       throw new Error(
         `Failed to get route: ${
           error instanceof Error ? error.message : 'Unknown error'

--- a/server/src/services/sharing.service.ts
+++ b/server/src/services/sharing.service.ts
@@ -26,6 +26,7 @@ import {
 } from './federation.service'
 import { parseHandle } from '../lib/crypto'
 import { publish } from './realtime/event-bus.service'
+import { logError } from '../lib/logger'
 
 export type ResourceType = 'collection' | 'route' | 'map' | 'layer'
 
@@ -542,8 +543,9 @@ async function sendShareToRemote(
       // A cross-server share without a complete client-signed envelope is
       // rejected — we'd send an unsigned message that the remote peer would
       // discard anyway, so surface the error to the caller instead.
-      console.error(
+      logError(
         'Refusing to send remote share without a signed v2 envelope',
+        undefined,
         { shareId: share.id },
       )
       return false
@@ -575,7 +577,7 @@ async function sendShareToRemote(
 
     return true
   } catch (error) {
-    console.error('Failed to send share to remote:', error)
+    logError('Failed to send share to remote', error)
     return false
   }
 }

--- a/server/src/services/street-imagery.service.ts
+++ b/server/src/services/street-imagery.service.ts
@@ -2,6 +2,7 @@ import type { StreetImageryPreview } from '../types/place.types'
 import { IntegrationId } from '../types/integration.enums'
 import { integrationManager } from './integrations'
 import { MapillaryIntegration } from './integrations/mapillary-integration'
+import { logError } from '../lib/logger'
 
 function getMapillaryInstance(): MapillaryIntegration | null {
   const record = integrationManager
@@ -27,7 +28,7 @@ export async function fetchNearestStreetImage(
   try {
     return await mapillary.findNearestImage(lat, lng)
   } catch (error) {
-    console.error('[StreetImagery] Mapillary lookup failed:', error)
+    logError('[StreetImagery] Mapillary lookup failed', error)
     return null
   }
 }

--- a/server/src/services/trip.service.ts
+++ b/server/src/services/trip.service.ts
@@ -26,6 +26,7 @@ import { routingService } from './routing.service'
 import { transitRoutingService } from './transit-routing.service'
 import { rideshareService } from './rideshare.service'
 import { searchByCategory } from './search.service'
+import { logError, logWarn } from '../lib/logger'
 
 /**
  * Simplified multimodal trip planning service
@@ -68,7 +69,7 @@ export class TripService {
             return trip ? [trip] : []
           }
         } catch (error) {
-          console.error(`Failed to plan ${mode} trip:`, error)
+          logError(`Failed to plan ${mode} trip`, error)
           return []
         }
       })
@@ -76,7 +77,7 @@ export class TripService {
     if (modes.includes('biking')) {
       modePromises.push(
         this.planSharedVehicleTrips(request, dataSources).catch((error) => {
-          console.error('Shared vehicle planning failed:', error)
+          logError('Shared vehicle planning failed', error)
           return []
         }),
       )
@@ -88,7 +89,7 @@ export class TripService {
           this.planDrivingWithParkingTrip(request, dataSources)
             .then((trip) => trip ? [trip] : [])
             .catch((error) => {
-              console.error('Parking-aware driving failed:', error)
+              logError('Parking-aware driving failed', error)
               return []
             }),
         )
@@ -98,7 +99,7 @@ export class TripService {
           this.planBikingWithParkingTrip(request, dataSources)
             .then((trip) => trip ? [trip] : [])
             .catch((error) => {
-              console.error('Parking-aware biking failed:', error)
+              logError('Parking-aware biking failed', error)
               return []
             }),
         )
@@ -590,7 +591,7 @@ export class TripService {
         },
       }
     } catch (error) {
-      console.error('Walking route failed:', error)
+      logError('Walking route failed', error)
       return null
     }
   }
@@ -650,7 +651,7 @@ export class TripService {
         },
       }
     } catch (error) {
-      console.error('Wheelchair route failed:', error)
+      logError('Wheelchair route failed', error)
       return null
     }
   }
@@ -772,7 +773,7 @@ export class TripService {
         },
       }
     } catch (error) {
-      console.error('Multimodal driving failed:', error)
+      logError('Multimodal driving failed', error)
       return null
     }
   }
@@ -837,7 +838,7 @@ export class TripService {
         },
       }
     } catch (error) {
-      console.error('Direct driving failed:', error)
+      logError('Direct driving failed', error)
       return null
     }
   }
@@ -1463,7 +1464,7 @@ export class TripService {
         return true
       })
     } catch (error) {
-      console.error(`Parking search (${category}) failed:`, error)
+      logError(`Parking search (${category}) failed`, error)
       return []
     }
   }
@@ -1576,7 +1577,7 @@ export class TripService {
         },
       }
     } catch (error) {
-      console.error('Multimodal biking failed:', error)
+      logError('Multimodal biking failed', error)
       return null
     }
   }
@@ -1604,9 +1605,10 @@ export class TripService {
       )
 
       if (!route.routes.length) {
-        console.warn(
-          'Direct biking: routing returned no routes for',
-          `(${from.location.lat},${from.location.lng}) → (${to.location.lat},${to.location.lng})`,
+        logWarn(
+          'Direct biking: routing returned no routes',
+          undefined,
+          { endpoints: `(${from.location.lat},${from.location.lng}) → (${to.location.lat},${to.location.lng})` },
         )
         return null
       }
@@ -1644,7 +1646,7 @@ export class TripService {
         },
       }
     } catch (error) {
-      console.error('Direct biking failed:', error)
+      logError('Direct biking failed', error)
       return null
     }
   }
@@ -1840,7 +1842,7 @@ export class TripService {
       return transitRoutingService.getIntermodalRoute(req)
         .then(r => r.itineraries ?? [])
         .catch(e => {
-          console.error(`Intermodal query (${label}) failed:`, e)
+          logError(`Intermodal query (${label}) failed`, e)
           return [] as import('../types/integration.types').TransitItinerary[]
         })
     }
@@ -1973,7 +1975,7 @@ export class TripService {
           walkTrips, from, to, startTime, preferences,
         )
       } catch (error) {
-        console.error('Rideshare+transit composition failed:', error)
+        logError('Rideshare+transit composition failed', error)
       }
     }
 
@@ -2373,7 +2375,7 @@ export class TripService {
 
       return trips
     } catch (error) {
-      console.error(`Vehicle-access (${vehicle.type}) transit query failed:`, error)
+      logError(`Vehicle-access (${vehicle.type}) transit query failed`, error)
       return []
     }
   }
@@ -2447,7 +2449,7 @@ export class TripService {
       )
       return adapted.filter((t): t is TripResponse => t !== null)
     } catch (error) {
-      console.error('Intermodal query failed:', error)
+      logError('Intermodal query failed', error)
       return []
     }
   }
@@ -3124,7 +3126,7 @@ export class TripService {
     )
 
     const logFailure = (side: string) => (error: unknown) => {
-      console.error(`Rideshare ${side} variant failed:`, error)
+      logError(`Rideshare ${side} variant failed`, error)
       return null
     }
 

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -12,6 +12,7 @@ import { matchTags } from '../lib/osm-presets'
 import { buildPlaceIcon } from '../lib/place-categories'
 import * as turf from '@turf/turf'
 import { resolveDisplayChips } from '../lib/display-chips'
+import { logError } from '../lib/logger'
 
 /**
  * Check if a place is a transit stop based on its OSM tags/type.
@@ -368,7 +369,7 @@ async function fetchTransitDepartures(
     const response = await fetch(`${config.host}/transit/departures?${queryParams}`, { headers })
 
     if (!response.ok) {
-      console.error(`[Widget/Transit] Barrelman returned ${response.status}`)
+      logError(`[Widget/Transit] Barrelman returned ${response.status}`)
       return { departures: [], sources: [] }
     }
 
@@ -490,7 +491,7 @@ async function fetchTransitDepartures(
       sources,
     }
   } catch (error) {
-    console.error('[Widget/Transit] Barrelman departure fetch failed:', error)
+    logError('[Widget/Transit] Barrelman departure fetch failed', error)
     return { departures: [], sources: [] }
   }
 }
@@ -531,7 +532,7 @@ async function fetchBikeshareStatus(
     if (!response.ok) {
       // 404 just means this dock isn't in any known GBFS feed — not an error.
       if (response.status !== 404) {
-        console.error(`[Widget/Bikeshare] Barrelman returned ${response.status}`)
+        logError(`[Widget/Bikeshare] Barrelman returned ${response.status}`)
       }
       return { status: null, sources: [] }
     }
@@ -568,7 +569,7 @@ async function fetchBikeshareStatus(
       sources: [{ id: 'gbfs', name: status.systemName || status.operator || 'GBFS' }],
     }
   } catch (error) {
-    console.error('[Widget/Bikeshare] Barrelman station fetch failed:', error)
+    logError('[Widget/Bikeshare] Barrelman station fetch failed', error)
     return { status: null, sources: [] }
   }
 }
@@ -930,7 +931,7 @@ async function fetchParentPlaces(
           }
         }
       } catch (error) {
-        console.error('[Widget/Parent] is_in query failed, falling back to Nominatim:', error)
+        logError('[Widget/Parent] is_in query failed, falling back to Nominatim', error)
       }
     }
   }
@@ -973,7 +974,7 @@ async function fetchParentPlaces(
 
     return parents
   } catch (error) {
-    console.error('[Widget/RelatedPlaces] Error fetching parent places:', error)
+    logError('[Widget/RelatedPlaces] Error fetching parent places', error)
     return []
   }
 }

--- a/server/src/services/wikidata.service.ts
+++ b/server/src/services/wikidata.service.ts
@@ -1,6 +1,7 @@
 import axios from 'axios'
 import { SOURCE } from '../lib/constants'
 import packageJson from '../../package.json'
+import { logError } from '../lib/logger'
 
 // Wikidata API URLs
 const WIKIDATA_API_BASE = 'https://www.wikidata.org/w/api.php'
@@ -48,7 +49,7 @@ export const fetchWikidataImage = async (
 
     return url || null
   } catch (error) {
-    console.error('Error fetching Wikidata image:', error)
+    logError('Error fetching Wikidata image', error)
     return null
   }
 }
@@ -96,7 +97,7 @@ export const fetchWikidataBrandMeta = async (
 
     return { logoUrl, description }
   } catch (error) {
-    console.error('Error fetching Wikidata brand meta:', error)
+    logError('Error fetching Wikidata brand meta', error)
     return { logoUrl: null, description: null }
   }
 }
@@ -134,7 +135,7 @@ export const fetchWikidataBrandLogo = async (
 
     return url || null
   } catch (error) {
-    console.error('Error fetching Wikidata brand logo:', error)
+    logError('Error fetching Wikidata brand logo', error)
     return null
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.5.1",
+  "version": "0.5.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.5.1"
+version = "0.5.2"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",


### PR DESCRIPTION
Patch release **0.5.2** (0.5.1 → 0.5.2). Merging to \`main\` auto-tags \`v0.5.2\` and runs the full release pipeline (server image + Tauri/Android/iOS + Google Play).

## Included
- **#331 — Axiom/OTel logging hardening:** `logError`/`logWarn` helpers (stdout + OTLP), uncaughtException/unhandledRejection handlers, app-level `onError` + startup errors routed to OTLP, ~170 `console.error` → `logError` sweep, and dynamic OTel exporters so saving the Axiom integration re-inits export without a restart.
- **#333 — `MARTIN_HOST` passthrough:** the compose `environment:` block now passes `MARTIN_HOST` to parchment-server so the barrelman tile proxy can reach Martin (the live host edit is already applied on vega7; this makes it durable).

## Release mechanics
- Version bumped in web/server `package.json`, `tauri.conf.json`, `Cargo.toml`; CHANGELOG.md + RELEASE_TITLE updated (same convention as 0.5.1).
- Cherry-picked onto `main` (which is ahead of `dev` on the 0.5.1 release + iOS/billing work). Compose cherry-pick auto-merged cleanly.

Note: `dev` still holds #331 (merged there) and #333 is open against `dev` — after this ships, `main` → `dev` sync will reconcile.