### PR TITLE
Serve geocoding from Barrelman instead of Nominatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+* Looking up an address — right-clicking the map, dropping a pin, searching a street — now answers from your own Barrelman instance instead of the public OpenStreetMap geocoder. It's faster, isn't rate limited, and the place you land on comes back with its real outline, opening hours and tags rather than just a name. Nominatim and the other providers stay on as fallbacks for anywhere outside the regions you've imported
+* Right-clicking somewhere with nothing on it — a park, a field, open water — now names the town or city you're in instead of coming back blank
+
 ## [0.5.10] - 2026-07-30
 
 ### Added

--- a/server/src/controllers/geocoding.controller.ts
+++ b/server/src/controllers/geocoding.controller.ts
@@ -1,7 +1,6 @@
 import { Elysia, t } from 'elysia'
 import { requireAuth } from '../middleware/auth.middleware'
-import { integrationManager } from '../services/integrations'
-import { IntegrationCapabilityId } from '../types/integration.types'
+import { forwardGeocode, reverseGeocode } from '../services/geocoding.service'
 import { logError } from '../lib/logger'
 
 const geocodingRouter = new Elysia({ prefix: '/geocoding' })
@@ -13,7 +12,7 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
    */
   .get(
     '/forward',
-    async ({ query, user, status, t }) => {
+    async ({ query, status, t }) => {
       const { query: searchQuery, lat, lng, limit = 10 } = query
 
       if (!searchQuery || searchQuery.trim().length === 0) {
@@ -23,44 +22,25 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
       }
 
       try {
-        // Get the highest priority geocoding integration
-        const geocodingIntegrations =
-          integrationManager.getConfiguredIntegrationsByCapability(
-            IntegrationCapabilityId.GEOCODING,
-          )
-
-        if (geocodingIntegrations.length === 0) {
-          return status(503, {
-            message: t('errors.geocoding.serviceUnavailable'),
-          })
-        }
-
-        // Use the first (highest priority) integration
-        const integrationRecord = geocodingIntegrations[0]
-        const integration =
-          integrationManager.getCachedIntegrationInstance(integrationRecord)
-
-        if (!integration || !integration.capabilities.geocoding) {
-          return status(503, {
-            message: t('errors.integration.notConfigured'),
-          })
-        }
-
-        // Call the geocoding capability
-        const results = await integration.capabilities.geocoding.geocode(
+        const { results, integrationId } = await forwardGeocode(
           searchQuery,
           lat ? parseFloat(lat) : undefined,
           lng ? parseFloat(lng) : undefined,
         )
 
-        // Limit results
+        if (!integrationId) {
+          return status(503, {
+            message: t('errors.geocoding.serviceUnavailable'),
+          })
+        }
+
         const limitedResults = results.slice(0, parseInt(limit.toString()))
 
         return {
           query: searchQuery,
           results: limitedResults,
           count: limitedResults.length,
-          integration: integrationRecord.integrationId,
+          integration: integrationId,
         }
       } catch (err) {
         logError('Error performing forward geocoding', err)
@@ -81,7 +61,7 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
         tags: ['Geocoding'],
         summary: 'Forward geocode an address to coordinates',
         description:
-          'Convert an address or location query into geographic coordinates. Optionally provide lat/lng for location bias.',
+          'Convert an address or location query into geographic coordinates. Optionally provide lat/lng for location bias. Served by the highest-priority configured geocoding integration, falling back to the next when one is unavailable or has no coverage.',
       },
     },
   )
@@ -92,7 +72,7 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
    */
   .get(
     '/reverse',
-    async ({ query, user, status, t }) => {
+    async ({ query, status, t }) => {
       const { lat, lng, limit = 10 } = query
 
       if (lat === undefined || lng === undefined) {
@@ -102,7 +82,6 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
       }
 
       try {
-        // Parse coordinates
         const latitude = parseFloat(lat)
         const longitude = parseFloat(lng)
 
@@ -112,7 +91,6 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
           })
         }
 
-        // Validate coordinate ranges
         if (latitude < -90 || latitude > 90) {
           return status(400, {
             message: t('errors.validation.latitudeRange'),
@@ -125,36 +103,17 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
           })
         }
 
-        // Get the highest priority geocoding integration
-        const geocodingIntegrations =
-          integrationManager.getConfiguredIntegrationsByCapability(
-            IntegrationCapabilityId.GEOCODING,
-          )
+        const { results, integrationId } = await reverseGeocode(
+          latitude,
+          longitude,
+        )
 
-        if (geocodingIntegrations.length === 0) {
+        if (!integrationId) {
           return status(503, {
             message: t('errors.geocoding.serviceUnavailable'),
           })
         }
 
-        // Use the first (highest priority) integration
-        const integrationRecord = geocodingIntegrations[0]
-        const integration =
-          integrationManager.getCachedIntegrationInstance(integrationRecord)
-
-        if (!integration || !integration.capabilities.geocoding) {
-          return status(503, {
-            message: t('errors.integration.notConfigured'),
-          })
-        }
-
-        // Call the reverse geocoding capability
-        const results = await integration.capabilities.geocoding.reverseGeocode(
-          latitude,
-          longitude,
-        )
-
-        // Limit results
         const limitedResults = results.slice(0, parseInt(limit.toString()))
 
         return {
@@ -164,7 +123,7 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
           },
           results: limitedResults,
           count: limitedResults.length,
-          integration: integrationRecord.integrationId,
+          integration: integrationId,
         }
       } catch (err) {
         logError('Error performing reverse geocoding', err)
@@ -186,7 +145,7 @@ const geocodingRouter = new Elysia({ prefix: '/geocoding' })
         tags: ['Geocoding'],
         summary: 'Reverse geocode coordinates to an address',
         description:
-          'Convert geographic coordinates (latitude and longitude) into a human-readable address.',
+          'Convert geographic coordinates (latitude and longitude) into a human-readable address. Served by the highest-priority configured geocoding integration, falling back to the next when one is unavailable or has no coverage.',
       },
     },
   )

