### PR TITLE
Grant alpha role all premium features plus read-only admin access

### DIFF
--- a/server/src/seed/roles.ts
+++ b/server/src/seed/roles.ts
@@ -64,13 +64,19 @@ const alpha: Role = {
   id: 'alpha',
   name: 'Alpha tester',
   description:
-    'A privileged user that is able to read all data in the app, but has limited write permissions',
+    'A privileged tester with every premium feature plus read-only, non-destructive access to admin data (users, roles, permissions, system integrations, and system status). Cannot make admin changes or view integration secrets.',
   permissions: [
-    ...(basic.permissions as PermissionId[]),
+    // Every premium feature (inherits the basic + premium permission sets)
+    ...(premium.permissions as PermissionId[]),
+    // Read-only, non-destructive admin access. Deliberately excludes every
+    // write/create/delete admin permission and INTEGRATIONS_WRITE_SYSTEM —
+    // system-integration secrets are only returned on the write path, so
+    // read-system alone never exposes them.
+    PermissionId.USERS_READ,
+    PermissionId.ROLES_READ,
+    PermissionId.PERMISSIONS_READ,
     PermissionId.INTEGRATIONS_READ_SYSTEM,
     PermissionId.SYSTEM_READ,
-    PermissionId.LAYERS_DELETE,
-    PermissionId.SEARCH_AUTO_REFRESH,
   ],
 }
 


### PR DESCRIPTION
## What

Brings the `alpha` role in line with its intended scope: **every premium feature** plus **read-only, non-destructive admin access**.

Before, the `alpha` role inherited only the `basic` permission set (plus `LAYERS_DELETE` / `SEARCH_AUTO_REFRESH`), so alpha testers had **no** premium features (missing all five `PREMIUM_*` permissions) and **could not view users** (missing `USERS_READ` / `ROLES_READ` / `PERMISSIONS_READ` — the Users admin page nav gate needs one of these).

## Changes

`server/src/seed/roles.ts` — the `alpha` role now grants:

- **Every premium feature** — inherits `premium.permissions` instead of `basic.permissions`, adding all five `PREMIUM_*` perms (`PREMIUM_LAYERS` → Mapbox engine, `PREMIUM_DATA_PROVIDERS` → premium place data, plus custom maps / navigation / location sharing). `LAYERS_DELETE` and `SEARCH_AUTO_REFRESH` are retained (both are part of `premium`).
- **Read-only admin** — adds `USERS_READ`, `ROLES_READ`, `PERMISSIONS_READ`; keeps `INTEGRATIONS_READ_SYSTEM` and `SYSTEM_READ`.
- **Nothing destructive** — no `*_CREATE/UPDATE/DELETE`, no `ROLES_WRITE`, no `INTEGRATIONS_WRITE_SYSTEM`.

## Secrets stay protected

`INTEGRATIONS_READ_SYSTEM` only reaches `GET /integrations/configured` and `/available`, which return `extractPublicConfig()` output — a strict whitelist of each definition's `publicFields`. The only endpoint returning full config with secrets (`GET /integrations/:id`) requires **write** permission, which alpha does not have. So alpha can see that system integrations exist and their public fields, but never their secret keys.

## Notes

- Billing settings will still display an alpha user as `free` tier — tier is derived from the `basic`/`premium` role, not permissions. This is cosmetic only; frontend feature access is permission-based, and upgrade banners only render when a permission is missing, so alpha sees no upsell prompts.
- `USERS_READ` also gates `GET /users/:id/billing` (a user's Polar billing summary). Read-only, but slightly more sensitive; included since it's consistent with "viewing users" and there's no finer-grained permission.

## Applying

Takes effect after the server re-seeds via `syncPermissionsAndRoles()` on boot (or `bun seed`). Existing alpha users pick up the new permissions on their next permissions fetch.