### PR TITLE
Add isochrone to the map context menu

### DIFF
--- a/web/src/components/map/ContextMenu.vue
+++ b/web/src/components/map/ContextMenu.vue
@@ -12,6 +12,7 @@ import { LngLat } from '@/types/map.types'
 import { useDirectionsStore } from '@/stores/directions.store'
 import { useMapStore } from '@/stores/map.store'
 import { useMapToolsStore } from '@/stores/map-tools.store'
+import { useIsochroneStore } from '@/stores/isochrone.store'
 import { useVehiclesStore } from '@/stores/vehicles.store'
 import { VEHICLE_TYPE_LABELS } from '@/lib/vehicle-mode-mapping'
 import type { VehicleType } from '@/types/multimodal.types'
@@ -32,6 +33,7 @@ import {
   MapPinIcon,
   RulerIcon,
   CircleDotIcon,
+  RadarIcon,
   CrosshairIcon,
   CarFrontIcon,
 } from 'lucide-vue-next'
@@ -54,6 +56,7 @@ const directionsService = useDirectionsService()
 const directionsStore = useDirectionsStore()
 const mapStore = useMapStore()
 const mapToolsStore = useMapToolsStore()
+const isochroneStore = useIsochroneStore()
 const vehiclesStore = useVehiclesStore()
 const { t } = useI18n()
 const { openExternalLink } = useExternalLink()
@@ -529,6 +532,15 @@ const menuItems = computed<MenuItemDefinition[]>(() => {
     mapToolsStore.setRadiusCenter(lngLat)
   }
 
+  const isochroneOnSelect = () => {
+    const lngLat = clickedLngLat.value
+    if (!lngLat) return
+    // Activate first: switching tools clears the isochrone store, which would
+    // otherwise throw away the origin we just set.
+    mapToolsStore.setActiveTool('isochrone')
+    isochroneStore.setOrigin(lngLat)
+  }
+
   items.push({
     type: 'submenu',
     id: 'measure',
@@ -551,6 +563,13 @@ const menuItems = computed<MenuItemDefinition[]>(() => {
         label: t('measure.circle'),
         icon: CircleDotIcon,
         onSelect: measureCircleOnSelect,
+      },
+      {
+        type: 'item',
+        id: 'measure-isochrone',
+        label: t('isochrone.title'),
+        icon: RadarIcon,
+        onSelect: isochroneOnSelect,
       },
     ],
   })

--- a/web/src/stores/isochrone.store.test.ts
+++ b/web/src/stores/isochrone.store.test.ts
@@ -258,6 +258,24 @@ describe('useIsochroneStore', () => {
       expect(store.error).toBe('Point not found in graph')
     })
 
+    test('a plain-text body still says something useful', async () => {
+      const store = useIsochroneStore()
+      // What a server predating the isochrone route returns: Elysia's own
+      // 404, whose body is text rather than our JSON error shape. Without
+      // handling it the panel showed only "Request failed with status code
+      // 404", which says nothing about the endpoint being missing.
+      get.mockRejectedValueOnce({
+        response: { status: 404, data: 'NOT_FOUND' },
+        message: 'Request failed with status code 404',
+      })
+
+      store.setOrigin(ORIGIN)
+      await vi.runAllTimersAsync()
+
+      expect(store.status).toBe('error')
+      expect(store.error).toBe('404 NOT_FOUND')
+    })
+
     test('an empty contour set reads as unreachable, not as success', async () => {
       const store = useIsochroneStore()
       get.mockResolvedValueOnce({ data: response([]) } as never)

--- a/web/src/stores/isochrone.store.ts
+++ b/web/src/stores/isochrone.store.ts
@@ -212,7 +212,25 @@ function isAbort(err: unknown): boolean {
  * server forwards them intact — so prefer that message over a generic one.
  */
 function messageFor(err: unknown): string {
-  const body = (err as { response?: { data?: { error?: string } } } | null)
-    ?.response?.data
-  return body?.error || (err instanceof Error ? err.message : 'unknown')
+  const response = (
+    err as { response?: { status?: number; data?: unknown } } | null
+  )?.response
+  const data = response?.data
+
+  if (
+    data &&
+    typeof data === 'object' &&
+    typeof (data as { error?: unknown }).error === 'string'
+  ) {
+    return (data as { error: string }).error
+  }
+
+  // A plain-text body means the response never came from the isochrone
+  // endpoint — most often a 404 from a server that predates it, where axios
+  // would otherwise report a bare "Request failed with status code 404".
+  if (typeof data === 'string' && data.trim()) {
+    return `${response?.status ?? ''} ${data.trim()}`.trim()
+  }
+
+  return err instanceof Error ? err.message : 'unknown'
 }


### PR DESCRIPTION
Follow-up to #363. The isochrone tool was in the toolbox dropdown but missing from the right-click menu, where Distance and Circle already live.

## Context menu

Adds **Reachable area** to the existing Measure submenu, alongside Distance and Circle. It follows the same pattern as `measureCircleOnSelect` — activate the tool, then seed it with the clicked coordinate — so right-clicking a spot and picking it computes from there immediately rather than dropping you into an empty tool waiting for a click.

Order matters and is commented: `setActiveTool` clears the isochrone store when switching *away* from the tool, so the origin has to be set after activation, not before.

No new translation keys — it reuses `isochrone.title`, which already exists in both locales.

## Error reporting

While debugging a report of a bare "Request failed with status code 404" in the panel, I found the store only read `response.data.error`. That's the shape the server sends for a *forwarded* Barrelman failure, but an unrouted path returns Elysia's own 404 with a plain-text `NOT_FOUND` body, which fell through to axios's generic message and said nothing about what was wrong.

Plain-text bodies are now surfaced with their status (`404 NOT_FOUND`), which distinguishes at a glance between:

- **the endpoint isn't there** — a server that predates the route, or one that hasn't restarted
- **`Upstream error: 404`** — the endpoint is there and Barrelman returned the 404

Covered by a new store test.

## Tests

Full web suite: 744 pass, `vue-tsc` clean.

`ContextMenu.vue` already failed `prettier --check` on `dev` before this change, so I left its formatting alone rather than bury a one-line addition in a reformat.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RsGgo9Lxcdb3VYoXytMV8K)_