--- a/server/src/services/geocoding.service.test.ts
+++ b/server/src/services/geocoding.service.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for provider selection in the geocoding service.
+ *
+ * The behaviour worth pinning: providers are tried in the order the integration
+ * manager hands them back (priority-sorted, Barrelman first), a provider that
+ * errors or returns nothing yields to the next, and an outage across *all* of
+ * them still surfaces as an error rather than looking like an empty result.
+ */
+
+import { describe, test, expect, mock, beforeEach } from 'bun:test'
+
+let configuredIntegrations: any[] = []
+const instances = new Map<string, any>()
+
+mock.module('./integrations', () => ({
+  integrationManager: {
+    getConfiguredIntegrationsByCapability: () => configuredIntegrations,
+    getCachedIntegrationInstance: (record: any) => instances.get(record.integrationId),
+  },
+}))
+
+mock.module('../lib/logger', () => ({
+  logger: { info: () => {}, warn: () => {}, debug: () => {}, error: () => {} },
+  logError: () => {},
+  logWarn: () => {},
+}))
+
+const { forwardGeocode, reverseGeocode } = await import('./geocoding.service')
+
+/** Register a provider, in priority order, with the given geocoding behaviour. */
+function provider(integrationId: string, geocoding: any) {
+  configuredIntegrations.push({ integrationId })
+  instances.set(integrationId, { capabilities: { geocoding } })
+}
+
+const place = (name: string) => ({ name }) as any
+
+/** A provider that answers both directions with the same fixed result. */
+function answering(name: string) {
+  return {
+    geocode: mock(async () => [place(name)]),
+    reverseGeocode: mock(async () => [place(name)]),
+  }
+}
+
+const empty = () => ({
+  geocode: mock(async () => []),
+  reverseGeocode: mock(async () => []),
+})
+
+const failing = (message: string) => ({
+  geocode: mock(async () => {
+    throw new Error(message)
+  }),
+  reverseGeocode: mock(async () => {
+    throw new Error(message)
+  }),
+})
+
+beforeEach(() => {
+  configuredIntegrations = []
+  instances.clear()
+})
+
+describe('provider priority', () => {
+  test('uses the first provider the manager returns', async () => {
+    provider('barrelman', answering('from barrelman'))
+    provider('nominatim', answering('from nominatim'))
+
+    const { results, integrationId } = await reverseGeocode(35.2, -80.8)
+
+    expect(integrationId).toBe('barrelman')
+    expect(results[0].name).toBe('from barrelman')
+  })
+
+  test('does not call lower-priority providers once one answers', async () => {
+    const nominatim = answering('from nominatim')
+    provider('barrelman', answering('from barrelman'))
+    provider('nominatim', nominatim)
+
+    await forwardGeocode('coffee')
+
+    expect(nominatim.geocode).not.toHaveBeenCalled()
+  })
+})
+
+describe('fallback', () => {
+  test('falls through to the next provider when the first has no coverage', async () => {
+    provider('barrelman', empty())
+    provider('nominatim', answering('from nominatim'))
+
+    const { results, integrationId } = await reverseGeocode(48.85, 2.29)
+
+    expect(integrationId).toBe('nominatim')
+    expect(results[0].name).toBe('from nominatim')
+  })
+
+  test('falls through to the next provider when the first throws', async () => {
+    provider('barrelman', failing('barrelman unreachable'))
+    provider('nominatim', answering('from nominatim'))
+
+    const { integrationId } = await forwardGeocode('coffee')
+
+    expect(integrationId).toBe('nominatim')
+  })
+
+  test('skips a provider that is configured but has no geocoding capability', async () => {
+    configuredIntegrations.push({ integrationId: 'stale' })
+    instances.set('stale', { capabilities: {} })
+    provider('nominatim', answering('from nominatim'))
+
+    const { integrationId } = await reverseGeocode(35.2, -80.8)
+
+    expect(integrationId).toBe('nominatim')
+  })
+})
+
+describe('exhausted providers', () => {
+  test('reports the highest-priority provider when every one comes back empty', async () => {
+    provider('barrelman', empty())
+    provider('nominatim', empty())
+
+    const { results, integrationId } = await reverseGeocode(0, 0)
+
+    expect(results).toEqual([])
+    expect(integrationId).toBe('barrelman')
+  })
+
+  test('signals "none configured" with a null integrationId', async () => {
+    const { results, integrationId } = await forwardGeocode('coffee')
+
+    expect(results).toEqual([])
+    expect(integrationId).toBeNull()
+  })
+
+  test('rethrows when every provider fails, so an outage is not read as no results', async () => {
+    provider('barrelman', failing('barrelman unreachable'))
+    provider('nominatim', failing('nominatim rate limited'))
+
+    await expect(reverseGeocode(35.2, -80.8)).rejects.toThrow('nominatim rate limited')
+  })
+
+  test('an empty provider after a failing one is not treated as a total outage', async () => {
+    provider('barrelman', failing('barrelman unreachable'))
+    provider('nominatim', empty())
+
+    const { results } = await forwardGeocode('coffee')
+
+    expect(results).toEqual([])
+  })
+})
+
+describe('argument passing', () => {
+  test('forwards the query and location bias to the provider', async () => {
+    const barrelman = answering('hit')
+    provider('barrelman', barrelman)
+
+    await forwardGeocode('9201 University City Blvd', 35.3, -80.73)
+
+    expect(barrelman.geocode).toHaveBeenCalledWith('9201 University City Blvd', 35.3, -80.73)
+  })
+
+  test('forwards the coordinate to the provider', async () => {
+    const barrelman = answering('hit')
+    provider('barrelman', barrelman)
+
+    await reverseGeocode(35.2271, -80.8431)
+
+    expect(barrelman.reverseGeocode).toHaveBeenCalledWith(35.2271, -80.8431)
+  })
+})

