### PR TITLE
search: cut autocomplete debounce to 150ms and cancel superseded requests

### DIFF
--- a/web/src/components/dashboard/SetPlaceDialog.vue
+++ b/web/src/components/dashboard/SetPlaceDialog.vue
@@ -16,6 +16,7 @@ import { Spinner } from '@/components/ui/spinner'
 import { useSearchService } from '@/services/search.service'
 import { useBookmarksService } from '@/services/library/bookmarks.service'
 import { useMapCamera } from '@/composables/useMapCamera'
+import { useAbortController } from '@/composables/useAbortController'
 import type { AutocompleteResult } from '@/types/search.types'
 import type { Place } from '@/types/place.types'
 import type { Bookmark } from '@/types/library.types'
@@ -47,6 +48,7 @@ const query = ref('')
 const customName = ref('')
 const results = ref<AutocompleteResult[]>([])
 const isLoading = ref(false)
+const { nextSignal } = useAbortController()
 const isSaving = ref(false)
 
 const isCustom = computed(() => props.frequentType === 'custom')
@@ -77,12 +79,18 @@ watch(
   },
 )
 
+// 150ms: barrelman's autocomplete now answers in ~20-40ms server-side, so the
+// debounce only has to avoid firing on every keystroke rather than hide backend
+// latency. nextSignal() cancels the previous request, which a shorter window
+// makes essential: without it a slower earlier response could land after a
+// newer one and overwrite the list with stale suggestions.
 const runSearch = useDebounceFn(async (value: string) => {
   if (!value.trim()) {
     results.value = []
     isLoading.value = false
     return
   }
+  const signal = nextSignal()
   isLoading.value = true
   try {
     const center = mapCamera.camera.value.center
@@ -92,15 +100,19 @@ const runSearch = useDebounceFn(async (value: string) => {
         ? [center.lng, center.lat]
         : [center.lon, center.lat]
 
-    results.value = await searchService.getAutocompleteSuggestions({
-      query: value,
-      lat,
-      lng,
-    })
+    const found = await searchService.getAutocompleteSuggestions(
+      { query: value, lat, lng },
+      signal,
+    )
+    // A cancelled request resolves to [] rather than rejecting, so assigning it
+    // would blank the list the newer request is about to fill.
+    if (signal.aborted) return
+    results.value = found
   } finally {
-    isLoading.value = false
+    // Don't clear the spinner the request that superseded this one still needs.
+    if (!signal.aborted) isLoading.value = false
   }
-}, 200)
+}, 150)
 
 watch(query, value => {
   runSearch(value)

--- a/web/src/components/palette/Palette.vue
+++ b/web/src/components/palette/Palette.vue
@@ -289,7 +289,12 @@ async function loadArgumentOptions(signal?: AbortSignal) {
   try {
     const items = activeArgument.value.getItems(undefined, signal)
     if (items instanceof Promise) {
-      argumentOptions.value = await items
+      const resolved = await items
+      // A superseded request doesn't reject here: the search service turns an
+      // axios cancel into an empty array. Assigning it would blank the list the
+      // newer request is about to fill, which reads as a flicker while typing.
+      if (signal?.aborted) return
+      argumentOptions.value = resolved
     } else {
       argumentOptions.value = items
     }
@@ -298,8 +303,12 @@ async function loadArgumentOptions(signal?: AbortSignal) {
     console.error('Error loading argument options:', error)
     argumentOptions.value = []
   } finally {
-    if (loadingTimer) clearTimeout(loadingTimer)
-    loadingOptions.value = false
+    // Same reasoning: a superseded request must not clear the spinner that the
+    // request which replaced it is still waiting on.
+    if (!signal?.aborted) {
+      if (loadingTimer) clearTimeout(loadingTimer)
+      loadingOptions.value = false
+    }
   }
 }
 
@@ -314,12 +323,18 @@ watch(activeArgument, async newArg => {
 
 // Create a debounced function for loading search options.
 // nextSignal() cancels the previous in-flight autocomplete request before issuing a new one.
+//
+// 150ms: barrelman's autocomplete now answers in ~20-40ms server-side (it was
+// 0.5-1.5s, with short prefixes reaching 10-20s), so the debounce no longer has
+// to hide backend latency — it only has to avoid firing on every keystroke of a
+// fast typist. Superseded requests are aborted above, so the extra in-flight
+// requests a shorter window allows are cancelled rather than raced.
 const debouncedLoadOptions = useDebounceFn(async () => {
   // Load options if we're in search mode
   if (activeCommand.value?.id === CommandName.SEARCH && activeArgument.value) {
     await loadArgumentOptions(nextSignal())
   }
-}, 300)
+}, 150)
 
 // Watch query and handle search
 watch(query, newQuery => {

--- a/web/src/views/directions/WaypointInput.vue
+++ b/web/src/views/directions/WaypointInput.vue
@@ -27,6 +27,7 @@ import { Place } from '@/types/place.types'
 import { AutocompleteResult } from '@/types/search.types'
 import { useSearchService } from '@/services/search.service'
 import { useMapCamera } from '@/composables/useMapCamera'
+import { useAbortController } from '@/composables/useAbortController'
 import { cn, useResponsive } from '@/lib/utils'
 import { useDebounceFn } from '@vueuse/core'
 import { Spinner } from '@/components/ui/spinner'
@@ -228,6 +229,7 @@ function selectPlace(index: number, place: Place, result?: AutocompleteResult) {
 const autocompleteResults = ref<AutocompleteResult[]>([])
 const isLoading = ref(false)
 const currentQuery = ref('')
+const { nextSignal } = useAbortController()
 
 // Combined results with current location prepended if not already used and matches query
 const combinedResults = computed(() => {
@@ -278,8 +280,14 @@ const combinedResults = computed(() => {
   return results
 })
 
+// 150ms: barrelman's autocomplete now answers in ~20-40ms server-side, so the
+// debounce only has to avoid firing on every keystroke rather than hide backend
+// latency. nextSignal() cancels the previous request, which a shorter window
+// makes essential: without it a slower earlier response could land after a
+// newer one and overwrite the list with stale suggestions.
 const getAutocomplete = useDebounceFn(async (index: number, value: string) => {
   currentQuery.value = value
+  const signal = nextSignal()
   isLoading.value = true
   try {
     const { camera } = mapCamera
@@ -292,15 +300,19 @@ const getAutocomplete = useDebounceFn(async (index: number, value: string) => {
         ? [center.lng, center.lat]
         : [center.lon, center.lat]
 
-    autocompleteResults.value = await searchService.getAutocompleteSuggestions({
-      query: value,
-      lat,
-      lng,
-    })
+    const results = await searchService.getAutocompleteSuggestions(
+      { query: value, lat, lng },
+      signal,
+    )
+    // A cancelled request resolves to [] rather than rejecting, so assigning it
+    // would blank the list the newer request is about to fill.
+    if (signal.aborted) return
+    autocompleteResults.value = results
   } finally {
-    isLoading.value = false
+    // Don't clear the spinner the request that superseded this one still needs.
+    if (!signal.aborted) isLoading.value = false
   }
-}, 200)
+}, 150)
 
 // Convert AutocompleteResult to Place object
 function autocompleteResultToPlace(result: AutocompleteResult): Place {


### PR DESCRIPTION
Barrelman's autocomplete now answers in **~20–40ms server-side**, down from 0.5–1.5s typical and 10–20s for short prefixes (barrelman#19, deployed to vega2). The debounce was sized to hide that latency — it no longer has to.

## Debounce

All three autocomplete entry points drop to **150ms**, which now only has to avoid firing on every keystroke of a fast typist:

| site | before | after |
|---|---|---|
| `Palette.vue` (command palette) | 300ms | **150ms** |
| `WaypointInput.vue` (directions) | 200ms | **150ms** |
| `SetPlaceDialog.vue` (dashboard) | 200ms | **150ms** |

## The race this also fixes

Shortening the window exposes a race that was latent at 200–300ms, so fixing it is part of the change rather than a follow-up.

Only the palette cancelled its previous request. The directions and dashboard inputs fired uncancelled and assigned results unconditionally — a slower earlier response could land after a newer one and overwrite the list with stale suggestions. Both now use the same `useAbortController` / `nextSignal()` pattern the palette already had.

**Passing a signal alone would have made this worse.** `search.service` turns an aborted request into an empty array (`axios.isCancel(err) → return []`) rather than rethrowing, so every superseded request would have blanked the list a few milliseconds before the newer results filled it — a visible flicker while typing. All three sites now:

- check `signal.aborted` before assigning results
- skip clearing the loading flag that the request which superseded them is still waiting on

The palette had this same latent bug — its `AbortError` catch never fires for search, because the service swallows the cancellation first.

## Why 150ms

Server-side is 20–40ms warm, ~230ms through the public API including network. At 150ms a fast typist still coalesces keystrokes, but the list keeps up with a pause mid-word instead of lagging a third of a second behind. Superseded requests are now cancelled client-side, so the extra in-flight requests a shorter window allows are aborted rather than raced.

## Testing

- `vue-tsc --noEmit`: zero errors in the three changed files
- Web test suite passes (pre-commit hook)

## Note

Barrelman still does **not** cancel its Postgres queries — the request's `AbortSignal` reaches Pelias only, so the DB query runs to completion even after the browser gives up. Client-side cancellation stops the UI waiting and prevents stale overwrites, but the server-side work isn't reclaimed. Tracked in barrelman#20.
