### PR TITLE
Role-aware invites

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,3 @@
-### Added
+### Changed
 
-* Alpha testers can now invite new users
-
-### Fixed
-
-* Time zones map layer now loads correctly in production again
+* Inviting users now respects your own roles — you can assign any role you already hold when inviting someone (so alpha testers can invite other alpha testers), and the invite form only offers the roles you're allowed to grant

--- a/RELEASE_TITLE
+++ b/RELEASE_TITLE
@@ -1,1 +1,1 @@
-Time zones fix & alpha invites
+Role-aware invites

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build:emails": "cd emails && bun install && npx maizzle build production",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.5.6",
+  "version": "0.5.7",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.5.6"
+version = "0.5.7"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",
@@ -66,7 +66,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 5060
+      "versionCode": 5070
     }
   }
 }


### PR DESCRIPTION
Release **v0.5.7**. Ships #348 (already merged to `main` via #349) to prod — the invite-your-own-roles change so **alpha testers can invite other alpha testers**.

Needed because merging #349 with the version unchanged (0.5.6) made the release workflow skip — no image was built. This bumps to 0.5.7 so a fresh image is built and can be deployed to vega7.

### Changed
* Inviting users now respects your own roles — you can assign any role you already hold when inviting someone (so alpha testers can invite other alpha testers), and the invite form only offers the roles you're allowed to grant

---
Version bumped to 0.5.7 across web/server `package.json`, `tauri.conf.json` (+ Android versionCode 5070), and `Cargo.toml`. Merging this tags `v0.5.7` and builds/pushes `parchment-server:latest`; then a `docker compose pull` on vega7 deploys it (iOS is non-blocking since 0.5.4, so a native-build failure won't withhold the Docker push).