### PR TITLE
Add compass direction indicator to geo location marker

### DIFF
--- a/web/src/components/map/UserLocationMarker.vue
+++ b/web/src/components/map/UserLocationMarker.vue
@@ -94,13 +94,18 @@ const props = withDefaults(defineProps<Props>(), {
   position: absolute;
   left: 50%;
   top: 50%;
-  /* Anchor the cone's apex (bottom-centre of the SVG) at the dot centre. */
-  transform: translate(-50%, -100%);
+  /* Anchor the cone's apex (bottom-centre of the SVG) at the dot centre, then
+     scale horizontally by the layer-provided spread (wider = less certain
+     heading). scaleX pivots on the centreline, which passes through the apex,
+     so the cone stays anchored. */
+  transform: translate(-50%, -100%) scaleX(var(--beam-spread, 1));
+  /* Ease width changes as compass accuracy improves/degrades. */
+  transition: transform 0.3s ease;
   z-index: 0;
   /* Softens the cone edges into a diffuse beam. */
   filter: blur(2px);
   /* Toggled by the layer via setMarkerHeading; hidden until a heading is
-     known. No transition so recreating the marker never re-fades the beam. */
+     known. No opacity transition so recreating the marker never re-fades. */
   opacity: var(--heading-opacity, 0);
   pointer-events: none;
 }

--- a/web/src/components/map/UserLocationMarker.vue
+++ b/web/src/components/map/UserLocationMarker.vue
@@ -15,6 +15,27 @@ const props = withDefaults(defineProps<Props>(), {
     class="user-location-marker"
     :class="{ 'navigation-mode': props.mode === 'navigation' }"
   >
+    <!--
+      Compass direction beam (dot mode). Points "up" in the marker's local
+      frame; the map layer rotates the whole marker to the device heading via
+      MapLibre `setRotation` (rotationAlignment 'map'), so it stays
+      north-relative as the map turns. Hidden until a heading is available,
+      toggled by the `--heading-opacity` custom property the layer sets.
+    -->
+    <div v-if="props.mode === 'dot'" class="heading-beam">
+      <svg width="72" height="72" viewBox="0 0 72 72" xmlns="http://www.w3.org/2000/svg">
+        <defs>
+          <radialGradient id="user-heading-beam" cx="50%" cy="100%" r="100%">
+            <stop offset="0%" stop-color="hsl(var(--primary))" stop-opacity="0.5" />
+            <stop offset="55%" stop-color="hsl(var(--primary))" stop-opacity="0.18" />
+            <stop offset="100%" stop-color="hsl(var(--primary))" stop-opacity="0" />
+          </radialGradient>
+        </defs>
+        <!-- Cone with its apex at the dot centre (36,72), fanning upward. -->
+        <path d="M36 72 L6 12 Q36 2 66 12 Z" fill="url(#user-heading-beam)" />
+      </svg>
+    </div>
+
     <!-- Accuracy pulse ring (dot mode only) -->
     <div v-if="props.mode === 'dot'" class="accuracy-ring" />
 
@@ -67,6 +88,21 @@ const props = withDefaults(defineProps<Props>(), {
   border: 2.5px solid white;
   box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
   transition: transform 0.3s ease;
+}
+
+.heading-beam {
+  position: absolute;
+  left: 50%;
+  top: 50%;
+  /* Anchor the cone's apex (bottom-centre of the SVG) at the dot centre. */
+  transform: translate(-50%, -100%);
+  z-index: 0;
+  /* Softens the cone edges into a diffuse beam. */
+  filter: blur(2px);
+  /* Toggled by the layer via setMarkerHeading; hidden until a heading is
+     known. No transition so recreating the marker never re-fades the beam. */
+  opacity: var(--heading-opacity, 0);
+  pointer-events: none;
 }
 
 .accuracy-ring {

--- a/web/src/components/map/layers/base-marker-layer.ts
+++ b/web/src/components/map/layers/base-marker-layer.ts
@@ -58,9 +58,10 @@ export interface MapMarkerAPI {
    * Rotate an already-mounted marker to a compass heading (degrees clockwise
    * from north) without recreating it — used by the user-location beam. Pass
    * `null` to hide the heading cue. The marker is rotated in map space so the
-   * heading stays north-relative as the map turns.
+   * heading stays north-relative as the map turns. `spread` is a horizontal
+   * scale for the beam cone (wider = less certain heading); defaults to 1.
    */
-  setMarkerHeading(id: string, heading: number | null): void
+  setMarkerHeading(id: string, heading: number | null, spread?: number): void
 }
 
 /**

--- a/web/src/components/map/layers/base-marker-layer.ts
+++ b/web/src/components/map/layers/base-marker-layer.ts
@@ -54,6 +54,13 @@ export interface MapMarkerAPI {
    * friend-locations dead-reckoning) call this from their own rAF loop.
    */
   setMarkerLngLat(id: string, lngLat: LngLat): void
+  /**
+   * Rotate an already-mounted marker to a compass heading (degrees clockwise
+   * from north) without recreating it — used by the user-location beam. Pass
+   * `null` to hide the heading cue. The marker is rotated in map space so the
+   * heading stays north-relative as the map turns.
+   */
+  setMarkerHeading(id: string, heading: number | null): void
 }
 
 /**

--- a/web/src/components/map/layers/user-location-layer.ts
+++ b/web/src/components/map/layers/user-location-layer.ts
@@ -17,6 +17,7 @@ import {
   type MarkerData,
 } from './base-marker-layer'
 import { useGeolocationService } from '@/services/geolocation.service'
+import { useOrientationService } from '@/services/orientation.service'
 import {
   buildTrack,
   predict,
@@ -36,10 +37,19 @@ const POSITION_EPSILON_DEG = 0.0000005
 
 export class UserLocationLayer extends BaseMarkerLayer {
   private geolocation = useGeolocationService()
+  private orientation = useOrientationService()
 
   private track: Track | null = null
   private unregisterTick: (() => void) | null = null
   private samplesWatchStop: WatchStopHandle | null = null
+  private headingWatchStop: WatchStopHandle | null = null
+
+  /**
+   * Last heading pushed to the marker, and a dirty flag forcing a re-push
+   * after the marker is recreated (recreate resets rotation + beam opacity).
+   */
+  private lastHeadingApplied: number | null = null
+  private headingDirty = true
 
   /**
    * Last position pushed to maplibre. Lets the scheduler tick skip
@@ -67,6 +77,7 @@ export class UserLocationLayer extends BaseMarkerLayer {
   initialize(mapAPI: MapMarkerAPI) {
     super.initialize(mapAPI)
     this.startSampleWatcher()
+    this.startHeadingWatcher()
     this.unregisterTick = registerTick(this.tick)
   }
 
@@ -138,6 +149,49 @@ export class UserLocationLayer extends BaseMarkerLayer {
   }
 
   /**
+   * Watch the effective heading (device compass, falling back to GPS
+   * course-over-ground) and rotate the marker's direction beam in place.
+   * Rotation goes through `setMarkerHeading`, not a prop, so the marker
+   * isn't recreated on every heading change — that would restart the pulse
+   * animation and thrash the Vue instance.
+   */
+  private startHeadingWatcher() {
+    this.headingWatchStop = watch(
+      () => this.orientation.heading.value ?? this.geolocation.heading.value,
+      () => this.applyHeading(),
+      { immediate: true },
+    )
+  }
+
+  /**
+   * Push the current heading to the marker. Prefers the device compass (works
+   * while stationary); falls back to GPS course. `null` when neither is
+   * available, which hides the beam. Sub-degree changes are skipped unless the
+   * marker was just recreated (`headingDirty`).
+   */
+  private applyHeading = () => {
+    if (!this.mapAPI) return
+    const fullId = `${this.idPrefix}${MARKER_ID}`
+    if (!this.mapAPI.hasMarker(fullId)) return
+
+    const effective =
+      this.orientation.heading.value ?? this.geolocation.heading.value
+
+    if (
+      !this.headingDirty &&
+      effective != null &&
+      this.lastHeadingApplied != null &&
+      Math.abs(effective - this.lastHeadingApplied) < 1
+    ) {
+      return
+    }
+
+    this.mapAPI.setMarkerHeading(fullId, effective)
+    this.lastHeadingApplied = effective
+    this.headingDirty = false
+  }
+
+  /**
    * Per-frame work, called by the shared animation scheduler. Returns
    * `'active'` when the dot actually moved this frame so the scheduler
    * keeps ticking; `'idle'` otherwise so it can sleep.
@@ -170,9 +224,9 @@ export class UserLocationLayer extends BaseMarkerLayer {
    * one frame and snaps it to the raw sample before the next rAF
    * tick moves it to the predicted position.
    *
-   * Heading is bucketed to 5° so navigation-mode rotation still
-   * updates frequently enough to feel responsive without thrashing
-   * the Vue instance every sample.
+   * Heading is deliberately excluded from the recreate snapshot — the
+   * beam is rotated in place via `setMarkerHeading`, so heading changes
+   * never remount the marker (which would restart the pulse animation).
    */
   protected updateMarkers(data: MarkerData[]) {
     if (!this.mapAPI) return
@@ -204,6 +258,8 @@ export class UserLocationLayer extends BaseMarkerLayer {
       // last-rendered cache so the scheduler tick force-emits the
       // predicted position on the next frame.
       this.lastRendered = null
+      // Recreate also resets the beam rotation + opacity; force a re-push.
+      this.headingDirty = true
     }
 
     for (const oldId of this.currentMarkerIds) {
@@ -216,13 +272,16 @@ export class UserLocationLayer extends BaseMarkerLayer {
       this.lastRendered = null
     }
     this.currentMarkerIds = newMarkerIds
-    if (data.length > 0) requestTick()
+    if (data.length > 0) {
+      requestTick()
+      // Re-apply the beam heading to the (possibly freshly created) marker.
+      this.applyHeading()
+    }
   }
 
   private snapshotProps(markerData: MarkerData): string {
     const p = markerData.props as {
       accuracy?: number | null
-      heading?: number | null
       mode?: 'dot' | 'navigation'
     }
     return [
@@ -230,10 +289,6 @@ export class UserLocationLayer extends BaseMarkerLayer {
       // 5m accuracy buckets — the pulse ring is roughly that resolution
       // visually, so finer grain wouldn't change anything on screen.
       p.accuracy != null ? Math.floor(p.accuracy / 5) : 'na',
-      // 5° heading buckets — fine enough for the navigation arrow not
-      // to look snappy, coarse enough to skip recreates on tiny GPS
-      // heading wobble.
-      p.heading != null ? Math.round(p.heading / 5) : 'na',
     ].join('|')
   }
 
@@ -242,6 +297,8 @@ export class UserLocationLayer extends BaseMarkerLayer {
     this.unregisterTick = null
     this.samplesWatchStop?.()
     this.samplesWatchStop = null
+    this.headingWatchStop?.()
+    this.headingWatchStop = null
     this.track = null
     this.lastSnapshot = null
     this.lastRendered = null

--- a/web/src/components/map/layers/user-location-layer.ts
+++ b/web/src/components/map/layers/user-location-layer.ts
@@ -35,6 +35,33 @@ const MARKER_ID = 'self'
 // See friend-locations-layer.ts for the rationale on this threshold.
 const POSITION_EPSILON_DEG = 0.0000005
 
+// Beam cone horizontal scale by heading confidence. 1 is the SVG's native
+// ~53° cone; tighter when the compass is confident, wider when it's unsure.
+const BEAM_SPREAD_DEFAULT = 1
+const BEAM_SPREAD_MIN = 0.55 // ~30° cone (confident)
+const BEAM_SPREAD_MAX = 2.4 // ~100° cone (uncalibrated / poor)
+
+// iOS `webkitCompassAccuracy` deviation range mapped onto the spread range.
+const ACCURACY_TIGHT_DEG = 10
+const ACCURACY_LOOSE_DEG = 60
+
+/**
+ * Map a heading-accuracy reading (degrees of uncertainty) to a beam spread.
+ * `null` means the platform gave no accuracy signal → default width; a
+ * negative value is iOS's "uncalibrated" flag → widest.
+ */
+function spreadFromAccuracy(accuracy: number | null): number {
+  if (accuracy == null) return BEAM_SPREAD_DEFAULT
+  if (accuracy < 0) return BEAM_SPREAD_MAX
+  const clamped = Math.min(
+    Math.max(accuracy, ACCURACY_TIGHT_DEG),
+    ACCURACY_LOOSE_DEG,
+  )
+  const t =
+    (clamped - ACCURACY_TIGHT_DEG) / (ACCURACY_LOOSE_DEG - ACCURACY_TIGHT_DEG)
+  return BEAM_SPREAD_MIN + t * (BEAM_SPREAD_MAX - BEAM_SPREAD_MIN)
+}
+
 export class UserLocationLayer extends BaseMarkerLayer {
   private geolocation = useGeolocationService()
   private orientation = useOrientationService()
@@ -45,10 +72,12 @@ export class UserLocationLayer extends BaseMarkerLayer {
   private headingWatchStop: WatchStopHandle | null = null
 
   /**
-   * Last heading pushed to the marker, and a dirty flag forcing a re-push
-   * after the marker is recreated (recreate resets rotation + beam opacity).
+   * Last heading + beam spread pushed to the marker, and a dirty flag forcing
+   * a re-push after the marker is recreated (recreate resets rotation, spread
+   * and beam opacity).
    */
   private lastHeadingApplied: number | null = null
+  private lastSpreadApplied = BEAM_SPREAD_DEFAULT
   private headingDirty = true
 
   /**
@@ -157,37 +186,48 @@ export class UserLocationLayer extends BaseMarkerLayer {
    */
   private startHeadingWatcher() {
     this.headingWatchStop = watch(
-      () => this.orientation.heading.value ?? this.geolocation.heading.value,
+      () => [
+        this.orientation.heading.value,
+        this.orientation.headingAccuracy.value,
+        this.geolocation.heading.value,
+      ],
       () => this.applyHeading(),
       { immediate: true },
     )
   }
 
   /**
-   * Push the current heading to the marker. Prefers the device compass (works
-   * while stationary); falls back to GPS course. `null` when neither is
-   * available, which hides the beam. Sub-degree changes are skipped unless the
-   * marker was just recreated (`headingDirty`).
+   * Push the current heading + beam width to the marker. Prefers the device
+   * compass (works while stationary); falls back to GPS course. `null` when
+   * neither is available, which hides the beam. The beam widens as the
+   * compass accuracy degrades (iOS only; a default width elsewhere). Skips
+   * redundant updates unless the marker was just recreated (`headingDirty`).
    */
   private applyHeading = () => {
     if (!this.mapAPI) return
     const fullId = `${this.idPrefix}${MARKER_ID}`
     if (!this.mapAPI.hasMarker(fullId)) return
 
-    const effective =
-      this.orientation.heading.value ?? this.geolocation.heading.value
+    const compass = this.orientation.heading.value
+    const effective = compass ?? this.geolocation.heading.value
+    // Accuracy only pairs with the compass source; GPS course carries none.
+    const accuracy =
+      compass != null ? this.orientation.headingAccuracy.value : null
+    const spread = spreadFromAccuracy(accuracy)
 
-    if (
-      !this.headingDirty &&
+    const headingSettled =
       effective != null &&
       this.lastHeadingApplied != null &&
       Math.abs(effective - this.lastHeadingApplied) < 1
-    ) {
+    const spreadSettled = Math.abs(spread - this.lastSpreadApplied) < 0.02
+
+    if (!this.headingDirty && headingSettled && spreadSettled) {
       return
     }
 
-    this.mapAPI.setMarkerHeading(fullId, effective)
+    this.mapAPI.setMarkerHeading(fullId, effective, spread)
     this.lastHeadingApplied = effective
+    this.lastSpreadApplied = spread
     this.headingDirty = false
   }
 

--- a/web/src/components/map/map-providers/map.strategy.ts
+++ b/web/src/components/map/map-providers/map.strategy.ts
@@ -206,6 +206,34 @@ export class MapStrategy {
     }
   }
 
+  /**
+   * Rotate an existing marker to a compass heading without recreating it, and
+   * toggle the `--heading-opacity` cue its element uses to show/hide the beam.
+   * The marker is switched to `rotationAlignment: 'map'` so the heading stays
+   * north-relative as the map rotates (pitch stays viewport-flat so the dot
+   * doesn't distort when the map is tilted). `null` hides the beam.
+   */
+  setMarkerHeading(id: string, heading: number | null) {
+    const marker = this.markers.get(id)
+    if (!marker || typeof marker.setRotation !== 'function') return
+
+    const element = marker.getElement?.()
+
+    if (heading === null || Number.isNaN(heading)) {
+      element?.style.setProperty('--heading-opacity', '0')
+      return
+    }
+
+    if (typeof marker.setRotationAlignment === 'function') {
+      marker.setRotationAlignment('map')
+    }
+    if (typeof marker.setPitchAlignment === 'function') {
+      marker.setPitchAlignment('viewport')
+    }
+    marker.setRotation(heading)
+    element?.style.setProperty('--heading-opacity', '1')
+  }
+
   removeAllMarkers() {
     this.markers.forEach(marker => {
       if (marker.getElement) {

--- a/web/src/components/map/map-providers/map.strategy.ts
+++ b/web/src/components/map/map-providers/map.strategy.ts
@@ -213,7 +213,7 @@ export class MapStrategy {
    * north-relative as the map rotates (pitch stays viewport-flat so the dot
    * doesn't distort when the map is tilted). `null` hides the beam.
    */
-  setMarkerHeading(id: string, heading: number | null) {
+  setMarkerHeading(id: string, heading: number | null, spread = 1) {
     const marker = this.markers.get(id)
     if (!marker || typeof marker.setRotation !== 'function') return
 
@@ -231,6 +231,7 @@ export class MapStrategy {
       marker.setPitchAlignment('viewport')
     }
     marker.setRotation(heading)
+    element?.style.setProperty('--beam-spread', String(spread))
     element?.style.setProperty('--heading-opacity', '1')
   }
 

--- a/web/src/services/layers/markers/marker-layers.service.ts
+++ b/web/src/services/layers/markers/marker-layers.service.ts
@@ -88,8 +88,8 @@ export function useMarkerLayersService() {
       hasMarker: (id: string) => mapStrategy?.hasMarker(id) ?? false,
       setMarkerLngLat: (id: string, lngLat: LngLat) =>
         mapStrategy?.setMarkerLngLat(id, lngLat),
-      setMarkerHeading: (id: string, heading: number | null) =>
-        mapStrategy?.setMarkerHeading(id, heading),
+      setMarkerHeading: (id: string, heading: number | null, spread?: number) =>
+        mapStrategy?.setMarkerHeading(id, heading, spread),
     }
 
     waypointsLayer.initialize(markerAPI)

--- a/web/src/services/layers/markers/marker-layers.service.ts
+++ b/web/src/services/layers/markers/marker-layers.service.ts
@@ -88,6 +88,8 @@ export function useMarkerLayersService() {
       hasMarker: (id: string) => mapStrategy?.hasMarker(id) ?? false,
       setMarkerLngLat: (id: string, lngLat: LngLat) =>
         mapStrategy?.setMarkerLngLat(id, lngLat),
+      setMarkerHeading: (id: string, heading: number | null) =>
+        mapStrategy?.setMarkerHeading(id, heading),
     }
 
     waypointsLayer.initialize(markerAPI)

--- a/web/src/services/map.service.ts
+++ b/web/src/services/map.service.ts
@@ -50,6 +50,7 @@ import { useRouter } from 'vue-router'
 import { ref, toRaw, watch, computed, Component } from 'vue'
 import { storedLocale } from '@/lib/i18n'
 import { useGeolocationService } from '@/services/geolocation.service'
+import { useOrientationService } from '@/services/orientation.service'
 import { useSearchStore } from '@/stores/search.store'
 import { api } from '@/lib/api'
 import { useAuthService } from '@/services/auth.service'
@@ -409,6 +410,9 @@ function mapService() {
 
   function locateUser() {
     const geo = useGeolocationService()
+    // Called from the locate button — a user gesture — so this is our chance
+    // to prompt for compass access on iOS, which powers the direction beam.
+    void useOrientationService().requestPermission()
     const speed = mapStore.settings.locateFlySpeed ?? LocateFlySpeed.NORMAL
     const duration = LOCATE_FLY_DURATIONS[speed]
 

--- a/web/src/services/orientation.service.ts
+++ b/web/src/services/orientation.service.ts
@@ -46,6 +46,11 @@ function screenAngle(): number {
 
 function orientationService() {
   const heading = ref<number | null>(null)
+  // Heading uncertainty in degrees, as reported by iOS `webkitCompassAccuracy`
+  // (lower = more confident, negative = uncalibrated). `null` where the
+  // platform gives no accuracy signal (Chrome/Android), so callers can fall
+  // back to a default beam width.
+  const headingAccuracy = ref<number | null>(null)
   const permissionState = ref<OrientationPermissionState>('prompt')
   let listening = false
 
@@ -61,6 +66,10 @@ function orientationService() {
       !Number.isNaN(e.webkitCompassHeading)
     ) {
       heading.value = e.webkitCompassHeading
+      headingAccuracy.value =
+        typeof e.webkitCompassAccuracy === 'number'
+          ? e.webkitCompassAccuracy
+          : null
       return
     }
 
@@ -69,6 +78,8 @@ function orientationService() {
     // heading is its complement, offset by the current screen rotation.
     if (e.absolute && e.alpha != null) {
       heading.value = (360 - e.alpha + screenAngle() + 360) % 360
+      // The DeviceOrientation API carries no heading-accuracy on this path.
+      headingAccuracy.value = null
     }
   }
 
@@ -150,6 +161,7 @@ function orientationService() {
 
   return {
     heading: readonly(heading),
+    headingAccuracy: readonly(headingAccuracy),
     permissionState: readonly(permissionState),
     isSupported,
     requestPermission,

--- a/web/src/services/orientation.service.ts
+++ b/web/src/services/orientation.service.ts
@@ -1,0 +1,160 @@
+/**
+ * Device Orientation (Compass) Service
+ *
+ * Reactive device compass heading, used to draw the direction beam on the
+ * user-location marker. Reads the magnetometer via DeviceOrientation events:
+ *
+ *  - iOS Safari exposes `webkitCompassHeading` (degrees clockwise from true
+ *    north) and gates the sensor behind a permission prompt that must be
+ *    requested from a user gesture — see `requestPermission()`.
+ *  - Chrome / Android deliver an earth-referenced frame via the
+ *    `deviceorientationabsolute` event; heading is derived from `alpha` and
+ *    corrected for the current screen rotation.
+ *
+ * `heading` stays null until a real reading arrives and on platforms with no
+ * magnetometer (most desktops), so callers can hide the beam when it's
+ * unavailable.
+ */
+
+import { createSharedComposable } from '@vueuse/core'
+import { readonly, ref } from 'vue'
+
+export type OrientationPermissionState =
+  | 'granted'
+  | 'denied'
+  | 'prompt'
+  | 'unsupported'
+
+// iOS exposes compass fields on the event and a static permission gate.
+interface DeviceOrientationEventiOS extends DeviceOrientationEvent {
+  webkitCompassHeading?: number
+  webkitCompassAccuracy?: number
+}
+type DeviceOrientationEventiOSConstructor = typeof DeviceOrientationEvent & {
+  requestPermission?: () => Promise<'granted' | 'denied'>
+}
+
+/** Current screen rotation in degrees (0 in portrait, 90/270 in landscape). */
+function screenAngle(): number {
+  const orientation = window.screen?.orientation
+  if (orientation && typeof orientation.angle === 'number') {
+    return orientation.angle
+  }
+  // Legacy Safari fallback.
+  return (window as unknown as { orientation?: number }).orientation ?? 0
+}
+
+function orientationService() {
+  const heading = ref<number | null>(null)
+  const permissionState = ref<OrientationPermissionState>('prompt')
+  let listening = false
+
+  const isSupported =
+    typeof window !== 'undefined' && 'DeviceOrientationEvent' in window
+
+  function handleEvent(event: DeviceOrientationEvent) {
+    const e = event as DeviceOrientationEventiOS
+
+    // iOS: compass heading is provided directly (deg clockwise from north).
+    if (
+      typeof e.webkitCompassHeading === 'number' &&
+      !Number.isNaN(e.webkitCompassHeading)
+    ) {
+      heading.value = e.webkitCompassHeading
+      return
+    }
+
+    // Others: derive from the absolute frame. `alpha` is degrees
+    // counter-clockwise from north around the vertical axis; the compass
+    // heading is its complement, offset by the current screen rotation.
+    if (e.absolute && e.alpha != null) {
+      heading.value = (360 - e.alpha + screenAngle() + 360) % 360
+    }
+  }
+
+  function start() {
+    if (listening || !isSupported) return
+    listening = true
+    // `deviceorientationabsolute` carries an earth-referenced frame on
+    // Chrome / Android; iOS fires plain `deviceorientation` with
+    // `webkitCompassHeading`. Listen for both.
+    window.addEventListener(
+      'deviceorientationabsolute',
+      handleEvent as EventListener,
+      true,
+    )
+    window.addEventListener(
+      'deviceorientation',
+      handleEvent as EventListener,
+      true,
+    )
+  }
+
+  function stop() {
+    if (!listening) return
+    listening = false
+    window.removeEventListener(
+      'deviceorientationabsolute',
+      handleEvent as EventListener,
+      true,
+    )
+    window.removeEventListener(
+      'deviceorientation',
+      handleEvent as EventListener,
+      true,
+    )
+  }
+
+  /**
+   * Request compass access. On iOS this must be called from a user gesture
+   * (e.g. the locate button) or the browser rejects it. Elsewhere there is no
+   * permission model, so this just starts listening.
+   */
+  async function requestPermission(): Promise<OrientationPermissionState> {
+    if (!isSupported) {
+      permissionState.value = 'unsupported'
+      return permissionState.value
+    }
+
+    const DeviceOrientation =
+      window.DeviceOrientationEvent as DeviceOrientationEventiOSConstructor
+
+    if (typeof DeviceOrientation.requestPermission === 'function') {
+      try {
+        const result = await DeviceOrientation.requestPermission()
+        permissionState.value = result === 'granted' ? 'granted' : 'denied'
+        if (result === 'granted') start()
+      } catch {
+        // Thrown when not called from a user gesture — leave as prompt so a
+        // later gesture can retry.
+        permissionState.value = 'prompt'
+      }
+    } else {
+      permissionState.value = 'granted'
+      start()
+    }
+
+    return permissionState.value
+  }
+
+  // Platforms without an iOS-style permission gate can listen immediately.
+  if (isSupported) {
+    const DeviceOrientation =
+      window.DeviceOrientationEvent as DeviceOrientationEventiOSConstructor
+    if (typeof DeviceOrientation.requestPermission !== 'function') {
+      start()
+    }
+  } else {
+    permissionState.value = 'unsupported'
+  }
+
+  return {
+    heading: readonly(heading),
+    permissionState: readonly(permissionState),
+    isSupported,
+    requestPermission,
+    stop,
+  }
+}
+
+export const useOrientationService = createSharedComposable(orientationService)


### PR DESCRIPTION
Adds an Apple/Google Maps–style compass beam to the user-location "blue dot" — a soft directional cone that points where the device is facing, rotates with the compass, and **fans wider when the heading is less certain**.

Closes #336 (PAR-275).

## What changed
- **`orientation.service.ts` (new)** — shared reactive device-compass service. Uses `webkitCompassHeading` on iOS (with the `DeviceOrientationEvent.requestPermission()` gate) and the `deviceorientationabsolute` frame on Chrome/Android, correcting for screen rotation. Also exposes `headingAccuracy` (from iOS `webkitCompassAccuracy`; `null` where no signal). `heading` stays `null` when no magnetometer is present (most desktops), so the beam simply doesn't show there.
- **`setMarkerHeading` marker API** — rotates a marker in place via MapLibre `setRotation` with `rotationAlignment: 'map'`, so the beam stays north-relative as the map turns; `pitchAlignment: 'viewport'` keeps the dot from distorting when tilted. No marker recreate, so the accuracy pulse doesn't restart. Takes a `spread` (horizontal cone scale).
- **`UserLocationMarker.vue`** — new gradient cone beam behind the dot, faded via a `--heading-opacity` cue and scaled via a `--beam-spread` cue the layer sets.
- **`user-location-layer.ts`** — watches the effective heading (device compass, falling back to GPS course-over-ground) and its accuracy, and pushes both to the marker; heading dropped from the recreate snapshot so rotation happens in place. Accuracy → spread: tight (~30° cone) when confident, wide (~100°) when uncalibrated, default (~53°) where no accuracy signal exists.
- **`map.service.ts`** — requests compass permission from the locate button tap (iOS requires a user gesture).

## Notes
- Beam appears only when a heading is available: mobile with compass access, or moving (GPS course). Desktop shows the dot as before.
- Accuracy-driven width is iOS-accurate (`webkitCompassAccuracy`); Android/Chrome and the GPS-course fallback have no heading-accuracy signal, so they use the default width.
- iOS shows a one-time motion-sensor prompt the first time the locate button is tapped.
- Branch is based on a local `main` that was ~8 commits behind `origin/main`; merge-base is clean so the PR diff is just these commits, but a rebase before merge is fine.

## Testing
- `vue-tsc --noEmit` passes; pre-commit test suite passed on each commit.
- Not yet verified live on a physical device — the beam rotation/width/permission flow should be smoke-tested on an actual phone (compass isn't available in the desktop preview).