### PR TITLE
Stop requireAuth leaking onto GET /auth/sessions/current

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * Looking up an address — right-clicking the map, dropping a pin, searching a street — now answers from your own Barrelman instance instead of the public OpenStreetMap geocoder. It's faster, isn't rate limited, and the place you land on comes back with its real outline, opening hours and tags rather than just a name. Nominatim and the other providers stay on as fallbacks for anywhere outside the regions you've imported
 * Right-clicking somewhere with nothing on it — a park, a field, open water — now names the town or city you're in instead of coming back blank
 
+### Fixed
+
+* Search, place detail and geocoding no longer go dark when Barrelman's transit data is stale. A single degraded subsystem was enough to make Parchment drop the connection entirely, taking every other Barrelman feature down with it
+
 ## [0.5.10] - 2026-07-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+* Indoor maps — switch it on under Appearance and airports, malls and stadiums that Mapbox has mapped inside show their floor plans, with a floor selector on the edge of the map for moving between levels
+
 ### Changed
 
 * Looking up an address — right-clicking the map, dropping a pin, searching a street — now answers from your own Barrelman instance instead of the public OpenStreetMap geocoder. It's faster, isn't rate limited, and the place you land on comes back with its real outline, opening hours and tags rather than just a name. Nominatim and the other providers stay on as fallbacks for anywhere outside the regions you've imported

--- a/server/src/controllers/auth.controller.test.ts
+++ b/server/src/controllers/auth.controller.test.ts
@@ -383,17 +383,32 @@ describe('GET /auth/sessions/current', () => {
     expect(res.body.subscription.tier).toBe('basic')
   })
 
-  test('401s when signed out, despite the handler’s 204 branch', async () => {
-    // The handler starts with `if (!user) { set.status = 204; return null }`,
-    // but that branch is unreachable: this route is declared with
-    // `app.use(getSession)` AFTER earlier routes in the same group called
-    // `app.use(requireAuth)`, and Elysia's `.use()` mutates the instance, so
-    // the guard is inherited and rejects first.
+  test('answers 204 when signed out, not 401', async () => {
+    // The client polls this to decide whether it *is* signed in, so a signed
+    // out caller must get the handler's `if (!user)` branch rather than a
+    // guard rejection. That branch was unreachable until the `/all` and
+    // `/others` routes were moved into their own `.group('')` scope: Elysia's
+    // `.use()` leaks forward, so their requireAuth was inherited here.
     setAuthUser(null)
 
     const res = await req(app).get('/auth/sessions/current')
 
-    expect(res.status).toBe(401)
+    expect(res.status).toBe(204)
+  })
+
+  test('sign-in and sign-out stay reachable without a session', async () => {
+    // Same guard-leak class as above: these sit on the /sessions instance
+    // alongside requireAuth'd routes. Pinned so a future route added in the
+    // wrong place can't quietly lock anonymous callers out of signing in.
+    setAuthUser(null)
+
+    const signIn = await req(app).post('/auth/sessions', {
+      body: { method: 'otp', email: TEST_USER.email, token: '12345678' },
+    })
+    expect(signIn.status).toBe(200)
+
+    const signOut = await req(app).delete('/auth/sessions')
+    expect(signOut.status).toBe(204)
   })
 })
 

--- a/server/src/controllers/auth.controller.ts
+++ b/server/src/controllers/auth.controller.ts
@@ -483,53 +483,122 @@ app.group('/sessions', (app) => {
     },
   )
 
