### PR TITLE
Add a manual trigger for releases whose push event gets skipped

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -3,12 +3,33 @@
 #
 # Tags pushed by GITHUB_TOKEN don't trigger `on: push: tags` workflows,
 # so we call release.yml directly via workflow_call instead.
+#
+# The manual trigger is an escape hatch for two ways a release can silently
+# not happen:
+#
+#   1. GitHub skips a whole push event when the commit message contains a
+#      CI-skip directive — and squash-merging a PR concatenates every branch
+#      commit message into the merge commit body. One routine "update the
+#      OpenAPI spec" commit on the branch is enough to swallow the release,
+#      with no run and no failure to notice. (This ate 0.5.9.)
+#
+#   2. Once the tag exists, a re-run finds it and no-ops, so the release can
+#      never be retried for that version. Historically this produced 9-second
+#      "successes" that hid the failing iOS build for three releases.
+#
+# Dispatch with `force` to release a version whose tag already exists.
 
 name: Tag Release
 
 on:
   push:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      force:
+        description: Release even if the tag already exists
+        type: boolean
+        default: false
 
 # The release workflow needs contents:write (GitHub Releases, tauri uploads)
 # and id-token:write (Docker Hub OIDC). These must be set at the top level
@@ -23,7 +44,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       tag: ${{ steps.version.outputs.TAG }}
-      created: ${{ steps.check_tag.outputs.exists == 'false' }}
+      # Release when the tag is new, or when a manual run explicitly forces it
+      # for a version that was already tagged but never actually shipped.
+      release: ${{ steps.check_tag.outputs.exists == 'false' || inputs.force == true }}
     steps:
       - uses: actions/checkout@v6
 
@@ -55,7 +78,7 @@ jobs:
   release:
     name: Release
     needs: tag
-    if: needs.tag.outputs.created == 'true'
+    if: needs.tag.outputs.release == 'true'
     uses: ./.github/workflows/release.yml
     with:
       tag: ${{ needs.tag.outputs.tag }}


### PR DESCRIPTION
0.5.9 merged to `main` and nothing happened — no workflow run, no failure, nothing to notice.

## Why

Squash-merging concatenates **every branch commit message** into the merge commit body. `dev` contained a routine `Update OpenAPI spec` commit carrying a CI-skip directive, so the squashed body carried it too — and GitHub evaluates skip directives against the whole commit message, so it discarded the entire push event.

That commit is generated by our own OpenAPI workflow, so this will recur on essentially every release.

Two follow-on traps made recovery worse:

- The skip is bound to the **commit**, not the event. Tagging the merge commit by hand was skipped for the same reason.
- Once a tag exists, `tag-release` no-ops (`release` only runs `if created == 'true'`). So a version can be tagged but never shipped, with no way to retry. This is what produced the 9-second "successful" Tag Release runs that hid the failing iOS build across 0.5.1–0.5.3.

Recovering 0.5.9 took deleting a tag and pushing two empty commits.

## This change

Adds `workflow_dispatch` to `tag-release.yml` with a `force` input:

| Situation | Behaviour |
| --- | --- |
| Push to `main`, tag is new | unchanged — tag and release |
| Push to `main`, tag exists | unchanged — no-op |
| Manual run, tag missing | tag and release (recovers a swallowed push) |
| Manual run, `force: true` | release without re-tagging (retries a tagged-but-unshipped version) |

`created` is renamed to `release`, since it now means "should we release" rather than "did we make a tag". On a `push` event `inputs.force` is null, so push behaviour is untouched.

## Also worth doing (not in this PR)

This is an escape hatch, not a root-cause fix. The repo currently has:

```
squash_merge_commit_message = COMMIT_MESSAGES
```

Setting it to `PR_BODY` makes the squash body the PR description instead of concatenated commit messages, which removes this whole class of bug — no branch commit can smuggle a directive into a merge commit again. It's a one-setting change under Settings → General → Pull Requests, and it changes how every squash merge is written, so I've left the call to you.
