### PR TITLE
Release 0.5.10 — ship 0.5.9 to the apps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.10] - 2026-07-30
+
+### Added
+
+* Your saved places now appear on the map, wearing the icon and colour of the collection they're in. Zoomed out they show as dots; zoom in and the collection's icon fills in. Home, Work and School keep their own markers
+* The layer picker now expands, so you can toggle what's inside a group — including a new "Saved places" group with a switch per collection
+* New isochrone tool — drop a point and see how far you can get in a given time on foot, by bike, by car or on transit, drawn as shaded travel-time bands. It works in reverse too, showing everywhere that can reach the point
+
+### Changed
+
+* Saved places take their icon and colour from the place itself in your lists, and from their collection on the map. The per-bookmark icon picker is gone
+
+### Fixed
+
+* The final step of a set of directions shows the arrival flag again instead of a turn arrow
+* Toggle buttons now highlight the option you picked
+* The desktop and mobile apps are up to date again — 0.5.9 reached the web and server but its app builds failed, so everything above arrives on iOS, Android and desktop with this release
+
 ## [0.5.9] - 2026-07-30
 
 ### Added

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build:emails": "cd emails && bun install && npx maizzle build production",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.5.9",
+  "version": "0.5.10",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.5.9"
+version = "0.5.10"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.5.9",
+  "version": "0.5.10",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",
@@ -66,7 +66,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 5090
+      "versionCode": 5100
     }
   }
 }


### PR DESCRIPTION
Patch release **0.5.10**, re-shipping 0.5.9 to the platforms that never received it.

> ⚠️ Merging triggers the full pipeline: Docker Hub, App Store, Play, and the Tauri auto-updater.

## Why this exists

0.5.9's app builds all failed on a `vue-tsc` error in `ToggleGroup.test.ts` (fixed in #368). `vue-tsc` gates the build script, so iOS, Android and all three desktop targets failed, and the App Store / Play / GitHub Release jobs were skipped. Docker doesn't run that script, so it shipped.

The upshot is a split: **web and server are on 0.5.9, the apps are still on 0.5.8.** This release brings the apps up to date.

## Release notes

The `[Unreleased]` section was empty — 0.5.9's cut consumed it. Since the apps never received any of that work, 0.5.10's notes carry those entries forward rather than shipping an empty "what's new" to the App Store and Play for what is, from a phone, the saved-places release. `[0.5.9]` is left intact in the changelog, since it did ship to Docker.

Added a Fixed entry explaining the version jump, so an app user isn't left wondering where 0.5.9 went.

Verified the Play "what's new" (500-char cap, truncated top-down) still leads with both headline features.

## Version bump

| File | Value |
| --- | --- |
| `web/package.json`, `server/package.json` | 0.5.10 |
| `web/src-tauri/tauri.conf.json` | 0.5.10 |
| `web/src-tauri/Cargo.toml` | 0.5.10 |
| Android `versionCode` | 5100 (was 5090) |

## Confidence

Unlike 0.5.9, the gate that failed has been verified locally: `vue-tsc` clean with no filtering, and `bun run build` — the exact command the app jobs run — completes.

Release history says the rest of the pipeline is sound: 0.5.8 built all five app targets successfully the day before, iOS included, so the 0.5.4 deployment-target fix is holding. 0.5.8's only failure was `ECONNRESET` fetching the Android artifact during the Play upload — transient, and worth a re-run if it recurs.
