### PR TITLE
Let read-only admins configure their own personal integrations

### DIFF
--- a/web/src/lib/integration-permissions.test.ts
+++ b/web/src/lib/integration-permissions.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Unit tests for integration write-permission resolution.
+ *
+ * Regression cover for the read-only-admin case: a role holding
+ * integrations:read:system (alpha) but not integrations:write:system must
+ * still be able to configure its own user-scoped integrations.
+ */
+
+import { describe, test, expect } from 'vitest'
+import { PermissionId } from '@server/types/auth.types'
+import {
+  IntegrationScope,
+  type IntegrationDefinition,
+} from '@server/types/integration.types'
+import {
+  canConfigureIntegration,
+  requiredWritePermission,
+} from './integration-permissions'
+
+function defWithScope(scope: IntegrationScope[]) {
+  return { scope } as Pick<IntegrationDefinition, 'scope'>
+}
+
+function holder(...permissions: PermissionId[]) {
+  return (permission: PermissionId) => permissions.includes(permission)
+}
+
+// Mirrors the alpha role: every premium permission (which includes
+// integrations:write:user) plus read-only system access.
+const alpha = holder(
+  PermissionId.INTEGRATIONS_READ_USER,
+  PermissionId.INTEGRATIONS_WRITE_USER,
+  PermissionId.INTEGRATIONS_READ_SYSTEM,
+)
+
+const admin = holder(
+  PermissionId.INTEGRATIONS_READ_USER,
+  PermissionId.INTEGRATIONS_WRITE_USER,
+  PermissionId.INTEGRATIONS_READ_SYSTEM,
+  PermissionId.INTEGRATIONS_WRITE_SYSTEM,
+)
+
+describe('requiredWritePermission', () => {
+  test('user-scoped integrations require write:user', () => {
+    expect(requiredWritePermission(defWithScope([IntegrationScope.USER]))).toBe(
+      PermissionId.INTEGRATIONS_WRITE_USER,
+    )
+  })
+
+  test('system-scoped integrations require write:system', () => {
+    expect(
+      requiredWritePermission(defWithScope([IntegrationScope.SYSTEM])),
+    ).toBe(PermissionId.INTEGRATIONS_WRITE_SYSTEM)
+  })
+
+  test('system wins for dual-scoped integrations, matching the server', () => {
+    expect(
+      requiredWritePermission(
+        defWithScope([IntegrationScope.USER, IntegrationScope.SYSTEM]),
+      ),
+    ).toBe(PermissionId.INTEGRATIONS_WRITE_SYSTEM)
+  })
+
+  test('a scopeless definition requires nothing and configures nothing', () => {
+    expect(requiredWritePermission(defWithScope([]))).toBeNull()
+  })
+})
+
+describe('canConfigureIntegration', () => {
+  test('read-only system admin can configure user-scoped integrations', () => {
+    expect(
+      canConfigureIntegration(defWithScope([IntegrationScope.USER]), alpha),
+    ).toBe(true)
+  })
+
+  test('read-only system admin cannot configure system-scoped integrations', () => {
+    expect(
+      canConfigureIntegration(defWithScope([IntegrationScope.SYSTEM]), alpha),
+    ).toBe(false)
+  })
+
+  test('full admin can configure both scopes', () => {
+    expect(
+      canConfigureIntegration(defWithScope([IntegrationScope.USER]), admin),
+    ).toBe(true)
+    expect(
+      canConfigureIntegration(defWithScope([IntegrationScope.SYSTEM]), admin),
+    ).toBe(true)
+  })
+
+  test('a user without any integration write permission is locked out', () => {
+    const readOnly = holder(
+      PermissionId.INTEGRATIONS_READ_USER,
+      PermissionId.INTEGRATIONS_READ_SYSTEM,
+    )
+    expect(
+      canConfigureIntegration(defWithScope([IntegrationScope.USER]), readOnly),
+    ).toBe(false)
+    expect(
+      canConfigureIntegration(
+        defWithScope([IntegrationScope.SYSTEM]),
+        readOnly,
+      ),
+    ).toBe(false)
+  })
+
+  test('a scopeless definition is never configurable', () => {
+    expect(canConfigureIntegration(defWithScope([]), admin)).toBe(false)
+  })
+})

