### PR TITLE
Clarify licensing: fix stale AGPL claim, add LICENSING.md

### DIFF
--- a/LICENSING.md
+++ b/LICENSING.md
@@ -1,0 +1,56 @@
+# License & commercial use
+
+Parchment is **source-available**. It is licensed under the **Apache License 2.0 with the
+Commons Clause** — see [LICENSE](LICENSE) for the full legal text.
+
+In one line:
+
+> **You can use Parchment for free — including inside your business — as long as you don't sell it.**
+
+This page is a plain-language summary of the intent. It is **not** a substitute for the
+[LICENSE](LICENSE), which is the binding legal agreement. If anything here conflicts with the
+LICENSE, the LICENSE controls.
+
+## What you can do
+
+- **Self-host it for yourself, family, or friends.** Run Parchment on your homelab or a personal
+  server, for free, for any non-commercial use.
+- **Run it inside your business.** Self-host Parchment to power your own company's internal
+  operations — for your employees, your own apps, or your own infrastructure.
+- **Fork and modify it.** Change the code, experiment, and build on it.
+- **Contribute back.** Fork it, improve it, and open a pull request.
+- **Fork it and use it for your business**, as long as you don't sell the software or a service
+  whose value is substantially just Parchment (see below).
+
+## What you can't do
+
+The Commons Clause removes exactly one right from the Apache 2.0 license: the right to **Sell** the
+software. "Sell" means charging a third party a fee for a product or service whose value comes
+**entirely or substantially from Parchment's functionality**. Concretely, you may not:
+
+- **Host Parchment as a paid online service** that others pay to use — especially one that competes
+  with the official hosted version.
+- **Sell a fork** of Parchment, modified or not, as a paid product or hosted service.
+- **Repackage or resell** Parchment (or a close derivative) as your commercial product.
+
+## Examples
+
+**Allowed**
+
+- You run Parchment on your homelab for you and your friends.
+- A company self-hosts Parchment internally so its team can use it — for free, on its own servers.
+- You fork Parchment, add a feature, and submit it upstream.
+- You fork Parchment and use it to help run your own business, without selling the software itself.
+
+**Not allowed**
+
+- You self-host Parchment and sell access to it as a subscription mapping service, competing with
+  the official hosted version.
+- You fork Parchment, rebrand it, and sell the modified version as a paid product or SaaS.
+- Anything substantially equivalent to the above — reselling Parchment's functionality to third
+  parties for a fee.
+
+## Want to sell or offer it commercially?
+
+If you'd like to offer Parchment (or a derivative) as a paid product or service, that needs a
+separate commercial license. Reach out to Alex Wohlbruck to discuss.

--- a/readme.md
+++ b/readme.md
@@ -32,5 +32,7 @@ Then open **http://localhost:3001/docs** (live site: **https://docs.parchment.ap
 
 ## License
 
-AGPL-3.0 — see [LICENSE](LICENSE). Free to self-host; cannot sell as a service without sharing source.
+Parchment is source-available under the **Apache License 2.0 with the Commons Clause** — see [LICENSE](LICENSE).
+
+In short: **free to self-host and use, including inside your business — but you may not sell it.** You can run it for yourself, your friends, or your company's internal use; fork it; and contribute back. You may not resell it, or host it as a paid service, where the value comes substantially from Parchment. See [LICENSING.md](LICENSING.md) for a plain-language explanation with examples.
 


### PR DESCRIPTION
Clarifies the licensing story and fixes a factual error in the README.

## Changes
- **Fix `readme.md`**: the License section claimed **AGPL-3.0**, but the actual `LICENSE` is **Apache 2.0 + Commons Clause** — which say opposite things about selling. Corrected to match `LICENSE`.
- **Add `LICENSING.md`**: a plain-language, non-binding summary of what you can and can't do, with concrete allowed / not-allowed examples. `LICENSE` remains the binding text — no legal text was changed.

## Intent
Free to self-host and use, **including internal business use**. You may **not** resell it, or host it as a paid service that competes with the official hosted version.