--- a/server/src/services/geocoding.service.ts
+++ b/server/src/services/geocoding.service.ts
@@ -1,0 +1,82 @@
+import { integrationManager } from './integrations'
+import {
+  IntegrationCapabilityId,
+  type GeocodingCapability,
+} from '../types/integration.types'
+import type { Place } from '../types/place.types'
+import { logError, logger } from '../lib/logger'
+
+export interface GeocodeOutcome {
+  results: Place[]
+  /** Integration that produced the results, or null when none are configured. */
+  integrationId: string | null
+}
+
+/**
+ * Run a geocoding operation against every configured geocoding integration in
+ * priority order, returning the first non-empty result.
+ *
+ * Barrelman ranks highest, so geocoding is served from our own OSM + Pelias
+ * index — no upstream rate limit, and hits come back hydrated with full OSM
+ * geometry and tags. Nominatim and the paid providers sit below it as fallbacks
+ * for coverage gaps outside our imported regions. An integration that throws or
+ * comes back empty is skipped so the next one gets a turn; only when *every*
+ * provider fails does the error propagate, so callers can still tell an outage
+ * apart from a coordinate with genuinely nothing at it.
+ */
+async function runGeocoding(
+  operation: (capability: GeocodingCapability) => Promise<Place[]>,
+): Promise<GeocodeOutcome> {
+  const records = integrationManager.getConfiguredIntegrationsByCapability(
+    IntegrationCapabilityId.GEOCODING,
+  )
+
+  let firstTried: string | null = null
+  let attempted = 0
+  let failed = 0
+  let lastError: unknown
+
+  for (const record of records) {
+    const integration = integrationManager.getCachedIntegrationInstance(record)
+    const capability = integration?.capabilities.geocoding
+    if (!capability) continue
+
+    firstTried ??= record.integrationId
+    attempted++
+
+    try {
+      const results = await operation(capability)
+      if (results?.length) {
+        return { results, integrationId: record.integrationId }
+      }
+      logger.debug(
+        `[geocoding] ${record.integrationId} returned no results, trying next provider`,
+      )
+    } catch (err) {
+      failed++
+      lastError = err
+      logError(`Geocoding failed with ${record.integrationId}`, err)
+    }
+  }
+
+  if (attempted > 0 && failed === attempted) throw lastError
+
+  return { results: [], integrationId: firstTried }
+}
+
+/** Resolve an address or place query to coordinates. */
+export function forwardGeocode(
+  query: string,
+  lat?: number,
+  lng?: number,
+): Promise<GeocodeOutcome> {
+  return runGeocoding((capability) => capability.geocode(query, lat, lng))
+}
+
+/** Resolve a coordinate to the places at that point. */
+export function reverseGeocode(
+  lat: number,
+  lng: number,
+): Promise<GeocodeOutcome> {
+  return runGeocoding((capability) => capability.reverseGeocode(lat, lng))
+}