--- a/web/src/lib/integration-permissions.ts
+++ b/web/src/lib/integration-permissions.ts
@@ -1,0 +1,43 @@
+import { PermissionId } from '@/types/auth.types'
+import {
+  IntegrationScope,
+  type IntegrationDefinition,
+} from '@/types/integrations.types'
+
+/**
+ * Which write permission a given integration requires to be configured.
+ *
+ * Mirrors the scope check the server applies on POST/PATCH/DELETE
+ * `/integrations` (see `integration.controller.ts`): system-scoped
+ * integrations need `integrations:write:system`, user-scoped ones need
+ * `integrations:write:user`. System wins when a definition declares both,
+ * matching the server's precedence.
+ *
+ * Returns `null` for a definition with no scope — nothing is configurable.
+ */
+export function requiredWritePermission(
+  integration: Pick<IntegrationDefinition, 'scope'>,
+): PermissionId | null {
+  if (integration.scope?.includes(IntegrationScope.SYSTEM)) {
+    return PermissionId.INTEGRATIONS_WRITE_SYSTEM
+  }
+  if (integration.scope?.includes(IntegrationScope.USER)) {
+    return PermissionId.INTEGRATIONS_WRITE_USER
+  }
+  return null
+}
+
+/**
+ * Whether the permissions a user holds allow configuring this integration.
+ *
+ * A read-only admin role (e.g. alpha) holds `integrations:read:system` but
+ * not `integrations:write:system` — it must still be able to connect its own
+ * personal integrations like the OpenStreetMap account.
+ */
+export function canConfigureIntegration(
+  integration: Pick<IntegrationDefinition, 'scope'>,
+  hasPermission: (permission: PermissionId) => boolean,
+): boolean {
+  const required = requiredWritePermission(integration)
+  return required !== null && hasPermission(required)
+}

--- a/web/src/views/settings/pages/Integrations.vue
+++ b/web/src/views/settings/pages/Integrations.vue
@@ -23,7 +23,8 @@ import { useIntegrationsStore } from '@/stores/integrations.store'
 import { useIntegrationService } from '@/services/integration.service'
 import { useAppService } from '@/services/app.service'
 import { useAuthService } from '@/services/auth.service'
-import { PermissionId } from '@/types/auth.types'
+import { canConfigureIntegration } from '@/lib/integration-permissions'
+import type { IntegrationDefinition } from '@/types/integrations.types'
 import {
   useIntegrationFilters,
   type SortField,
@@ -76,6 +77,13 @@ const {
   removeFilter,
   clearAllFilters,
 } = useIntegrationFilters()
+
+// Write access depends on the integration's scope, not on system write alone.
+// A read-only admin role holds integrations:read:system but still configures
+// its own user-scoped integrations (OSM account, Dawarich).
+function canConfigure(integration: IntegrationDefinition): boolean {
+  return canConfigureIntegration(integration, authService.hasPermission)
+}
 
 // Handle OAuth callback query params
 function handleOAuthCallback() {
@@ -594,9 +602,7 @@ onMounted(async () => {
             :key="item.config?.id || item.integration.id"
             :integration="item.integration"
             :configuration="item.config"
-            :disabled="
-              !authService.hasPermission(PermissionId.INTEGRATIONS_WRITE_SYSTEM)
-            "
+            :disabled="!canConfigure(item.integration)"
           />
         </div>
       </SettingsSection>


### PR DESCRIPTION
Fixes #344 (PAR-276). An `alpha` user couldn't connect user-scoped integrations like the OpenStreetMap account — the tiles rendered greyed out and swallowed clicks.

## Root cause

Client-side only. `Integrations.vue` disabled **every** tile unless the user held `INTEGRATIONS_WRITE_SYSTEM`, ignoring the integration's own scope:

```
:disabled="!authService.hasPermission(PermissionId.INTEGRATIONS_WRITE_SYSTEM)"
```

The server already gets this right — `integration.controller.ts` checks `write:system` for system-scoped definitions and `write:user` for user-scoped ones on every write path (POST, PATCH, DELETE, `GET /:id`, `/:id/dependents`). And `alpha` already holds `INTEGRATIONS_WRITE_USER`, inherited from `basic` via `premium`. So no role or permission data needed to change; the UI was simply over-gating and contradicting what the API would have allowed.

## Changes

- **`web/src/lib/integration-permissions.ts`** (new) — `requiredWritePermission()` maps a definition's scope to the permission it needs; `canConfigureIntegration()` evaluates that against a permission holder. Mirrors the server's precedence, including system-wins when a definition declares both scopes.
- **`web/src/views/settings/pages/Integrations.vue`** — binds `:disabled="!canConfigure(item.integration)"` per tile.
- **`web/src/lib/integration-permissions.test.ts`** (new) — 9 tests covering both scopes, the dual-scope precedence, the scopeless case, and the alpha regression itself.

Only the two user-scoped definitions today (`OPENSTREETMAP_ACCOUNT`, `DAWARICH`) change behavior. System-scoped tiles stay gated exactly as before, so a read-only admin still can't touch system integration config or secrets.

## Verification

- `web` unit suite: 702 tests across 47 files pass, on this branch rebased onto `dev`.
- `vue-tsc --noEmit`: no errors in any changed file. The 24 it does report are all pre-existing `Cannot find module 'drizzle-orm'` / `'i18next'` under `server/src/`, from server dependencies not being installed in the sandbox this was built in.
- Not exercised in a running browser — the change is a single prop binding backed by unit-tested pure functions.

## Noticed, not addressed

`GET /integrations/osm/authorize` (`osm-oauth.controller.ts:70`) is gated on `requireAuth` alone, with no `INTEGRATIONS_WRITE_USER` check, unlike every other integration write path. That's a permissiveness gap in the opposite direction from this issue, so I left it alone rather than fold a behavior change into this fix. Probably worth its own ticket.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AAnDMu4Y7VT2RqoZaxwp76)_