### PR TITLE
Let alpha testers invite other alpha testers

### DIFF
--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -21,6 +21,7 @@ import {
   rpID,
   sendEmailVerificationCode,
   getPermissions,
+  getRoles,
 } from '../services/auth.service'
 import {
   fetchUser,
@@ -561,13 +562,14 @@ app.group('/sessions', (app) => {
   app.use(requireAuth).get(
     'current/permissions',
     async ({ user }) => {
-      const [permissions, subscription] = await Promise.all([
+      const [permissions, subscription, userRoles] = await Promise.all([
         getPermissions(user.id),
         billing.enabled
           ? getSubscriptionStatus(user.id)
           : { isPremium: true, isBasic: false, hasSubscription: false, tier: 'premium' as const },
+        getRoles(user.id),
       ])
-      return { permissions, subscription }
+      return { permissions, subscription, roles: userRoles.map((r) => r.id) }
     },
     {
       detail: {

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -136,18 +136,19 @@ app.group('', (admin) =>
       async ({ body, user, status }) => {
         const roleIds = body.roles?.length ? body.roles : ['user']
 
-        // Assigning roles other than the default 'user' is a privileged action:
-        // it can provision elevated accounts (e.g. admin). Gate it on
-        // USERS_UPDATE (the "role assignments" permission) so an invite-only
-        // caller such as an alpha tester can create plain users but cannot
-        // escalate by inviting a privileged account.
-        const assignsPrivilegedRole =
-          roleIds.length !== 1 || roleIds[0] !== 'user'
-        if (assignsPrivilegedRole) {
-          const callerPermissions = await getPermissions(user.id)
-          if (!hasPermission(callerPermissions, PermissionId.USERS_UPDATE)) {
+        // Assigning roles on invite is privileged. Callers with USERS_UPDATE
+        // (the "role assignments" permission, e.g. admins) may assign any role.
+        // Everyone else may only assign the default 'user' role plus roles they
+        // themselves hold — so an alpha tester can invite other alpha testers,
+        // but no one can grant a role above their own (no privilege escalation).
+        const callerPermissions = await getPermissions(user.id)
+        if (!hasPermission(callerPermissions, PermissionId.USERS_UPDATE)) {
+          const ownRoleIds = (await getRoles(user.id)).map((r) => r.id)
+          const grantable = new Set(['user', ...ownRoleIds])
+          const disallowed = roleIds.filter((r) => !grantable.has(r))
+          if (disallowed.length) {
             return status(403, {
-              message: 'You do not have permission to assign roles to invited users',
+              message: 'You can only invite users with your own roles',
             })
           }
         }

--- a/server/src/seed/roles.ts
+++ b/server/src/seed/roles.ts
@@ -64,7 +64,7 @@ const alpha: Role = {
   id: 'alpha',
   name: 'Alpha tester',
   description:
-    'A privileged tester with every premium feature plus read-only admin access to users, roles, permissions, system integrations, and system status. Can invite new users, but cannot edit or remove them, assign elevated roles, or view integration secrets.',
+    'A privileged tester with every premium feature plus read-only admin access to users, roles, permissions, system integrations, and system status. Can invite new users (including other alpha testers), but cannot edit or remove them, grant a role above their own, or view integration secrets.',
   permissions: [
     // Every premium feature (inherits the basic + premium permission sets)
     ...(premium.permissions as PermissionId[]),
@@ -77,9 +77,10 @@ const alpha: Role = {
     PermissionId.PERMISSIONS_READ,
     PermissionId.INTEGRATIONS_READ_SYSTEM,
     PermissionId.SYSTEM_READ,
-    // Invite-only user creation. Assigning roles on invite additionally
-    // requires USERS_UPDATE (see the invite endpoint), which alpha lacks — so
-    // alpha can only invite plain users, never provision elevated accounts.
+    // Invite-only user creation. The invite endpoint lets a caller without
+    // USERS_UPDATE grant only the default 'user' role plus roles they hold —
+    // so alpha can invite plain users and other alpha testers, but never an
+    // elevated account like admin.
     PermissionId.USERS_CREATE,
   ],
 }

--- a/web/src/components/admin/InviteUserForm.vue
+++ b/web/src/components/admin/InviteUserForm.vue
@@ -5,6 +5,7 @@ import { toTypedSchema } from '@vee-validate/zod'
 import { z } from 'zod'
 import { type Role, PermissionId } from '@/types/auth.types'
 import { useAuthService } from '@/services/auth.service'
+import { useAuthStore } from '@/stores/auth.store'
 
 import { FormField, FormItem, FormLabel, FormControl, FormMessage } from '@/components/ui/form'
 import { Input } from '@/components/ui/input'
@@ -36,12 +37,21 @@ const { validate } = useForm({
 })
 
 const authService = useAuthService()
+const authStore = useAuthStore()
 
-// Assigning roles on invite is a privileged action gated server-side by
-// USERS_UPDATE. Invite-only callers (e.g. alpha testers) can only create
-// plain users, so hide the picker and default them to the 'user' role.
-const canAssignRoles = computed(() =>
+// Role assignment on invite is gated server-side: callers with USERS_UPDATE
+// (admins) may grant any role; everyone else may grant only the default 'user'
+// role plus roles they themselves hold. Mirror that here so the picker offers
+// exactly the assignable roles — letting an alpha tester invite other alphas.
+const canAssignAnyRole = computed(() =>
   authService.hasPermission(PermissionId.USERS_UPDATE),
+)
+const grantableRoleIds = computed(() =>
+  canAssignAnyRole.value ? null : new Set(['user', ...authStore.roles]),
+)
+// Only worth showing the picker when there's a non-default role to choose.
+const showRolePicker = computed(
+  () => canAssignAnyRole.value || authStore.roles.some(r => r !== 'user'),
 )
 
 const selectedRoles = ref<string[]>(['user'])
@@ -51,7 +61,8 @@ const open = ref(false)
 const availableRoles = computed(() =>
   props.roles.filter(r =>
     !selectedRoles.value.includes(r.id) &&
-    r.name.toLowerCase().includes(searchTerm.value.toLowerCase()),
+    r.name.toLowerCase().includes(searchTerm.value.toLowerCase()) &&
+    (!grantableRoleIds.value || grantableRoleIds.value.has(r.id)),
   ),
 )
 
@@ -65,7 +76,8 @@ defineExpose({
     if (!valid) return false
     return {
       ...values,
-      roles: canAssignRoles.value ? selectedRoles.value : ['user'],
+      // Picker only offers grantable roles; empty falls back to 'user' server-side.
+      roles: selectedRoles.value,
     }
   },
 })
@@ -83,7 +95,7 @@ defineExpose({
       </FormItem>
     </FormField>
 
-    <div v-if="canAssignRoles">
+    <div v-if="showRolePicker">
       <p class="text-sm font-medium mb-2">Roles</p>
       <Combobox v-model="selectedRoles" v-model:open="open" v-model:search-term="searchTerm" multiple open-on-focus>
         <ComboboxAnchor as-child>

--- a/web/src/services/auth.service.ts
+++ b/web/src/services/auth.service.ts
@@ -42,11 +42,14 @@ function authService() {
 
   async function getPermissions() {
     const {
-      data: { permissions, subscription },
+      data: { permissions, subscription, roles },
     } = await api.get('auth/sessions/current/permissions')
     authStore.setPermissions(permissions)
     if (subscription) {
       authStore.setSubscription(subscription)
+    }
+    if (roles) {
+      authStore.setRoles(roles)
     }
   }
 

--- a/web/src/stores/auth.store.ts
+++ b/web/src/stores/auth.store.ts
@@ -38,6 +38,12 @@ export const useAuthStore = defineStore('auth', () => {
   } | null>('parchment-subscription', null, undefined, {
     serializer: jsonSerializer,
   })
+  // Role IDs the current user holds. Used to decide which roles they may grant
+  // when inviting users (a caller can grant the default 'user' role plus roles
+  // they hold; admins with USERS_UPDATE can grant any role).
+  const roles = useStorage<string[]>('parchment-roles', [], undefined, {
+    serializer: jsonSerializer,
+  })
   const sessions = ref<Session[]>([])
   const sessionId = ref<Session['id'] | null>(null)
   const stashedPath = ref<string | null>(null)
@@ -87,11 +93,16 @@ export const useAuthStore = defineStore('auth', () => {
     subscription.value = _subscription
   }
 
+  function setRoles(_roles: string[]) {
+    roles.value = _roles
+  }
+
   async function unsetAuthenticatedUser() {
     me.value = null
     cachedUser.value = null // Clear localStorage cache
     permissions.value = [] // Clear cached premium permissions
     subscription.value = null // Clear cached subscription
+    roles.value = [] // Clear cached role membership
     sessionId.value = null
     authenticatedUserPromise.value = undefined // Clear the promise to prevent router guards from waiting
     if (isTauri) {
@@ -168,6 +179,7 @@ export const useAuthStore = defineStore('auth', () => {
     needsOnboarding,
     permissions,
     subscription,
+    roles,
     sessionId,
     stashPath,
     setAuthToken,
@@ -175,6 +187,7 @@ export const useAuthStore = defineStore('auth', () => {
     updateUser,
     setPermissions,
     setSubscription,
+    setRoles,
     unsetAuthenticatedUser,
     authenticatedUserPromise,
     setAuthenticatedUserPromise,


### PR DESCRIPTION
Follow-up to #345. That PR let alpha invite users but restricted them to the default `user` role. This lets an inviter grant **any role they themselves hold**, so alpha testers can invite other alpha testers — without opening an escalation path.

## Rule
On `POST /users/` (invite):
- Callers with `USERS_UPDATE` (admins) may assign **any** role — unchanged.
- Everyone else may assign only the default `user` role **plus roles they hold**. So an alpha (member of `alpha`) can invite `user` and `alpha`, but never `admin` — you can't grant a role above your own.

## Changes
- **`user.controller.ts`** — invite guard rewritten from "non-`user` needs `USERS_UPDATE`" to the own-roles rule above (via `getRoles(caller)`).
- **`auth.controller.ts`** — `GET auth/sessions/current/permissions` now also returns the caller's `roles` (IDs), so the client knows what it may grant.
- **`auth.store.ts` / `auth.service.ts`** — cache the caller's `roles` alongside permissions/subscription (cleared on sign-out).
- **`InviteUserForm.vue`** — the role picker now offers exactly the grantable roles (all roles for admins; `user` + own roles otherwise), and shows only when there's a non-default role to pick. So an alpha sees `alpha` as an option.
- **`seed/roles.ts`** — updated the alpha role description/comment.

## Answer to "what's the default role?"
`user`. (Open registration gives the very first user `admin` as a bootstrap; the invite endpoint defaults to `user`.)

## Verification
Server `tsc --noEmit` and `vue-tsc`: no new errors from any changed file (pre-existing errors only shift by the added lines — diffed against the `origin/dev` baseline).