--- a/server/src/services/integrations/barrelman-integration.test.ts
+++ b/server/src/services/integrations/barrelman-integration.test.ts
@@ -783,6 +783,50 @@ describe('BarrelmanIntegration', () => {
     })
   })
 
+  // ── Geocoding ─────────────────────────────────────────────────────────────
+
+  describe('geocoding capability', () => {
+    test('declares the geocoding capability so it outranks Nominatim', () => {
+      expect(integration.capabilityIds).toContain('geocoding')
+      expect(integration.capabilities.geocoding).toBeDefined()
+    })
+
+    test('reverseGeocode calls /geocode/reverse with the coordinate', async () => {
+      mockAxiosGet.mockResolvedValueOnce({ data: [] })
+      await integration.reverseGeocode(37.77, -122.41)
+      const [url, config] = mockAxiosGet.mock.calls[0] as any
+      expect(url).toBe('http://localhost:3100/geocode/reverse')
+      expect(config.params).toEqual({ lat: 37.77, lng: -122.41 })
+    })
+
+    test('reverseGeocode adapts results into the unified Place model', async () => {
+      mockAxiosGet.mockResolvedValueOnce({ data: [baseResult] })
+      const places = await integration.reverseGeocode(37.7749, -122.4194)
+      expect(places).toHaveLength(1)
+      expect(places[0].name.value).toBe('Test Place')
+      expect(places[0].externalIds.osm).toBe('node/123456')
+    })
+
+    test('reverseGeocode returns [] when barrelman has nothing at the point', async () => {
+      mockAxiosGet.mockResolvedValueOnce({ data: [] })
+      expect(await integration.reverseGeocode(0, 0)).toEqual([])
+    })
+
+    test('forward geocode goes through /search so addresses and POIs both resolve', async () => {
+      mockAxiosPost.mockResolvedValueOnce({ data: [baseResult] })
+      const places = await integration.capabilities.geocoding.geocode(
+        '9201 University City Blvd',
+        37.77,
+        -122.41,
+      )
+      const [url, body] = mockAxiosPost.mock.calls[0] as any
+      expect(url).toBe('http://localhost:3100/search')
+      expect(body.query).toBe('9201 University City Blvd')
+      expect(body.lat).toBe(37.77)
+      expect(places[0].name.value).toBe('Test Place')
+    })
+  })
+
   // ── API key authentication ────────────────────────────────────────────────
 
   describe('API key authentication', () => {

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -13,6 +13,7 @@ import type {
   SpatialParentsCapability,
   SpatialChildrenCapability,
   SearchAlongRouteCapability,
+  GeocodingCapability,
   RoutingCapability,
   TransitRoutingCapability,
   TransitRouteRequest,
@@ -222,6 +223,7 @@ export class BarrelmanIntegration
     IntegrationCapabilityId.SPATIAL_PARENTS,
     IntegrationCapabilityId.SPATIAL_CHILDREN,
     IntegrationCapabilityId.SEARCH_ALONG_ROUTE,
+    IntegrationCapabilityId.GEOCODING,
     IntegrationCapabilityId.TILE_SERVER,
     IntegrationCapabilityId.ROUTING,
     IntegrationCapabilityId.TRANSIT_ROUTING,
@@ -254,6 +256,14 @@ export class BarrelmanIntegration
     searchAlongRoute: {
       searchAlongRoute: this.searchAlongRoute.bind(this),
     } as SearchAlongRouteCapability,
+    geocoding: {
+      // Forward geocoding is just search: barrelman's /search already folds the
+      // Pelias address index in with its own POI layers, so one call resolves
+      // both "Starbucks" and "9201 University City Blvd".
+      geocode: (query: string, lat?: number, lng?: number) =>
+        this.searchPlaces(query, lat, lng),
+      reverseGeocode: this.reverseGeocode.bind(this),
+    } as GeocodingCapability,
     routing: {
       getRoute: this.getRoute.bind(this),
       metadata: {
@@ -921,6 +931,26 @@ export class BarrelmanIntegration
         autocomplete: options?.autocomplete ?? false,
       },
       { headers: this.headers, timeout: 10000 },
+    )
+    return (response.data || []).map((r: any) => this.adaptPlace(r))
+  }
+
+  /**
+   * Reverse geocode a coordinate to the places at that point. Barrelman returns
+   * the geocoder hit already hydrated into its full OSM row (geometry, tags,
+   * hours), falling back to the smallest containing administrative area when
+   * nothing addressable is nearby — so a dropped pin always resolves to
+   * something, and does so from our own index rather than a rate-limited
+   * upstream.
+   */
+  async reverseGeocode(lat: number, lng: number): Promise<Place[]> {
+    const response = await barrelmanSearchHttp.get(
+      `${this.config.host}/geocode/reverse`,
+      {
+        params: { lat, lng },
+        headers: this.headers,
+        timeout: 10000,
+      },
     )
     return (response.data || []).map((r: any) => this.adaptPlace(r))
   }

--- a/server/src/services/place.service.ts
+++ b/server/src/services/place.service.ts
@@ -14,6 +14,7 @@ import { WikipediaIntegration } from './integrations/wikipedia-integration'
 import { WikimediaIntegration } from './integrations/wikimedia-integration'
 import { dedupeWikiPhotos } from './integrations/wiki-utils'
 import { isTransitStop, extractAllOnestopIdsFromWikidata } from '../lib/transit-utils'
+import { reverseGeocode } from './geocoding.service'
 import { logError, logWarn, logger } from '../lib/logger'
 
 /** True for an aborted/cancelled request (axios CanceledError or DOM AbortError). */
@@ -954,28 +955,19 @@ export async function lookupEnrichedPlaceByCoordinates(
   try {
     const { userId, radius = 50, language = 'en', addressOnly = false, premiumData = false } = options || {}
 
-    // Step 1: Reverse geocode to find place at coordinates
-    const geocodingIntegrations = integrationManager.getConfiguredIntegrationsByCapability(
-      IntegrationCapabilityId.GEOCODING
-    )
-    
-    if (!geocodingIntegrations.length) {
+    // Step 1: Reverse geocode to find place at coordinates. Walks the geocoding
+    // integrations by priority (Barrelman first), so a provider with no
+    // coverage at this coordinate falls through to the next.
+    const step1Start = Date.now()
+    const { results, integrationId } = await reverseGeocode(lat, lng)
+    const step1Time = Date.now() - step1Start
+    logger.debug(`[PERF] Step 1 - Reverse geocoding: ${step1Time}ms`)
+
+    if (!integrationId) {
       logError('No geocoding integration available')
       return null
     }
-    
-    const geocodingIntegration = integrationManager.getCachedIntegrationInstance(geocodingIntegrations[0])
-    
-    if (!geocodingIntegration?.capabilities.geocoding) {
-      logError('Geocoding capability not available')
-      return null
-    }
-    
-    const step1Start = Date.now()
-    const results = await geocodingIntegration.capabilities.geocoding.reverseGeocode(lat, lng)
-    const step1Time = Date.now() - step1Start
-    logger.debug(`[PERF] Step 1 - Reverse geocoding: ${step1Time}ms`)
-    
+
     if (!results?.[0]) {
       logger.debug(`[PERF] Total time (no results): ${Date.now() - startTime}ms`)
       return null
@@ -998,7 +990,7 @@ export async function lookupEnrichedPlaceByCoordinates(
       place.name = { value: `${parseFloat(lat.toFixed(5))}, ${parseFloat(lng.toFixed(5))}`, sourceId: 'geocoding', timestamp: new Date().toISOString() }
       place.description = null
       place.placeType = { value: 'Coordinates', sourceId: 'geocoding', timestamp: new Date().toISOString() }
-      place.icon = { icon: 'Crosshair', iconPack: 'lucide' }
+      place.icon = { category: 'default', icon: 'Crosshair', iconPack: 'lucide' }
       place.photos = []
       place.contactInfo = { phone: null, email: null, website: null, socials: {} }
       place.openingHours = null


### PR DESCRIPTION
## Why

Reverse geocoding — the map context menu, dropped pins, coordinate lookups — went to the public Nominatim instance, which is rate limited to 1 req/s and returns a flat address with no geometry or tags. Barrelman has the data locally and now [exposes reverse geocoding](https://github.com/alexwohlbruck/barrelman/pull/24).

**Requires barrelman#24** — `reverseGeocode` calls the new `/geocode/reverse` endpoint.

## What

**Barrelman gains the `geocoding` capability.** Forward geocoding routes to `/search`, which already folds the Pelias address index in with the POI layers, so one call resolves both `Starbucks` and `9201 University City Blvd`. Reverse routes to the new `/geocode/reverse`. Barrelman's priority is already 105 against Nominatim's 90, so it takes over wherever it's configured — and startup capability reconciliation activates it on existing DB rows, no migration needed.

**Provider selection moved into `geocoding.service.ts`.** The controller previously took `integrations[0]` and nothing else, so promoting Barrelman to first would have made it a single point of failure. Providers are now walked in priority order: one that errors or returns nothing yields to the next, so Nominatim and the paid providers become real fallbacks for coordinates outside imported regions. `place.service`'s coordinate lookup had the same `[0]`-only problem and now shares this path.

Error semantics are preserved deliberately: the error propagates only when *every* provider fails, so callers can still tell an outage apart from a coordinate with genuinely nothing at it.

## Result

Reverse geocoding now returns the full OSM feature — outline, tags, opening hours — rather than a name and an address string.

| Click | Provider | Result |
|---|---|---|
| UNCC campus | barrelman | The University of North Carolina at Charlotte + polygon + tags |
| Uptown statue | barrelman | "Industry", 105 South Tryon Street |
| Empty area | barrelman | Charlotte (admin fallback, previously blank) |
| Forward "Truist Field" | barrelman | Truist Field |

## Tests

16 new — 5 on the integration (capability declared, endpoint + params, adaptation, empty result, forward via `/search`) and 11 on provider selection (priority order, fallback on empty and on error, skipping a provider without the capability, null `integrationId` when none configured, rethrow only on total outage).

`barrelman-integration.test.ts` passes 95/95 in isolation. Note it fails wholesale in a full-suite run — all 90 of its tests already did before this change, from a pre-existing `mock.module` isolation issue with the axios mock.

Docs: alexwohlbruck/parchment-docs#docs/barrelman-geocoding