### PR TITLE
Default the Barrelman integration to the hosted instance

### DIFF
--- a/web/src/types/integrations.types.ts
+++ b/web/src/types/integrations.types.ts
@@ -195,10 +195,17 @@ export const configSchemas: Record<
   }),
 
   barrelmanSchema: z.object({
+    // The hosted instance, as with the other services that offer one. The
+    // previous default assumed barrelman was something you ran yourself,
+    // which was true before it had a public host — it left every new
+    // integration pointing at a port that answers on a developer's laptop
+    // and nowhere else.
+    //
+    // Self-hosting is still first-class: overwrite this with your own origin.
     host: z
       .string()
       .url('Please enter a valid URL')
-      .default('http://localhost:5001'),
+      .default('https://api.barrelman.dev'),
     apiKey: z.string().optional(),
     tileKey: z.string().optional(),
   }),


### PR DESCRIPTION
`barrelmanSchema.host` defaulted to `http://localhost:5001` — an assumption
that barrelman was something you ran yourself. That held before it had a public
host. It now means every new integration starts pointing at a port that answers
on a developer's laptop and nowhere else.

```diff
-      .default('http://localhost:5001'),
+      .default('https://api.barrelman.dev'),
```

This matches how the other services with a hosted instance are configured —
`axiomSchema`, immediately below, defaults to `https://api.axiom.co` for the
same reason.

### Scope

One line, plus a comment. Branched off `main` rather than raised from `dev`: a
`dev → main` PR would also carry the four search-palette commits, which are a
separate concern.

`web/src/types/integrations.types.ts` is the only place this default lives. The
server names the schema by string (`integration.service.ts:124`) but does not
define its own copy, so there is nothing to keep in sync.

### Compatibility

Self-hosting is unaffected — the field is still free text. **Existing
integrations are untouched:** a zod `.default()` only applies where no value is
present, so anything with a stored host keeps it. This changes what a *new*
integration starts with.

One trade-off worth naming: someone running barrelman locally now has to
overwrite the default instead of accepting it. That seemed the right way round,
since the hosted instance is what most people will point at, and a wrong
localhost default fails silently for them.

### Verification

`vitest run` — 977 pass, 0 fail, matching baseline exactly.

An earlier run showed 2 failures in `key-storage.test.ts` and a subscription
test. Both are flakes: they pass in isolation with and without this change, and
the full suite passes on re-run. Both were slow (4950ms, 6461ms), so they look
timing-sensitive under parallel load. Unrelated to this diff, but worth knowing
they exist.

### Noticed, not changed

- The integration is registered with `cloud: false`, which drives the
  Cloud/Self-hosted filter in settings. Now that a hosted instance exists, that
  flag is arguably wrong — but it changes how the tile is filtered and labelled,
  so it belongs in its own change.
- The `TODO` above the registration asks for "dynamic API and access key
  management to Barrelman, with a UI to create, rotate, and revoke keys."
  Barrelman has that now — accounts, `/account/keys`, and a console UI — so the
  TODO is stale.