### PR TITLE
Prod / self-hosted robustness fixes

### DIFF
--- a/.infisical.json
+++ b/.infisical.json
@@ -1,0 +1,5 @@
+{
+    "workspaceId": "098d0f45-135a-4132-a319-f0d7167468fb",
+    "defaultEnvironment": "",
+    "gitBranchToEnvironmentMapping": null
+}

--- a/server/Dockerfile.prod
+++ b/server/Dockerfile.prod
@@ -29,6 +29,10 @@ RUN bun install --frozen-lockfile --production || (rm -f bun.lock && bun install
 # Copy build output from builder stage
 COPY --from=builder /app/server/dist ./dist
 
+# Copy static data assets served by the /data endpoints (timezones.geojson, logos).
+# The build bundles code into ./dist but does not include these files.
+COPY --from=builder /app/server/data ./data
+
 # Copy compiled email templates
 COPY --from=builder /app/server/emails/output ./emails/output
 

--- a/server/src/config/cors.config.ts
+++ b/server/src/config/cors.config.ts
@@ -28,7 +28,12 @@ const tauriOrigins = [
 // emulator's host alias (10.0.2.2).
 const devOriginMatchers =
   process.env.NODE_ENV !== 'production'
-    ? [/^https?:\/\/(localhost|127\.0\.0\.1|10\.0\.2\.2)(:\d+)?$/]
+    ? [
+        /^https?:\/\/(localhost|127\.0\.0\.1|10\.0\.2\.2)(:\d+)?$/,
+        // Dev only: let the deployed frontend point at a local backend — e.g.
+        // debugging the prod client (map.parchment.app) against localhost:5000.
+        /^https:\/\/([a-z0-9-]+\.)*parchment\.app$/,
+      ]
     : []
 
 const corsConfig: CORSConfig = {

--- a/server/src/controllers/data.controller.ts
+++ b/server/src/controllers/data.controller.ts
@@ -4,11 +4,16 @@ import { resolve } from 'path'
 
 const app = new Elysia({ prefix: '/data' })
 
+// Resolve from the app root (cwd is /app/server in both dev and prod containers)
+// rather than __dirname, which sits 2 levels deep in dev (src/controllers) but
+// only 1 level deep in the prod bundle (dist), breaking a fixed relative path.
+const dataDir = resolve(process.cwd(), 'data')
+
 let timezonesCache: Buffer | null = null
 
 app.get('/timezones.geojson', () => {
   if (!timezonesCache) {
-    timezonesCache = readFileSync(resolve(__dirname, '../../data/timezones.geojson'))
+    timezonesCache = readFileSync(resolve(dataDir, 'timezones.geojson'))
   }
   return new Response(timezonesCache, {
     headers: {
@@ -22,7 +27,7 @@ let logoSvgCache: Buffer | null = null
 
 app.get('/logo.svg', () => {
   if (!logoSvgCache) {
-    logoSvgCache = readFileSync(resolve(__dirname, '../../data/logo.svg'))
+    logoSvgCache = readFileSync(resolve(dataDir, 'logo.svg'))
   }
   return new Response(logoSvgCache, {
     headers: {
@@ -36,7 +41,7 @@ let logoPngCache: Buffer | null = null
 
 app.get('/logo.png', () => {
   if (!logoPngCache) {
-    logoPngCache = readFileSync(resolve(__dirname, '../../data/logo.png'))
+    logoPngCache = readFileSync(resolve(dataDir, 'logo.png'))
   }
   return new Response(logoPngCache, {
     headers: {

--- a/server/src/controllers/library/layers.controller.ts
+++ b/server/src/controllers/library/layers.controller.ts
@@ -322,7 +322,11 @@ app.group('', (g) =>
           DEFAULT_GROUP_TEMPLATES,
           resolveProxyUrls,
         } = await import('../../constants/default-layers')
-        const serverUrl = process.env.SERVER_URL || 'http://localhost:5000'
+        // SERVER_ORIGIN is the canonical public-origin env everything else uses;
+        // fall back to it so a deployment that sets only SERVER_ORIGIN doesn't
+        // silently emit localhost tile URLs (mixed-content-blocked on https).
+        const serverUrl =
+          process.env.SERVER_URL || process.env.SERVER_ORIGIN || 'http://localhost:5000'
         return {
           layers: DEFAULT_LAYER_TEMPLATES.map((t) => ({
             ...t,
@@ -433,7 +437,8 @@ app.group('', (g) =>
           set.status = 404
           return { error: 'Default layer template not found' }
         }
-        const serverUrl = process.env.SERVER_URL || 'http://localhost:5000'
+        const serverUrl =
+          process.env.SERVER_URL || process.env.SERVER_ORIGIN || 'http://localhost:5000'
         const resolved = resolveProxyUrls(template.configuration, serverUrl)
         const clone = await layersService.cloneDefaultLayer(
           user.id,

--- a/server/src/controllers/user.controller.ts
+++ b/server/src/controllers/user.controller.ts
@@ -145,16 +145,30 @@ app.group('', (admin) =>
           return status(400, { message: 'One or more role IDs are invalid' })
         }
 
-        const result = await db
-          .insert(users)
-          .values({
-            id: generateId(),
-            firstName: body.firstName,
-            lastName: body.lastName,
-            email: body.email,
-            picture: body.picture,
-          })
-          .returning()
+        let result
+        try {
+          result = await db
+            .insert(users)
+            .values({
+              id: generateId(),
+              firstName: body.firstName,
+              lastName: body.lastName,
+              email: body.email,
+              picture: body.picture,
+            })
+            .returning()
+        } catch (err: any) {
+          // Postgres unique_violation = 23505 — a user with this email
+          // already exists. Postgres.js surfaces it on .code; drizzle may
+          // wrap it via .cause depending on the driver, so check both.
+          const code = err?.code ?? err?.cause?.code
+          if (code === '23505') {
+            return status(409, {
+              message: 'A user with this email already exists',
+            })
+          }
+          throw err
+        }
 
         const newUser = result[0]
 

--- a/web/src/composables/useSettingsIndex.ts
+++ b/web/src/composables/useSettingsIndex.ts
@@ -41,13 +41,21 @@ export function useSettingsIndex() {
 
   // Filter out pages the current user can't access. Permissions on a page
   // hide all of its sections from both the sub-nav and the search.
-  // The subscription page is hidden when billing is disabled (self-hosted).
   const allowedPages = computed<SettingsPageDef[]>(() => {
     return settingsIndex.filter(page => {
-      if (page.pageId === 'billing' && !subscriptionService.billingEnabled.value) return false
       return !page.permissions || authService.hasPermission(page.permissions)
     })
   })
+
+  // The subscription section (nested under the account page) is hidden when
+  // billing is disabled — self-hosted or not configured — so search and the
+  // sub-nav don't surface a section that renders nothing.
+  const isSectionVisible = (section: SettingsSectionDef): boolean => {
+    if (section.id === 'subscription') {
+      return subscriptionService.billingEnabled.value
+    }
+    return true
+  }
 
   // Sections grouped by page, with i18n applied. Used by the sidebar to
   // render sub-nav items beneath each tab.
@@ -59,7 +67,7 @@ export function useSettingsIndex() {
     for (const page of allowedPages.value) {
       map.set(
         page.pageId,
-        page.sections.map(section => ({
+        page.sections.filter(isSectionVisible).map(section => ({
           id: section.id,
           title: tr(section.titleKey) ?? section.id,
           hash: `#${section.id}`,
@@ -77,6 +85,7 @@ export function useSettingsIndex() {
     for (const page of allowedPages.value) {
       const pageTitle = tr(`settings.${page.pageId}.title`) ?? page.pageId
       for (const section of page.sections) {
+        if (!isSectionVisible(section)) continue
         const sectionTitle = tr(section.titleKey) ?? section.id
         const sectionDescription = tr(section.descriptionKey)
         entries.push({

--- a/web/src/services/subscription.service.ts
+++ b/web/src/services/subscription.service.ts
@@ -49,7 +49,10 @@ function subscriptionService() {
     }
   }
 
-  fetchConfig()
+  // Kick off the config fetch once and keep the promise so callers (and
+  // guarded endpoints below) can wait for `billingEnabled` to settle before
+  // deciding whether to hit billing-only routes.
+  const configReady = fetchConfig()
 
   const isPremium = computed(() => authStore.subscription?.isPremium ?? false)
   const isBasic = computed(() => authStore.subscription?.isBasic ?? false)
@@ -81,8 +84,19 @@ function subscriptionService() {
   }
 
   async function fetchDetails() {
+    // Billing-only route: when billing is disabled the server never registers
+    // it, so calling would 404 (and spawn an error toast). Wait for config,
+    // then bail out cleanly. `silentStatuses` is a defensive net in case
+    // billing flips off server-side between config and this call.
+    await configReady
+    if (!billingEnabled.value) {
+      details.value = null
+      return
+    }
     try {
-      const { data } = await api.get('/subscriptions/details')
+      const { data } = await api.get('/subscriptions/details', {
+        silentStatuses: [404],
+      } as any)
       details.value = data.details
     } catch {
       details.value = null
@@ -119,6 +133,7 @@ function subscriptionService() {
     verifySubscription,
     fetchConfig,
     fetchDetails,
+    configReady,
   }
 }
 


### PR DESCRIPTION
## Summary

A small batch of prod / self-hosted deployment robustness fixes, plus the prod `/data` 500 fix. No user-facing feature work — these harden behavior when the app runs deployed or self-hosted (billing disabled, origin envs set, etc.).

## Changes

**Billing-disabled (self-hosted) UI**
- `subscription.service.ts` — keep the config-fetch promise (`configReady`); `fetchDetails()` awaits it and bails out cleanly when billing is disabled instead of calling `/subscriptions/details`, which the server never registers when billing is off (404 → error toast). Adds `silentStatuses: [404]` as a backstop in case billing flips off server-side mid-session.
- `useSettingsIndex.ts` — move the billing gate from page-level to a section-level `isSectionVisible()` check, so the subscription section (nested under the account page) is hidden from both the sub-nav and search when billing is disabled.

**Prod / deploy correctness**
- `layers.controller.ts` — fall back to `SERVER_ORIGIN` (then `localhost:5000`) when `SERVER_URL` is unset, so default-layer tile URLs aren't emitted as `localhost` (mixed-content-blocked over https) on a deploy that only sets `SERVER_ORIGIN`.
- `cors.config.ts` — dev-only: also allow `*.parchment.app` origins so the deployed prod client can be pointed at a local backend for debugging.

**Admin robustness**
- `user.controller.ts` — admin "create user" now catches Postgres `unique_violation` (23505) on duplicate email and returns 409 with a clear message instead of a 500.

**Prod `/data` 500** (previously committed on the branch)
- Ship the data dir and resolve its path from cwd so the prod `/data` endpoint stops 500ing.

## Notes
- Excludes a stray `web/src-tauri/Cargo.lock` version bump (0.1.6 → 0.5.1) that was inconsistent with `Cargo.toml` (0.5.0) and unrelated to this work.
- Not linked to a Linear issue.

## Test plan
- [x] `web` unit test suite (runs via pre-commit hook on each commit)
- [ ] Verify subscription section is hidden with billing disabled; no `/subscriptions/details` 404 toast
- [ ] Verify default-layer tile URLs resolve to the public origin in a deploy with only `SERVER_ORIGIN` set
- [ ] Verify admin create-user returns 409 on a duplicate email
