### PR TITLE
Let alpha testers invite users (invite-only, no escalation)

### DIFF
--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -9,7 +9,7 @@ import { permissions as permissionsSchema } from '../schema/permissions.schema'
 import { roleToPermissions } from '../schema/roles-permissions.schema'
 import { lucia } from '../lucia'
 import { generateId } from '../util'
-import { getRoles } from '../services/auth.service'
+import { getRoles, getPermissions, hasPermission } from '../services/auth.service'
 import { sendMail } from '../services/mailer.service'
 import { clientOrigin } from '../config/origins.config'
 import { permissions, requireAuth } from '../middleware/auth.middleware'
@@ -133,9 +133,26 @@ app.group('', (admin) =>
     .use(permissions(PermissionId.USERS_CREATE))
     .post(
       '/',
-      async ({ body, status }) => {
-        // Validate roles exist
+      async ({ body, user, status }) => {
         const roleIds = body.roles?.length ? body.roles : ['user']
+
+        // Assigning roles other than the default 'user' is a privileged action:
+        // it can provision elevated accounts (e.g. admin). Gate it on
+        // USERS_UPDATE (the "role assignments" permission) so an invite-only
+        // caller such as an alpha tester can create plain users but cannot
+        // escalate by inviting a privileged account.
+        const assignsPrivilegedRole =
+          roleIds.length !== 1 || roleIds[0] !== 'user'
+        if (assignsPrivilegedRole) {
+          const callerPermissions = await getPermissions(user.id)
+          if (!hasPermission(callerPermissions, PermissionId.USERS_UPDATE)) {
+            return status(403, {
+              message: 'You do not have permission to assign roles to invited users',
+            })
+          }
+        }
+
+        // Validate roles exist
         const existingRoles = await db
           .select({ id: roles.id })
           .from(roles)

--- a/server/src/seed/roles.ts
+++ b/server/src/seed/roles.ts
@@ -64,12 +64,12 @@ const alpha: Role = {
   id: 'alpha',
   name: 'Alpha tester',
   description:
-    'A privileged tester with every premium feature plus read-only, non-destructive access to admin data (users, roles, permissions, system integrations, and system status). Cannot make admin changes or view integration secrets.',
+    'A privileged tester with every premium feature plus read-only admin access to users, roles, permissions, system integrations, and system status. Can invite new users, but cannot edit or remove them, assign elevated roles, or view integration secrets.',
   permissions: [
     // Every premium feature (inherits the basic + premium permission sets)
     ...(premium.permissions as PermissionId[]),
-    // Read-only, non-destructive admin access. Deliberately excludes every
-    // write/create/delete admin permission and INTEGRATIONS_WRITE_SYSTEM —
+    // Read-only admin access. Deliberately excludes USERS_UPDATE/USERS_DELETE,
+    // every ROLES write permission, and INTEGRATIONS_WRITE_SYSTEM —
     // system-integration secrets are only returned on the write path, so
     // read-system alone never exposes them.
     PermissionId.USERS_READ,
@@ -77,6 +77,10 @@ const alpha: Role = {
     PermissionId.PERMISSIONS_READ,
     PermissionId.INTEGRATIONS_READ_SYSTEM,
     PermissionId.SYSTEM_READ,
+    // Invite-only user creation. Assigning roles on invite additionally
+    // requires USERS_UPDATE (see the invite endpoint), which alpha lacks — so
+    // alpha can only invite plain users, never provision elevated accounts.
+    PermissionId.USERS_CREATE,
   ],
 }
 

--- a/web/src/components/admin/InviteUserForm.vue
+++ b/web/src/components/admin/InviteUserForm.vue
@@ -3,7 +3,8 @@ import { ref, computed } from 'vue'
 import { useForm } from 'vee-validate'
 import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
-import type { Role } from '@/types/auth.types'
+import { type Role, PermissionId } from '@/types/auth.types'
+import { useAuthService } from '@/services/auth.service'
 
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
@@ -34,6 +35,15 @@ const { validate } = useForm({
   },
 })
 
+const authService = useAuthService()
+
+// Assigning roles on invite is a privileged action gated server-side by
+// USERS_UPDATE. Invite-only callers (e.g. alpha testers) can only create
+// plain users, so hide the picker and default them to the 'user' role.
+const canAssignRoles = computed(() =>
+  authService.hasPermission(PermissionId.USERS_UPDATE),
+)
+
 const selectedRoles = ref<string[]>(['user'])
 const searchTerm = ref('')
 const open = ref(false)
@@ -55,7 +65,7 @@ defineExpose({
     if (!valid) return false
     return {
       ...values,
-      roles: selectedRoles.value,
+      roles: canAssignRoles.value ? selectedRoles.value : ['user'],
     }
   },
 })
@@ -73,7 +83,7 @@ defineExpose({
       </FormItem>
     </FormField>
 
-    <div>
+    <div v-if="canAssignRoles">
       <p class="text-sm font-medium mb-2">Roles</p>
       <Combobox v-model="selectedRoles" v-model:open="open" v-model:search-term="searchTerm" multiple open-on-focus>
         <ComboboxAnchor as-child>


### PR DESCRIPTION
Adds `USERS_CREATE` to the **alpha** role so alpha testers can invite new users, while keeping them unable to edit, remove, or otherwise elevate users.

## Why this needed a guard
`POST /users/` (invite) was gated only by `USERS_CREATE`, but it assigns **whatever roles the request body specifies** — validating only that the role IDs exist, not that the caller may grant them. Granting alpha `USERS_CREATE` as-is would let an alpha tester invite a user with `roles: ['admin']` and escalate to full admin. That contradicts the "not able to otherwise modify users" intent.

## Changes
- **`seed/roles.ts`** — alpha gains `PermissionId.USERS_CREATE` (invite only). Still no `USERS_UPDATE`/`USERS_DELETE`/`ROLES_*` write.
- **`user.controller.ts`** — the invite endpoint now requires `USERS_UPDATE` to assign any role other than the default `user`; otherwise it returns 403. So invite-only callers (alpha) can create plain users but never provision elevated accounts. Admins (who have `USERS_UPDATE`) are unaffected. This also hardens the endpoint against any future invite-capable role.
- **`InviteUserForm.vue`** — hides the role picker and defaults to `['user']` when the caller lacks `USERS_UPDATE`, so alpha doesn't see an option that would 403.

## Verification
- Server `tsc --noEmit`: no new errors from these files (the 4 pre-existing user.controller.ts errors just shift by the added lines).
- `vue-tsc`: InviteUserForm.vue clean.

Net effect for alpha: can invite plain users; cannot edit/remove users, assign roles, or create privileged accounts.