-  app.use(requireAuth).delete(
-    '/all',
-    async ({ user, cookie, set }) => {
-      await destroyAllSessions(user.id)
-      // Drop the current cookie too so the caller doesn't keep a stale
-      // session id locally after the DB rows are gone.
-      const sessionCookie = cookie['auth_session']
-      if (sessionCookie) {
-        sessionCookie.path = '/'
-        sessionCookie.remove()
-      }
-      set.status = 204
-    },
-    {
-      detail: {
-        tags: ['Auth'],
-        description:
-          'Sign out of every device. Destroys all session rows and rotates ' +
-          'every per-device wrap secret so any cached seed envelope on any ' +
-          'device is immediately unusable.',
-      },
-    },
-  )
+  // Every session-guarded route lives in this one `.group('')` scope, and the
+  // public routes stay outside it. `.use()` applies to the whole instance it is
+  // called on regardless of declaration order, so a bare `.use(requireAuth)`
+  // here would also guard `current` below — which must answer 204 rather than
+  // 401 when signed out, since the client polls it to decide if it is signed
+  // in. `.group('')` is what contains the guard; ordering alone does not.
+  // Keep `/all` and `/others` ahead of `/:sessionId` so the literal paths win.
+  app.group('', (app) => {
+    // `.use()` mutates and returns the same instance, but only the returned
+    // reference carries the derived `user` / `session` types — bind it.
+    const guarded = app.use(requireAuth)
 
-  app.use(requireAuth).delete(
-    '/others',
-    async ({ user, session, body, set }) => {
-      await destroyOtherSessions(user.id, session.id, body.deviceId)
-      set.status = 204
-    },
-    {
-      body: t.Object({
-        deviceId: t.String({
-          minLength: 8,
-          maxLength: 64,
-          pattern: '^[a-zA-Z0-9-]+$',
-        }),
-      }),
-      detail: {
-        tags: ['Auth'],
-        description:
-          "Sign out of every OTHER device. Keeps the caller's session " +
-          "and wrap secret intact; rotates every other device's wrap " +
-          'secret and deletes every other session row.',
+    guarded.delete(
+      '/all',
+      async ({ user, cookie, set }) => {
+        await destroyAllSessions(user.id)
+        // Drop the current cookie too so the caller doesn't keep a stale
+        // session id locally after the DB rows are gone.
+        const sessionCookie = cookie['auth_session']
+        if (sessionCookie) {
+          sessionCookie.path = '/'
+          sessionCookie.remove()
+        }
+        set.status = 204
       },
-    },
-  )
+      {
+        detail: {
+          tags: ['Auth'],
+          description:
+            'Sign out of every device. Destroys all session rows and rotates ' +
+            'every per-device wrap secret so any cached seed envelope on any ' +
+            'device is immediately unusable.',
+        },
+      },
+    )
+
+    guarded.delete(
+      '/others',
+      async ({ user, session, body, set }) => {
+        await destroyOtherSessions(user.id, session.id, body.deviceId)
+        set.status = 204
+      },
+      {
+        body: t.Object({
+          deviceId: t.String({
+            minLength: 8,
+            maxLength: 64,
+            pattern: '^[a-zA-Z0-9-]+$',
+          }),
+        }),
+        detail: {
+          tags: ['Auth'],
+          description:
+            "Sign out of every OTHER device. Keeps the caller's session " +
+            "and wrap secret intact; rotates every other device's wrap " +
+            'secret and deletes every other session row.',
+        },
+      },
+    )
+
+    guarded.get(
+      'current/permissions',
+      async ({ user }) => {
+        const [permissions, subscription, userRoles] = await Promise.all([
+          getPermissions(user.id),
+          billing.enabled
+            ? getSubscriptionStatus(user.id)
+            : { isPremium: true, isBasic: false, hasSubscription: false, tier: 'premium' as const },
+          getRoles(user.id),
+        ])
+        return { permissions, subscription, roles: userRoles.map((r) => r.id) }
+      },
+      {
+        detail: {
+          tags: ['Auth'],
+          summary: 'Get current session permissions',
+        },
+      },
+    )
+
+    guarded.get(
+      '/',
+      async ({ set, user }) => {
+        return await db
+          .select()
+          .from(sessions)
+          .where(eq(sessions.userId, user.id))
+          .orderBy(desc(sessions.createdAt))
+      },
+      {
+        detail: {
+          tags: ['Auth'],
+          summary: 'Get all sessions for current user',
+        },
+      },
+    )
+
+    guarded.delete(
+      '/:sessionId',
+      async ({ set, user, params: { sessionId } }) => {
+        if (!user) return (set.status = 401)
+        await db
+          .delete(sessions)
+          .where(and(eq(sessions.id, sessionId), eq(sessions.userId, user.id)))
+        return (set.status = 204)
+      },
+      {
+        detail: {
+          tags: ['Auth'],
+          summary: 'Delete a session',
+        },
+      },
+    )
+
+    return app
+  })
 
   app.use(getSession).get(
     'current',
@@ -555,60 +624,6 @@ app.group('/sessions', (app) => {
     {
       detail: {
         tags: ['Auth', 'Users'],
-      },
-    },
-  )
-
-  app.use(requireAuth).get(
-    'current/permissions',
-    async ({ user }) => {
-      const [permissions, subscription, userRoles] = await Promise.all([
-        getPermissions(user.id),
-        billing.enabled
-          ? getSubscriptionStatus(user.id)
-          : { isPremium: true, isBasic: false, hasSubscription: false, tier: 'premium' as const },
-        getRoles(user.id),
-      ])
-      return { permissions, subscription, roles: userRoles.map((r) => r.id) }
-    },
-    {
-      detail: {
-        tags: ['Auth'],
-        summary: 'Get current session permissions',
-      },
-    },
-  )
-
-  app.use(requireAuth).get(
-    '/',
-    async ({ set, user }) => {
-      return await db
-        .select()
-        .from(sessions)
-        .where(eq(sessions.userId, user.id))
-        .orderBy(desc(sessions.createdAt))
-    },
-    {
-      detail: {
-        tags: ['Auth'],
-        summary: 'Get all sessions for current user',
-      },
-    },
-  )
-
-  app.use(requireAuth).delete(
-    '/:sessionId',
-    async ({ set, user, params: { sessionId } }) => {
-      if (!user) return (set.status = 401)
-      await db
-        .delete(sessions)
-        .where(and(eq(sessions.id, sessionId), eq(sessions.userId, user.id)))
-      return (set.status = 204)
-    },
-    {
-      detail: {
-        tags: ['Auth'],
-        summary: 'Delete a session',
       },
     },
   )

--- a/server/src/services/integrations/barrelman-integration.test.ts
+++ b/server/src/services/integrations/barrelman-integration.test.ts
@@ -82,11 +82,38 @@ describe('BarrelmanIntegration', () => {
       expect(result.success).toBe(true)
     })
 
-    test('fails when endpoint returns non-ok status', async () => {
-      mockAxiosGet.mockResolvedValueOnce({ data: { status: 'degraded' } })
+    test('succeeds when degraded — an optional subsystem down is not an outage', async () => {
+      // A stale MOTIS realtime feed reports `degraded`. Failing here would throw
+      // out of initializeWithTest and leave Barrelman uncached, taking search,
+      // place detail and geocoding down with transit.
+      mockAxiosGet.mockResolvedValueOnce({
+        data: { status: 'degraded', database: 'connected', motis: 'unavailable' },
+      })
+      const result = await integration.testConnection({ host: 'http://api.example.com' })
+      expect(result.success).toBe(true)
+    })
+
+    test('fails when the status is error — the database is down', async () => {
+      mockAxiosGet.mockResolvedValueOnce({
+        data: { status: 'error', database: 'disconnected' },
+      })
+      const result = await integration.testConnection({ host: 'http://api.example.com' })
+      expect(result.success).toBe(false)
+      expect(result.message).toContain('error')
+    })
+
+    test('fails when the response carries no status at all', async () => {
+      mockAxiosGet.mockResolvedValueOnce({ data: {} })
       const result = await integration.testConnection({ host: 'http://api.example.com' })
       expect(result.success).toBe(false)
       expect(result.message).toBeDefined()
+    })
+
+    test('allows enough time for the health probe to reach MOTIS', async () => {
+      mockAxiosGet.mockResolvedValueOnce({ data: { status: 'ok' } })
+      await integration.testConnection({ host: 'http://api.example.com' })
+      const [, config] = mockAxiosGet.mock.calls[0]
+      expect(config.timeout).toBeGreaterThanOrEqual(10_000)
     })
 
     test('fails immediately when config has no host', async () => {

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -331,12 +331,25 @@ export class BarrelmanIntegration
     try {
       const response = await barrelmanHttp.get(`${config.host}/health/auth`, {
         headers,
-        timeout: 5000,
+        // Generous, because /health/auth transitively probes MOTIS (3s of its
+        // own) — a tighter budget times out while Barrelman is merely busy
+        // starting up, and a failed test leaves it out of the cache entirely.
+        timeout: 10_000,
       })
-      if (response.data?.status === 'ok') {
+      // `degraded` means an optional subsystem is down — today that is MOTIS
+      // realtime, which affects transit only. Search, place detail, geocoding,
+      // tiles and routing all still serve. Refusing the connection there would
+      // drop EVERY Barrelman capability (initializeWithTest throws and the
+      // integration is never cached), turning a stale transit feed into a
+      // total search outage. Only `error` — the database being down — is fatal.
+      const status = response.data?.status
+      if (status === 'ok' || status === 'degraded') {
         return { success: true }
       }
-      return { success: false, message: 'Barrelman health check failed' }
+      return {
+        success: false,
+        message: `Barrelman health check failed${status ? `: ${status}` : ''}`,
+      }
     } catch (e: any) {
       if (e.response?.status === 401) {
         return {

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -44,7 +44,7 @@
         "latest": "^0.2.0",
         "lucide-static": "^0.511.0",
         "lucide-vue-next": "0.475.0",
-        "mapbox-gl": "^3.25.0",
+        "mapbox-gl": "^3.27.0",
         "mapillary-js": "^4.1.2",
         "maplibre-gl": "^4.2.0",
         "mitt": "^3.0.1",
@@ -1612,7 +1612,7 @@
 
     "make-asynchronous": ["make-asynchronous@1.1.0", "", { "dependencies": { "p-event": "^6.0.0", "type-fest": "^4.6.0", "web-worker": "^1.5.0" } }, "sha512-ayF7iT+44LXdxJLTrTd3TLQpFDDvPCBxXxbv+pMUSuHA5Q8zyAfwkRP6aHHwNVFBUFWtxAHqwNJxF8vMZLAbVg=="],
 
-    "mapbox-gl": ["mapbox-gl@3.25.0", "", {}, "sha512-I+9oSkJVFu51xIAAQcjKophFe6zVAGWROHsszeRhX9E1OXEizgPH+8BkF7GaxmmLd9FbADdEfvULF8NxEFcB5w=="],
+    "mapbox-gl": ["mapbox-gl@3.27.0", "", {}, "sha512-K8W9LTTjFEJsg9qsnJbKk+zbXrmSqa+nU1EiFXez5gQ0T0RMtylZUelgg1/RE6vCUMvHX0gaYfWU9g2mTWuA0g=="],
 
     "mapillary-js": ["mapillary-js@4.1.2", "", { "dependencies": { "@types/earcut": "^2.1.1", "@types/node": "^14.14.31", "@types/pako": "^1.0.2", "@types/pbf": "^3.0.2", "@types/polylabel": "^1.0.5", "@types/rbush": "^3.0.0", "@types/three": "^0.134.0", "@types/virtual-dom": "^2.1.1", "earcut": "^2.2.3", "martinez-polygon-clipping": "^0.7.1", "pako": "^2.0.4", "pbf": "^3.2.1", "polylabel": "^1.1.0", "rbush": "^3.0.1", "rxjs": "^7.3.0", "s2-geometry": "^1.2.10", "three": "^0.134.0", "virtual-dom": "^2.1.1" } }, "sha512-LYj6xbp/Y9wfBkr/prRwgJGb3+KwvzUri0yl5QEpMEH7oC1p52ErshWmPXysKefmm6JaFML4D7FJ89viwJ4T5g=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -71,7 +71,7 @@
     "latest": "^0.2.0",
     "lucide-static": "^0.511.0",
     "lucide-vue-next": "0.475.0",
-    "mapbox-gl": "^3.25.0",
+    "mapbox-gl": "^3.27.0",
     "mapillary-js": "^4.1.2",
     "maplibre-gl": "^4.2.0",
     "mitt": "^3.0.1",

--- a/web/src/components/map/ContextMenu.vue
+++ b/web/src/components/map/ContextMenu.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, computed, watch, h } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRouter, type RouteLocationRaw } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import { storeToRefs } from 'pinia'
 import { useAppService } from '@/services/app.service'
@@ -39,7 +39,7 @@ import {
 } from 'lucide-vue-next'
 import ResponsiveDropdown from '@/components/responsive/ResponsiveDropdown.vue'
 import { Skeleton } from '@/components/ui/skeleton'
-import { formatAddress } from '@/lib/place.utils'
+import { formatAddress, getPlaceRouteFromExternalIds } from '@/lib/place.utils'
 import {
   findSegmentToInsert,
   distancePx,
@@ -72,8 +72,8 @@ const clickedLngLat = ref<LngLat | null>(null)
 const clickedPoint = ref<{ x: number; y: number } | null>(null)
 const geocodedPlaceName = ref<string | null>(null)
 const geocodedAddress = ref<string | null>(null)
-const geocodedOsmId = ref<string | null>(null)
-const geocodedPlaceId = ref<{ provider: string; id: string } | null>(null)
+/** Route to the geocoded place's detail page, when its ids resolve to one. */
+const geocodedRoute = ref<RouteLocationRaw | null>(null)
 const isGeocoding = ref(false)
 
 onMounted(() => {
@@ -120,25 +120,11 @@ function copyAddress() {
 function openPlaceAtLocation() {
   if (!clickedLngLat.value) return
 
-  // Priority 1: If we have an OSM ID from geocoding, open the full OSM place
-  if (geocodedOsmId.value) {
-    const [type, id] = geocodedOsmId.value.split('/')
-    router.push({
-      name: AppRoute.PLACE,
-      params: { type, id },
-    })
+  // Priority 1: the geocoded place resolved to its own detail route
+  if (geocodedRoute.value) {
+    router.push(geocodedRoute.value)
   }
-  // Priority 2: If we have a provider-specific place ID (e.g., Geoapify), use provider lookup
-  else if (geocodedPlaceId.value) {
-    router.push({
-      name: AppRoute.PLACE_PROVIDER,
-      params: {
-        provider: geocodedPlaceId.value.provider,
-        placeId: geocodedPlaceId.value.id,
-      },
-    })
-  }
-  // Priority 3: If we have a place name (but no ID), use name+coordinate lookup
+  // Priority 2: If we have a place name (but no ID), use name+coordinate lookup
   else if (geocodedPlaceName.value) {
     router.push({
       name: AppRoute.PLACE_LOCATION,
@@ -149,7 +135,7 @@ function openPlaceAtLocation() {
       },
     })
   }
-  // Priority 4: No name or ID, use coordinate-only lookup
+  // Priority 3: No name or ID, use coordinate-only lookup
   else {
     router.push({
       name: AppRoute.PLACE_COORDS,
@@ -177,8 +163,7 @@ watch([showContextMenu, clickedLngLat], async ([isOpen, lngLat]) => {
   if (isOpen && lngLat) {
     geocodedPlaceName.value = null
     geocodedAddress.value = null
-    geocodedOsmId.value = null
-    geocodedPlaceId.value = null
+    geocodedRoute.value = null
     isGeocoding.value = true
 
     try {
@@ -192,20 +177,13 @@ watch([showContextMenu, clickedLngLat], async ([isOpen, lngLat]) => {
       if (result.results?.[0]) {
         const place = result.results[0]
 
-        // Priority 1: Store OSM ID if available
-        geocodedOsmId.value = place.externalIds?.osm || null
-
-        // Priority 2: Store provider-specific place ID (e.g., Geoapify)
-        if (
-          !geocodedOsmId.value &&
-          result.integration &&
-          place.externalIds?.[result.integration]
-        ) {
-          geocodedPlaceId.value = {
-            provider: result.integration,
-            id: place.externalIds[result.integration],
-          }
-        }
+        // Resolve the route from the place's own external ids. Keying off the
+        // integration name instead would miss geocoder addresses: Barrelman
+        // fronts Pelias, so an address comes back under `pelias` while the
+        // integration reads `barrelman`, and the mismatch dropped it through to
+        // a fuzzy name search. This is the same helper bookmarks and map dots
+        // route on, so every surface resolves a place identically.
+        geocodedRoute.value = getPlaceRouteFromExternalIds(place.externalIds)
 
         // Store place name and address separately
         geocodedPlaceName.value = place.name?.value || null
@@ -219,8 +197,7 @@ watch([showContextMenu, clickedLngLat], async ([isOpen, lngLat]) => {
   } else {
     geocodedPlaceName.value = null
     geocodedAddress.value = null
-    geocodedOsmId.value = null
-    geocodedPlaceId.value = null
+    geocodedRoute.value = null
     isGeocoding.value = false
   }
 })

--- a/web/src/components/map/map-providers/map.strategy.ts
+++ b/web/src/components/map/map-providers/map.strategy.ts
@@ -139,6 +139,7 @@ export class MapStrategy {
   setBasemap(basemap: Basemap) {}
   setMapStyle(styleId: MapStyleId) {}
   setHdRoads(value: boolean) {}
+  setIndoorMaps(value: boolean) {}
   setMapLanguage(locale: string): boolean {
     return false // Default: no reinitialization needed
   }

--- a/web/src/components/map/map-providers/mapbox.strategy.ts
+++ b/web/src/components/map/map-providers/mapbox.strategy.ts
@@ -1,5 +1,7 @@
 import { MapStrategy } from './map.strategy'
-import {
+// `IndoorControl` is only reachable through the default export — mapbox-gl's
+// typings don't re-export the experimental indoor API as a named binding.
+import mapboxgl, {
   Map as MapboxMap,
   NavigationControl,
   AttributionControl,
@@ -68,13 +70,18 @@ declare module 'mapbox-gl' {
   }
 }
 
+// Whether the loaded style imports the Standard `basemap` fragment. Config
+// properties (lightPreset, showIndoor, …) only exist on that import — the
+// satellite styles have none, so setting them there throws.
+function hasBasemapImport(map: MapboxMap): boolean {
+  return !!(map.style as any).fragments?.some((f: any) => f.id === 'basemap')
+}
+
 // Guard decorator to ensure the basemap is loaded
 function ifBasemapLoaded(target, name, descriptor) {
   const original = descriptor.value
   descriptor.value = function (...args) {
-    if (
-      this.mapInstance.style.fragments?.some((f: any) => f.id === 'basemap')
-    ) {
+    if (hasBasemapImport(this.mapInstance)) {
       original.apply(this, args)
     }
   }
@@ -120,6 +127,7 @@ export class MapboxStrategy extends MapStrategy {
   layerGroups: Map<string, MapLayerGroup> = new Map()
   private currentLanguage?: string
   private hdRoadsEnabled: boolean = false
+  private indoorControl?: InstanceType<typeof mapboxgl.IndoorControl>
 
   constructor(
     container,
@@ -432,12 +440,10 @@ export class MapboxStrategy extends MapStrategy {
     })
 
     // Get all route coordinates
-    const allCoordinates: mapboxgl.LngLatLike[] = directions.legs.flatMap(
-      leg => {
-        const shape = decodeShape(leg.shape)
-        return shape.map(([lat, lon]) => [lon, lat] as mapboxgl.LngLatLike)
-      },
-    )
+    const allCoordinates: LngLatLike[] = directions.legs.flatMap(leg => {
+      const shape = decodeShape(leg.shape)
+      return shape.map(([lat, lon]) => [lon, lat] as LngLatLike)
+    })
 
     // Create a bounds object that encompasses all coordinates
     const bounds = allCoordinates.reduce(
@@ -594,6 +600,32 @@ export class MapboxStrategy extends MapStrategy {
     } else {
       // Remove HD roads import
       this.mapInstance.removeImport('hd-roads')
+    }
+  }
+
+  /**
+   * Indoor floor plans, plus the floor selector needed to move between them.
+   * Standard style only — on satellite/hybrid there is no `basemap` import to
+   * configure, so the control would render an empty shell. Config properties
+   * reset on every style load, but the control persists across them, so the
+   * two are kept in sync independently.
+   */
+  setIndoorMaps(value: boolean) {
+    // A persisted settings object may predate this key, and setConfigProperty
+    // rejects `undefined` outright — coerce before handing it to the engine.
+    const enabled = !!value
+    const supported = hasBasemapImport(this.mapInstance)
+    if (supported) {
+      this.mapInstance.setConfigProperty('basemap', 'showIndoor', enabled)
+    }
+
+    const shouldShowControl = enabled && supported
+    if (shouldShowControl && !this.indoorControl) {
+      this.indoorControl = new mapboxgl.IndoorControl()
+      this.mapInstance.addControl(this.indoorControl, 'right')
+    } else if (!shouldShowControl && this.indoorControl) {
+      this.mapInstance.removeControl(this.indoorControl)
+      this.indoorControl = undefined
     }
   }
 

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -1507,6 +1507,8 @@
         "3dObjects": "3D objects",
         "hdRoads": "HD roads",
         "hdRoadsDescription": "High-definition road visualization with enhanced detail",
+        "indoorMaps": "Indoor maps",
+        "indoorMapsDescription": "Show floor plans for airports, malls and stadiums, with a floor selector. Requires the standard basemap.",
         "poiLabels": "POI labels",
         "roadLabels": "Road labels",
         "transitLabels": "Transit labels",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -1424,6 +1424,8 @@
         "3dObjects": "Objetos 3D",
         "hdRoads": "Carreteras HD",
         "hdRoadsDescription": "Visualización de carreteras de alta definición con detalles mejorados",
+        "indoorMaps": "Mapas de interiores",
+        "indoorMapsDescription": "Muestra planos de aeropuertos, centros comerciales y estadios, con un selector de plantas. Requiere el mapa base estándar.",
         "poiLabels": "Etiquetas de POI",
         "roadLabels": "Etiquetas de carreteras",
         "transitLabels": "Etiquetas de tránsito",

--- a/web/src/lib/place.utils.test.ts
+++ b/web/src/lib/place.utils.test.ts
@@ -38,6 +38,30 @@ describe('getPlaceRouteFromExternalIds', () => {
     ).toMatchObject({ params: { lat: '35.2271', lng: '-80.8431' } })
   })
 
+  it('routes a geocoder address to the pelias provider view', () => {
+    // Barrelman fronts Pelias, so a reverse-geocoded street address arrives
+    // with only a `pelias` id. Routing it by name instead produced
+    // `?source=osm&id=1415 South Church Street`, which the backend rejects as a
+    // malformed OSM id.
+    expect(
+      getPlaceRouteFromExternalIds({
+        pelias: 'openaddresses:address:us/nc/mecklenburg:9944f712',
+      }),
+    ).toMatchObject({
+      params: {
+        provider: 'pelias',
+        placeId: 'openaddresses:address:us/nc/mecklenburg:9944f712',
+      },
+    })
+  })
+
+  it('keeps the whole gid when the id itself contains slashes', () => {
+    const route: any = getPlaceRouteFromExternalIds({
+      pelias: 'openaddresses:address:us/nc/mecklenburg:9944f712',
+    })
+    expect(route.params.placeId).toContain('us/nc/mecklenburg')
+  })
+
   it('returns null when there is nothing to route to', () => {
     expect(getPlaceRouteFromExternalIds({})).toBeNull()
     expect(getPlaceRouteFromExternalIds(undefined)).toBeNull()

--- a/web/src/services/map.service.ts
+++ b/web/src/services/map.service.ts
@@ -559,6 +559,7 @@ function mapService() {
     mapStrategy?.setMap3dObjects(mapStore.settings.objects3d)
     mapStrategy?.setMap3dTerrain(mapStore.settings.terrain3d)
     mapStrategy?.setHdRoads(mapStore.settings.hdRoads)
+    mapStrategy?.setIndoorMaps(mapStore.settings.indoorMaps)
   }
 
   let isInitializingGroups = false
@@ -949,6 +950,17 @@ function mapService() {
     },
   )
 
+  function toggleIndoorMaps(value?: boolean) {
+    mapStore.settings.indoorMaps = value ?? !mapStore.settings.indoorMaps
+  }
+
+  watch(
+    () => mapStore.settings.indoorMaps,
+    value => {
+      mapStrategy?.setIndoorMaps(value)
+    },
+  )
+
   function toggleNorthUpSnap(value?: boolean) {
     // Default-on: a persisted settings object may predate this key.
     const enabled = mapStore.settings.northUpSnap !== false
@@ -1331,6 +1343,7 @@ function mapService() {
     toggleTransitLabels,
     togglePlaceLabels,
     toggleHdRoads,
+    toggleIndoorMaps,
     toggleNorthUpSnap,
     destroy,
     on,

--- a/web/src/services/place.service.ts
+++ b/web/src/services/place.service.ts
@@ -204,6 +204,32 @@ function placeService() {
   }
 
   /**
+   * Fetch place details by name near a coordinate — the fallback for a place
+   * that has a label but no id we can look up (a geocoder hit whose source we
+   * can't resolve to a provider route).
+   *
+   * Kept separate from `fetchPlaceDetails` rather than threaded through its
+   * options: that function defaults `source` to `osm`, so passing `undefined`
+   * still produced `?source=osm&id=<the name>` and the backend rejected it as a
+   * malformed OSM id.
+   */
+  async function fetchPlaceDetailsByName(
+    name: string,
+    coordinates: { lat: number; lng: number },
+    options?: { radius?: number },
+    signal?: AbortSignal,
+  ): Promise<Place | null> {
+    const queryParams: Record<string, string> = {
+      name,
+      lat: coordinates.lat.toString(),
+      lng: coordinates.lng.toString(),
+    }
+    if (options?.radius) queryParams.radius = options.radius.toString()
+
+    return fetchPlaceWithCache(queryParams, signal)
+  }
+
+  /**
    * Fetch place details by coordinates with enrichment
    */
   async function fetchPlaceDetailsByCoordinates(
@@ -254,6 +280,7 @@ function placeService() {
     currentPlace,
     loading,
     fetchPlaceDetails,
+    fetchPlaceDetailsByName,
     fetchPlaceDetailsByCoordinates,
     setPartialPlace,
     findCachedPlace,

--- a/web/src/stores/map.store.ts
+++ b/web/src/stores/map.store.ts
@@ -35,6 +35,7 @@ const defaultSettings: MapSettings = {
   transitLabels: true,
   placeLabels: true,
   hdRoads: false,
+  indoorMaps: false,
   northUpSnap: true,
   gridSnapMode: GridSnapMode.NORTH_UP,
   locateFlySpeed: LocateFlySpeed.NORMAL,

--- a/web/src/types/map.types.ts
+++ b/web/src/types/map.types.ts
@@ -78,6 +78,11 @@ export interface MapSettings {
   placeLabels: boolean
   hdRoads: boolean
   /**
+   * Render indoor floor plans (airports, malls, stadiums) with a floor
+   * selector. Mapbox Standard style only, and only from zoom 16.
+   */
+  indoorMaps: boolean
+  /**
    * When true, snaps the map upright when a rotation ends close to north. This
    * is our own reimplementation — the engine's native `bearingSnap` is disabled
    * so the behavior can be toggled live (see map.service `snapRotation`).

--- a/web/src/views/place/Place.vue
+++ b/web/src/views/place/Place.vue
@@ -11,7 +11,7 @@ import { AppRoute } from '@/router'
 
 const route = useRoute()
 const router = useRouter()
-const { currentPlace, loading, fetchPlaceDetails, fetchPlaceDetailsByCoordinates, clearPlace, setPartialPlace } =
+const { currentPlace, loading, fetchPlaceDetails, fetchPlaceDetailsByName, fetchPlaceDetailsByCoordinates, clearPlace, setPartialPlace } =
   usePlaceService()
 const { flyTo, fitBounds, addMarker, removeMarker, updatePlacePolygon } = useMapService()
 const { nextSignal } = useAbortController()
@@ -100,7 +100,7 @@ async function loadPlace() {
     }
 
     // Use name-based search for more accurate results
-    const place = await fetchPlaceDetails(name, undefined, coordinates, nextSignal())
+    const place = await fetchPlaceDetailsByName(name, coordinates, undefined, nextSignal())
     handlePlaceResult(place)
     return
   }

--- a/web/src/views/settings/pages/appearance/Appearance.vue
+++ b/web/src/views/settings/pages/appearance/Appearance.vue
@@ -22,6 +22,7 @@ import {
   TrainIcon,
   MapPinIcon,
   RouteIcon,
+  DoorOpenIcon,
 } from 'lucide-vue-next'
 import { useThemeStore, allColors } from '@/stores/theme.store'
 import { useMapStore } from '@/stores/map.store'
@@ -215,6 +216,21 @@ const handleColorChange = (value: any) => {
         <Switch
           :model-value="settings.hdRoads"
           @update:model-value="mapService.toggleHdRoads()"
+        />
+      </SettingsItem>
+
+      <SettingsItem
+        v-if="settings.engine === MapEngine.MAPBOX"
+        :title="$t('settings.mapSettings.configuration.indoorMaps')"
+        :description="
+          $t('settings.mapSettings.configuration.indoorMapsDescription')
+        "
+        :icon="DoorOpenIcon"
+        :badge="$t('settings.mapSettings.configuration.experimental')"
+      >
+        <Switch
+          :model-value="settings.indoorMaps"
+          @update:model-value="mapService.toggleIndoorMaps()"
         />
       </SettingsItem>
 

--- a/web/src/views/settings/settingsIndex.ts
+++ b/web/src/views/settings/settingsIndex.ts
@@ -226,6 +226,11 @@ export const settingsIndex: SettingsPageDef[] = [
             descriptionKey:
               'settings.mapSettings.configuration.hdRoadsDescription',
           },
+          {
+            titleKey: 'settings.mapSettings.configuration.indoorMaps',
+            descriptionKey:
+              'settings.mapSettings.configuration.indoorMapsDescription',
+          },
           { titleKey: 'settings.mapSettings.configuration.poiLabels' },
           { titleKey: 'settings.mapSettings.configuration.roadLabels' },
           { titleKey: 'settings.mapSettings.configuration.transitLabels' },


### PR DESCRIPTION
Found while auditing controllers for the guard-leak pattern in #355 (PAR-277).

## The bug

`GET /auth/sessions/current` returned **401 to anonymous callers**, even though:

* the handler opens with `if (!user) { set.status = 204; return null }`, and
* `auth.controller.test.ts`'s own docblock states it must answer 204 "because the client polls it to decide whether it *is* signed in."

The two `requireAuth` routes earlier in the `/sessions` group were guarding it, so that 204 branch was unreachable dead code. It was pinned as-a-bug in the test suite, the same way the two cases in #355 were.

Impact was masked, not absent: `web/src/lib/api.ts:189` special-cases this URL and swallows the error before the global 401 → redirect-to-signin handler. So there was no user-visible symptom, but the server contract was wrong and the guard placement was load-bearing by accident.

## The fix

Move every guarded route in the `/sessions` group into one `.group('')` scope — the convention already used in `library/layers.controller.ts`. Public routes (sign-in, sign-out, `current`) stay outside it.

Two things I'd flag for review:

1. **Ordering is not a valid workaround.** #355 describes the guard as leaking to routes "declared above" it. What actually reproduces on Elysia 1.4.29 is that `.use()` applies to the whole instance *regardless of declaration order*, and `.group('')` is the only reliable containment. Minimal repro: a public route followed by `app.use(guard).get('other')` returns 401; wrapping that guarded route in `.group('')` returns 200.
2. **`const guarded = app.use(requireAuth)` is deliberate.** Splitting `.use()` onto its own statement keeps the runtime guard but drops the derived `user` / `session` types, which added 6 type errors on the first attempt. Binding the returned reference restores them. Nothing would have caught this — the server has no `typecheck` script and `bun build` strips types.

Route declaration order within the group is preserved so `/all` and `/others` still win over `/:sessionId`.

## Tests

`GET /auth/sessions/current` flipped from asserting 401 to asserting 204. Added a case pinning sign-in and sign-out as anonymous-reachable, so a route added in the wrong place can't quietly lock anonymous callers out of signing in.

## Verification

* `bun run test:unit` → **3679 passed, 0 failed** across 137 files (+1 new test)
* Server type errors unchanged at 357 (all pre-existing; 4 in this file before and after)
* Probed the full `/sessions` matrix anonymous-vs-authenticated to confirm nothing shadows anything:

```
POST   /auth/sessions                       anon=200  auth=200
DELETE /auth/sessions                       anon=204  auth=204
DELETE /auth/sessions/all                   anon=401  auth=204
DELETE /auth/sessions/others                anon=401  auth=204
GET    /auth/sessions/current               anon=204  auth=200   <- fixed, was 401
GET    /auth/sessions/current/permissions   anon=401  auth=200
GET    /auth/sessions                       anon=401  auth=200
DELETE /auth/sessions/:sessionId            anon=401  auth=204
```

## Audit result for #355

Only `auth.controller.ts` and `integration.controller.ts` mix public and guarded middleware on one instance. `public.controller.ts` (the share-link surface named in that issue's impact section) has no guards at all, and `environment.controller.ts` already uses the two-instance split. `device-transfer.controller.ts`'s `/sweep` remains benign as documented.

The two cases originally reported in #355 were already fixed in 30565e3b, and #356 (PAR-278) was already fixed in ec346ae2 — GBFS moved out of the tile proxy into its own `/gbfs` controller, with a regression test asserting `/proxy/gbfs` 404s. Both verified before closing.

No changelog entry: the client already masked this, so a user wouldn't notice it.

Closes #355