### PR TITLE
Fix ToggleGroup test types breaking every app build

### DIFF
--- a/web/src/components/ui/toggle-group/ToggleGroup.test.ts
+++ b/web/src/components/ui/toggle-group/ToggleGroup.test.ts
@@ -20,7 +20,13 @@ const Harness = defineComponent({
       {
         type: 'single',
         modelValue: this.value,
-        'onUpdate:modelValue': (v: string) => (this.value = v),
+        // reka's emit is typed for every ToggleGroup shape, so the payload is
+        // `AcceptableValue | AcceptableValue[]` — including null when the
+        // active item is deselected. This harness is single-select over
+        // strings, so narrow it here rather than widening `value`.
+        'onUpdate:modelValue': (v: unknown) => {
+          if (typeof v === 'string') this.value = v
+        },
       },
       () =>
         ['walk', 'bike'].map(id =>


### PR DESCRIPTION
Every app build in the 0.5.9 release failed on the same error:

```
src/components/ui/toggle-group/ToggleGroup.test.ts(23,9): error TS2769: No overload matches this call.
Process completed with exit code 2.
```

iOS, Android and all three desktop targets failed; App Store, Play and the GitHub Release were skipped. Docker shipped, because its job doesn't run the build script.

## Cause

`web/package.json`'s build is `vue-tsc && bun run test -- run && vite build`, so a type error anywhere — including in a test file — fails the build for every packaged app.

The harness typed its update handler as `(v: string)`, but reka's `ToggleGroup` emit is typed for every shape the component supports, so the payload is `AcceptableValue | AcceptableValue[]` — `null` included, for when the active item is deselected. Narrowed in the harness rather than widening `value`, since this harness is deliberately single-select over strings.

## Why it reached a release

The file is new since v0.5.8 — added by `9a955e98 Fix toggle group selection indicator not updating`, which landed on `dev` and had never been through a release build. 0.5.8 built fine.

It was visible as a `vue-tsc` failure the whole time it sat on `dev`, and I repeatedly discounted it as pre-existing and unrelated to what I was working on. "Pre-existing" wasn't the same as harmless: `vue-tsc` is a release gate.

## Verification

`vue-tsc` clean with no filtering, the three ToggleGroup tests pass, and `bun run build` — the exact command the app jobs run — completes.

## Shipping this

0.5.9 is tagged and its Docker images are published, so the version is spent. This needs to go out as 0.5.10 once merged.
