### PR TITLE
Expand search browsing and improve recents and transit interactions

### DIFF
--- a/.codex/config.toml
+++ b/.codex/config.toml
@@ -1,0 +1,2 @@
+[mcp_servers.superconductor]
+url = "http://localhost:31418/mcp?sc_token=c8e68b2dc9f5dff53c99870b8991a7eb&worktree=%2FUsers%2Falexwohlbruck%2FDocuments%2Fcode%2Fparchment%2F"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,41 @@
+# Parchment
+
+## Architecture
+
+- **Parchment server** (API): runs in Docker as `parchment-server`, port 5000. Restart with `docker compose -f docker-compose.dev.yml restart parchment-server`
+- **Parchment web** (Vite): runs on port 5173. HMR handles client code changes. Do NOT start a new dev server.
+- **Barrelman** (geospatial engine): separate repo at `../barrelman`, Docker container `barrelman`, port 5001. Runs with hot-reload in dev (`bun --hot`, source mounted) — `src/` changes apply instantly, no rebuild. The `.env` defaults `COMPOSE_FILE` to base + dev override, so `cd ../barrelman && docker compose up -d barrelman` uses HMR. Only rebuild (`docker compose up -d --build barrelman`) for dependency or `Dockerfile`/`Dockerfile.dev` changes.
+- **Parchment DB**: Docker container `parchment-db`
+- **Barrelman DB**: Docker container `barrelman-db`, port 5434
+
+## When to restart what
+
+- **Client code changes** (`web/src/`): Vite HMR picks them up automatically
+- **Server code changes** (`server/src/`): `bun --hot` in Docker picks them up automatically (source is volume-mounted from `./server` into the container). If hot reload fails: `docker compose -f docker-compose.dev.yml restart parchment-server`
+- **Barrelman code changes** (`../barrelman/src/`): `bun --hot` picks them up automatically (source volume-mounted via the dev compose override). If hot reload fails: `docker compose -f ../barrelman/docker-compose.yml -f ../barrelman/docker-compose.dev.yml restart barrelman`. Rebuild the image only for dependency / `Dockerfile` changes.
+- **Barrelman import scripts** (`../barrelman/import/`, `../barrelman/scripts/`): mounted into the container; re-run them directly, no rebuild.
+
+## Release notes
+
+`CHANGELOG.md` is cumulative ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/)). When a user-facing feature or fix is complete, append an entry under `## [Unreleased]` at the top — do not wait for release time.
+
+- Group entries under `### Added`, `### Changed`, or `### Fixed` within `[Unreleased]`. Create the heading if it isn't there; otherwise append to the existing one.
+- One `*` bullet per change, written for users rather than developers: what it does for them, not which files moved. Match the tone of the released sections below it.
+- Skip purely internal work (refactors, test-only changes, dependency bumps) — if a user wouldn't notice it, it doesn't belong here.
+- Never edit the released `## [X.Y.Z]` sections. `deploy.sh` retitles `[Unreleased]` at release time and opens a fresh empty one; `scripts/changelog.sh` is the only thing that should rewrite the file.
+
+## Important rules
+
+- Do NOT start new dev servers. The user runs their own.
+- Do NOT merge to main. Work on feature branches.
+- If a Linear ticket was linked for the relevant work, update the status of the ticket as work progresses.
+- Use `bun` over `npm` for package management.
+- Commit messages: short (5-20 words), distinct logical commits.
+- Keep code structure clean, modular, and dry. Use concise, straightforward naming conventions and move code to appropriate modules when it isn't in the correct place. Add comments when the code is not intuitive at a glance or to convey important context/information.
+- "Modules" represent all code components for a single entity. Users, directions, search, settings, etc are all modules. These module identities are represented throught the codebase and should contain related UI, data, and business logic for that entity. Make sure to keep new and old code nicely modularized.
+- Offer to refactor malformed code when we come across any. This is anything that doesn't follow our normal conventions or industry practices.
+- When we add new features, integrations, modules, etc, update the relevant documentation in the sibiling `parchment-docs` repo.
+- Write clean, functional tests for new code logic. Do not add frivilous or non-meaningful tests.
+- Keep the swagger API documentation up-to-date and clean while making changes to the backend.
+- Always apply a clean, minimalist, and refined style when designing UI.
+- No uppercase tracking-wider text in UI.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,10 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 * The search palette opens instantly. It used to wait on your recent searches — which are encrypted, so they have to be fetched and unlocked first — before drawing anything at all, leaving the first open of a session on a spinner. Your shortcuts and frequent places now appear immediately and recents drop in as they arrive
 * "Bus Stops" is now "Transit", and covers tram and rail platforms alongside buses
 * Searching "wifi" finds the category under that name rather than "Wi-Fi Hotspot", and bike repair stands are called that instead of "Bicycle Repair Tool Stand" — both in search and on the place itself. Searching "bike repair stand", "repair stand", "outdoor gym" or "calisthenics" now finds the right category too
+* Recents on the Library home no longer stop at five — the list starts with ten and keeps loading more as you scroll
 
 ### Fixed
 
 * The "Inside" and "Located in" rows on a place no longer run their first two cards together — every card in the row is evenly spaced
+* The departure board no longer greys out trains you can plainly catch. It used to hold on to the walking time from when you planned the trip, so a seven-minute walk still read as seven minutes even once you were standing on the platform. The walk now counts down as you approach the stop — from your actual position when location is on, otherwise from the clock — and any departure on the board can be picked, whether it's already gone or looks like a stretch. Those still show as departed or a tight connection, but they're a hint now, not a lock
 
 ## [0.5.11] - 2026-08-03
 

--- a/web/src/components/LeftSheet.vue
+++ b/web/src/components/LeftSheet.vue
@@ -159,6 +159,7 @@ useHotkeys([
     :style="{ transform: `translate3d(${offset}%, 0, 0)` }"
   >
     <Card
+      data-sheet-scroll
       class="bg-muted-light shadow-none overflow-y-auto pointer-events-auto w-full md:w-104 h-full flex flex-col rounded-l-none border-foreground/5 border-l-0 border-y-0 justify-start"
       style="--background: var(--card);"
     >

--- a/web/src/components/dashboard/DashboardHome.vue
+++ b/web/src/components/dashboard/DashboardHome.vue
@@ -1,5 +1,13 @@
 <script setup lang="ts">
-import { computed, inject, ref, onMounted, onUnmounted } from 'vue'
+import {
+  computed,
+  inject,
+  ref,
+  watch,
+  nextTick,
+  onMounted,
+  onUnmounted,
+} from 'vue'
 import { storeToRefs } from 'pinia'
 import { useDark } from '@vueuse/core'
 import { useI18n } from 'vue-i18n'
@@ -18,6 +26,7 @@ import { capitalize } from '@/filters/text.filters'
 import Palette from '@/components/palette/Palette.vue'
 import PresetPlacesRow from '@/components/library/PresetPlacesRow.vue'
 import { appEventBus } from '@/lib/eventBus'
+import { findScrollAncestor } from '@/lib/scroll'
 import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { PlaceCard } from '@/components/place/card'
@@ -65,6 +74,63 @@ onMounted(() => {
 onUnmounted(() => {
   appEventBus.off('palette:focus', handlePaletteFocus)
 })
+
+/**
+ * Recents infinite scroll. The E2EE blob is fully decrypted in memory, so
+ * "loading more" is just revealing more of the array — pages exist only to
+ * keep the initial dashboard render short.
+ *
+ * The scroll surface belongs to the host sheet, and this listens to it
+ * directly — deliberately, because the two tidier-looking options both fail
+ * here. A sentinel at the end of the list only enters view on the sheet's very
+ * last pixel of scroll, and not at all once the list has trailing padding.
+ * `useInfiniteScroll` never binds to a scroll element that resolves after
+ * mount, so it sat silent through every scroll in Firefox.
+ */
+const RECENTS_PAGE_SIZE = 10
+const RECENTS_LOAD_MARGIN = 200
+const visibleRecentsCount = ref(RECENTS_PAGE_SIZE)
+const visibleRecents = computed(() =>
+  recentPlaces.value.slice(0, visibleRecentsCount.value),
+)
+const hasMoreRecents = computed(
+  () => visibleRecentsCount.value < recentPlaces.value.length,
+)
+
+const rootEl = ref<HTMLElement | null>(null)
+let scrollEl: HTMLElement | null = null
+
+/**
+ * Reveal the next page once the sheet is scrolled within `RECENTS_LOAD_MARGIN`
+ * of its end, then re-check: a page that doesn't make the sheet scrollable
+ * would otherwise leave no way to ask for the one after it.
+ *
+ * Paging a hidden list would page all of it — the palette covers this section,
+ * and a covered sheet has nothing to scroll, which reads as "at the end".
+ */
+function revealMore(margin: number) {
+  if (!scrollEl || paletteFocused.value || !hasMoreRecents.value) return
+  const remaining =
+    scrollEl.scrollHeight - scrollEl.clientHeight - scrollEl.scrollTop
+  if (remaining > margin) return
+  visibleRecentsCount.value += RECENTS_PAGE_SIZE
+  nextTick(() => revealMore(margin))
+}
+
+const onSheetScroll = () => revealMore(RECENTS_LOAD_MARGIN)
+/** Margin 0, so a sheet the user can already scroll keeps its first page. */
+const fillUnscrollableSheet = () => nextTick(() => revealMore(0))
+
+onMounted(() => {
+  scrollEl = findScrollAncestor(rootEl.value)
+  scrollEl?.addEventListener('scroll', onSheetScroll, { passive: true })
+  fillUnscrollableSheet()
+})
+
+onUnmounted(() => scrollEl?.removeEventListener('scroll', onSheetScroll))
+
+// Recents decrypt asynchronously, so the list usually lands after mount.
+watch(recentPlaces, fillUnscrollableSheet)
 
 const libraryTabs = computed(() => [
   {
@@ -118,7 +184,11 @@ function recentSubtitle(place: RecentPlaceEntry): string {
 </script>
 
 <template>
-  <div class="flex flex-col h-full">
+  <!-- min-h-full + shrink-0, never h-full: the sheet is a flex column, so a
+       shrinkable child gets squeezed back to the sheet's height while the list
+       grows past it. The content then spills out of its own box and every
+       trailing padding lands above the last card instead of below it. -->
+  <div ref="rootEl" class="flex flex-col min-h-full shrink-0 pb-6">
     <div class="space-y-4 flex-1">
       <!-- Inline command palette -->
       <div class="relative rounded-xl bg-card">
@@ -202,7 +272,7 @@ function recentSubtitle(place: RecentPlaceEntry): string {
         <SectionHeader size="lg" :title="t('general.recents')" class="mb-1.5 px-1" />
         <div class="space-y-2">
           <PlaceCard
-            v-for="place in recentPlaces.slice(0, 5)"
+            v-for="place in visibleRecents"
             :key="place.id"
             :display="recentPlaceToDisplay(place, { isDark })"
             variant="row"

--- a/web/src/components/directions/timeline/DepartureBoard.vue
+++ b/web/src/components/directions/timeline/DepartureBoard.vue
@@ -3,7 +3,10 @@ import { ref } from 'vue'
 import RouteBullet from '@/components/transit/RouteBullet.vue'
 import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
 
-/** One card on the board: the run, plus how it should read to the rider. */
+/** One card on the board: the run, plus how it should read to the rider.
+ *  `departed` and `unreachable` are cosmetic hints only — every run stays
+ *  selectable, because the rider knows their own situation better than the
+ *  walk estimate does. */
 export interface BoardCard {
   ms: number
   route?: { shortName?: string; color?: string; textColor?: string }
@@ -12,7 +15,8 @@ export interface BoardCard {
     sub?: string
     title?: string
     planned?: boolean
-    missed?: boolean
+    departed?: boolean
+    unreachable?: boolean
     hurry?: boolean
     live?: boolean
     arriving?: boolean
@@ -56,10 +60,15 @@ function updateEdges(el: HTMLElement) {
 
 /**
  * Put the first catchable run at the left edge, leaving a sliver of the past
- * as a scroll-back hint — the leading struck cards are noise on open.
+ * as a scroll-back hint — the leading struck cards are noise on open. They
+ * stay reachable by scrolling back; this only picks the resting position.
  */
 function scrollToFirstAvailable(el: HTMLElement, cards: BoardCard[]) {
-  const first = cards.findIndex(c => !c.card.missed)
+  // Prefer the first comfortably catchable run; when nothing is reachable
+  // (rider still far out) fall back to the first upcoming one, so the board
+  // never rests on a wall of departed cards.
+  let first = cards.findIndex(c => !c.card.departed && !c.card.unreachable)
+  if (first < 0) first = cards.findIndex(c => !c.card.departed)
   if (first <= 0) return
   const button = el.children[first] as HTMLElement | undefined
   if (!button) return
@@ -83,6 +92,11 @@ function onScrollerMount(el: unknown, cards: BoardCard[]) {
   })
 }
 
+/** Gone or a stretch to reach — same muted treatment either way. */
+function dimmed(card: BoardCard['card']) {
+  return Boolean(card.departed || card.unreachable)
+}
+
 function onScroll(e: Event) {
   if (e.target instanceof HTMLElement) updateEdges(e.target)
 }
@@ -104,15 +118,17 @@ defineExpose({
         v-for="item in cards"
         :key="item.ms"
         type="button"
-        class="shrink-0 min-w-[80px] flex flex-col items-center justify-center gap-1 px-2.5 py-2 rounded-xl border-2 text-center tabular-nums transition-colors"
+        class="shrink-0 min-w-[80px] flex flex-col items-center justify-center gap-1 px-2.5 py-2 rounded-xl border-2 text-center tabular-nums transition-colors cursor-pointer"
         :class="[
           item.card.planned
             ? (lineColor ? '' : 'border-parchment-500 bg-parchment-500/10')
-            : item.card.missed
-              ? 'border-transparent bg-muted/20 cursor-default'
-              : item.card.hurry
-                ? 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100/60 dark:hover:bg-amber-900/40 cursor-pointer'
-                : 'border-border bg-muted/30 hover:bg-muted/60 hover:border-foreground/30 cursor-pointer',
+            : item.card.departed
+              ? 'border-transparent bg-muted/20 hover:bg-muted/40'
+              : item.card.unreachable
+                ? 'border-dashed border-border/70 bg-muted/20 hover:bg-muted/50 hover:border-foreground/30'
+                : item.card.hurry
+                  ? 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-950/30 hover:bg-amber-100/60 dark:hover:bg-amber-900/40'
+                  : 'border-border bg-muted/30 hover:bg-muted/60 hover:border-foreground/30',
           busy && 'opacity-50 pointer-events-none',
         ]"
         :style="item.card.planned && lineColor ? {
@@ -120,7 +136,6 @@ defineExpose({
           background: `#${lineColor}1f`,
         } : {}"
         :title="item.card.title"
-        :disabled="item.card.missed"
         @click="item.card.clickable && emit('choose', item.ms)"
       >
         <!-- Route bullet + status cue. A tight connection shows a spelled-out
@@ -129,7 +144,7 @@ defineExpose({
              scheduled is just the bullet. -->
         <div
           class="flex items-center justify-center gap-1 leading-none"
-          :class="item.card.missed && 'opacity-50'"
+          :class="dimmed(item.card) && 'opacity-50'"
         >
           <RouteBullet
             v-if="item.route?.shortName ?? lineName"
@@ -145,16 +160,18 @@ defineExpose({
           <RealtimeIndicator
             v-else-if="item.card.live"
             :real-time="true"
-            :class="!item.card.missed && 'animate-pulse'"
+            :class="!dimmed(item.card) && 'animate-pulse'"
           />
         </div>
         <!-- Countdown — 'now' for an arriving train, else N min. Statuses use
-             theme-safe tokens (never the raw line colour as text): muted+struck
-             when missed, amber when hurry, the parchment accent for 'now'. -->
+             theme-safe tokens (never the raw line colour as text): struck when
+             already departed, merely muted when it's a stretch to reach, amber
+             when hurry, the parchment accent for 'now'. -->
         <div
           class="text-[13px] font-semibold leading-tight whitespace-nowrap"
           :class="[
-            item.card.missed && 'line-through text-muted-foreground/50',
+            item.card.departed && 'line-through text-muted-foreground/50',
+            item.card.unreachable && 'text-muted-foreground/70',
             item.card.hurry && 'text-amber-700 dark:text-amber-300',
             item.card.arriving && !item.card.hurry && 'text-parchment-600 dark:text-parchment-400',
           ]"
@@ -165,7 +182,7 @@ defineExpose({
         <div
           v-if="item.card.sub"
           class="text-[10px] leading-none text-muted-foreground"
-          :class="item.card.missed && 'opacity-60'"
+          :class="dimmed(item.card) && 'opacity-60'"
         >{{ item.card.sub }}</div>
       </button>
     </div>

--- a/web/src/components/place/Place.vue
+++ b/web/src/components/place/Place.vue
@@ -15,6 +15,7 @@ import { useDirectionsService } from '@/services/directions.service'
 import { getPrimaryPhoto, getLogoPhoto } from '@/types/place.types'
 import type { Place } from '@/types/place.types'
 import { useAppService } from '@/services/app.service'
+import { findScrollAncestor } from '@/lib/scroll'
 import { Skeleton, SkeletonText } from '@/components/ui/skeleton'
 
 import PlaceHeader from './header/PlaceHeader.vue'
@@ -137,18 +138,6 @@ const stuck = ref(false)
 let scrollRootEl: HTMLElement | null = null
 let stuckRaf = 0
 
-function findScrollRoot(el: HTMLElement): HTMLElement | null {
-  const named = el.closest('[data-sheet-scroll]') as HTMLElement | null
-  if (named) return named
-  let node = el.parentElement
-  while (node) {
-    const oy = getComputedStyle(node).overflowY
-    if (oy === 'auto' || oy === 'scroll') return node
-    node = node.parentElement
-  }
-  return null
-}
-
 // Stuck exactly when the bar can rise no higher than its docked line — not
 // merely when scrolling begins.
 function measureStuck() {
@@ -166,7 +155,7 @@ function attachStuck() {
   detachStuck()
   const bar = tabBarRef.value
   if (!bar) return
-  scrollRootEl = findScrollRoot(bar)
+  scrollRootEl = findScrollAncestor(bar)
   scrollRootEl?.addEventListener('scroll', onRootScroll, { passive: true })
   measureStuck()
 }

--- a/web/src/components/place/SheetPageHost.vue
+++ b/web/src/components/place/SheetPageHost.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, watch, onMounted, nextTick } from 'vue'
 import { provideSheetPage } from '@/composables/useSheetPage'
+import { findScrollAncestor } from '@/lib/scroll'
 
 // Stack lifecycle and route reconciliation (path-change clears, view-query
 // sync) are owned by the composable now — see `provideSheetPage`.
@@ -31,28 +32,10 @@ const hostRef = ref<HTMLElement | null>(null)
 let scrollAncestor: HTMLElement | null = null
 const scrollStack: number[] = []
 
-function findScrollAncestor(el: HTMLElement | null): HTMLElement | null {
-  if (!el) return null
-  // BottomSheet annotates its scrollContainer with `data-sheet-scroll` so
-  // we can target it explicitly. Falls back to walking up looking for any
-  // overflow-y-set ancestor — useful if a future host wraps us in a
-  // different scrollable container.
-  const tagged = el.closest('[data-sheet-scroll]') as HTMLElement | null
-  if (tagged) return tagged
-
-  let cur: HTMLElement | null = el.parentElement
-  while (cur) {
-    const overflow = getComputedStyle(cur).overflowY
-    if (overflow === 'auto' || overflow === 'scroll' || overflow === 'hidden') {
-      return cur
-    }
-    cur = cur.parentElement
-  }
-  return null
-}
-
 onMounted(() => {
-  scrollAncestor = findScrollAncestor(hostRef.value)
+  // includeHidden: this only ever sets scrollTop itself, and a collapsed
+  // sheet's container is overflow-hidden yet still scrolls programmatically.
+  scrollAncestor = findScrollAncestor(hostRef.value, { includeHidden: true })
 })
 
 watch(depth, (newDepth, oldDepth) => {

--- a/web/src/lib/scroll.ts
+++ b/web/src/lib/scroll.ts
@@ -1,0 +1,44 @@
+/**
+ * Scroll-surface lookup for panel views.
+ *
+ * A view rendered inside a sheet doesn't own its scroll container — the host
+ * sheet does (LeftSheet's Card on desktop, BottomSheet's container on mobile),
+ * and both tag it with `data-sheet-scroll`. Views that need the scrolling
+ * element itself — to save/restore a position, or to drive infinite scroll —
+ * resolve it through here rather than assuming a particular ancestor.
+ *
+ * The walk up the tree is a fallback for hosts that don't carry the tag.
+ */
+
+export interface FindScrollAncestorOptions {
+  /**
+   * Also match `overflow-y: hidden` ancestors. Those still scroll
+   * programmatically, so save/restore wants them; anything reacting to a
+   * *user* scroll does not.
+   */
+  includeHidden?: boolean
+}
+
+export function findScrollAncestor(
+  el: HTMLElement | null,
+  { includeHidden = false }: FindScrollAncestorOptions = {},
+): HTMLElement | null {
+  if (!el) return null
+
+  const tagged = el.closest('[data-sheet-scroll]') as HTMLElement | null
+  if (tagged) return tagged
+
+  let node = el.parentElement
+  while (node) {
+    const overflowY = getComputedStyle(node).overflowY
+    if (
+      overflowY === 'auto' ||
+      overflowY === 'scroll' ||
+      (includeHidden && overflowY === 'hidden')
+    ) {
+      return node
+    }
+    node = node.parentElement
+  }
+  return null
+}

--- a/web/src/lib/transit-reachability.test.ts
+++ b/web/src/lib/transit-reachability.test.ts
@@ -1,0 +1,135 @@
+import { describe, expect, it } from 'vitest'
+import {
+  departureReachability,
+  remainingAccessWalkSec,
+} from './transit-reachability'
+
+const NOW = new Date('2026-08-14T14:00:00Z').getTime()
+const MIN = 60_000
+
+// Grand Central-ish, and a point ~800m west of it.
+const STOP = { lat: 40.7527, lng: -73.9772 }
+const BLOCKS_AWAY = { lat: 40.7527, lng: -73.9677 }
+
+describe('remainingAccessWalkSec', () => {
+  it('returns the full walk before the rider is due to set off', () => {
+    const remaining = remainingAccessWalkSec(
+      { plannedSec: 420, arrivalMs: NOW + 10 * MIN },
+      NOW,
+    )
+    expect(remaining).toBe(420)
+  })
+
+  it('decays as the plan says the rider should be walking', () => {
+    // 3 minutes into a 7 minute walk.
+    const remaining = remainingAccessWalkSec(
+      { plannedSec: 420, arrivalMs: NOW + 4 * MIN },
+      NOW,
+    )
+    expect(remaining).toBe(240)
+  })
+
+  it('reaches zero once the plan has the rider at the stop', () => {
+    const remaining = remainingAccessWalkSec(
+      { plannedSec: 420, arrivalMs: NOW - 2 * MIN },
+      NOW,
+    )
+    expect(remaining).toBe(0)
+  })
+
+  it('prefers the live position over the schedule', () => {
+    // The schedule still thinks the rider is 7 minutes out, but they're
+    // standing at the stop.
+    const remaining = remainingAccessWalkSec(
+      {
+        plannedSec: 420,
+        arrivalMs: NOW + 7 * MIN,
+        stop: STOP,
+        position: { lat: STOP.lat + 0.0001, lng: STOP.lng },
+        accuracyM: 12,
+      },
+      NOW,
+    )
+    expect(remaining).toBeLessThan(30)
+  })
+
+  it('scales the position estimate by the pace implied by the plan', () => {
+    // 800m of planned walk over 400s → 2 m/s, so ~800m out still reads as a
+    // few minutes of walking (plus the detour allowance).
+    const remaining = remainingAccessWalkSec(
+      {
+        plannedSec: 400,
+        distanceM: 800,
+        arrivalMs: NOW + 400_000,
+        stop: STOP,
+        position: BLOCKS_AWAY,
+        accuracyM: 10,
+      },
+      NOW,
+    )
+    expect(remaining).toBeGreaterThan(300)
+    expect(remaining).toBeLessThanOrEqual(400)
+  })
+
+  it('ignores a fix too coarse to place the rider', () => {
+    const remaining = remainingAccessWalkSec(
+      {
+        plannedSec: 420,
+        arrivalMs: NOW + 7 * MIN,
+        stop: STOP,
+        position: STOP,
+        accuracyM: 2000,
+      },
+      NOW,
+    )
+    expect(remaining).toBe(420)
+  })
+
+  it('never exceeds the planned walk', () => {
+    const remaining = remainingAccessWalkSec(
+      {
+        plannedSec: 120,
+        arrivalMs: NOW + 60 * MIN,
+        stop: STOP,
+        position: BLOCKS_AWAY,
+        accuracyM: 10,
+      },
+      NOW,
+    )
+    expect(remaining).toBe(120)
+  })
+
+  it('is zero when there is no approach walk (mid-trip boarding)', () => {
+    expect(remainingAccessWalkSec({ plannedSec: 0 }, NOW)).toBe(0)
+  })
+})
+
+describe('departureReachability', () => {
+  it('marks past runs departed', () => {
+    expect(departureReachability(NOW - MIN, NOW, 0)).toBe('departed')
+    expect(departureReachability(NOW - MIN, NOW, 420)).toBe('departed')
+  })
+
+  it('marks upcoming runs inside the remaining walk unreachable', () => {
+    expect(departureReachability(NOW + 2 * MIN, NOW, 420)).toBe('unreachable')
+  })
+
+  it('flags a tight but catchable run as hurry', () => {
+    expect(departureReachability(NOW + 9 * MIN, NOW, 420)).toBe('hurry')
+  })
+
+  it('is ok with comfortable slack', () => {
+    expect(departureReachability(NOW + 20 * MIN, NOW, 420)).toBe('ok')
+  })
+
+  it('never reports hurry without an approach walk', () => {
+    expect(departureReachability(NOW + 30_000, NOW, 0)).toBe('ok')
+  })
+
+  it('reopens runs the rider has walked into reach of', () => {
+    // A 5-minute-out train with 7 minutes of static walk reads unreachable...
+    expect(departureReachability(NOW + 5 * MIN, NOW, 420)).toBe('unreachable')
+    // ...but is plainly catchable once the walk has decayed to a minute.
+    expect(departureReachability(NOW + 5 * MIN, NOW, 60)).toBe('ok')
+  })
+})

--- a/web/src/lib/transit-reachability.ts
+++ b/web/src/lib/transit-reachability.ts
@@ -1,0 +1,105 @@
+/**
+ * How catchable is a given departure, right now?
+ *
+ * The planner hands us a static approach walk ("7 min to the platform"), but a
+ * rider reading the departure board has usually already spent part of it. Held
+ * static, the board keeps insisting the rider is 7 minutes out while they stand
+ * on the platform watching catchable trains read as missed. So the remaining
+ * walk decays: from the live position when we have one, otherwise from the
+ * plan's own schedule.
+ *
+ * The result is a hint, never a gate — see `departureReachability`.
+ */
+
+import type { LngLat } from '@/types/map.types'
+import { distanceMeters } from './measure.utils'
+
+/** Walking pace assumed when the plan carries no usable distance. */
+const DEFAULT_WALK_SPEED_MPS = 1.35
+/** Sane bounds for a pace inferred from the plan, so one odd leg can't imply
+ *  a sprint or a crawl. */
+const MIN_WALK_SPEED_MPS = 0.7
+const MAX_WALK_SPEED_MPS = 2.2
+/** Straight-line distance undershoots a real walking route — street grids and
+ *  station entrances add roughly a third. */
+const DETOUR_FACTOR = 1.3
+/** A fix this coarse can't tell "at the platform" from "a block away". */
+const MAX_USABLE_ACCURACY_M = 150
+/** Slack below which a catchable run still means running for it. */
+const HURRY_SLACK_MS = 180_000
+
+export interface AccessWalk {
+  /** Moving seconds of the planned approach walk (excludes platform wait). */
+  plannedSec: number
+  /** When the plan has the rider reaching the stop (ms epoch), wait excluded. */
+  arrivalMs?: number
+  /** Metres of the planned approach walk, used to infer the rider's pace. */
+  distanceM?: number
+  /** The boarding stop, for the position-based estimate. */
+  stop?: LngLat | null
+  /** Live position; ignored when absent or too coarse to be meaningful. */
+  position?: LngLat | null
+  accuracyM?: number | null
+}
+
+/**
+ * Seconds of approach walk still ahead of the rider. Never exceeds the planned
+ * walk: the failure we care about is the board being too pessimistic, so when
+ * the estimates disagree we trust the plan as the ceiling.
+ */
+export function remainingAccessWalkSec(walk: AccessWalk, nowMs: number): number {
+  const planned = Math.max(0, walk.plannedSec)
+  if (planned === 0) return 0
+
+  // Position first — it reflects where the rider actually is, not where the
+  // plan assumed they'd be.
+  if (
+    walk.stop &&
+    walk.position &&
+    (walk.accuracyM == null || walk.accuracyM <= MAX_USABLE_ACCURACY_M)
+  ) {
+    const pace = walk.distanceM
+      ? clamp(walk.distanceM / planned, MIN_WALK_SPEED_MPS, MAX_WALK_SPEED_MPS)
+      : DEFAULT_WALK_SPEED_MPS
+    const remaining =
+      (distanceMeters(walk.position, walk.stop) * DETOUR_FACTOR) / pace
+    return clamp(remaining, 0, planned)
+  }
+
+  // Otherwise assume the rider is keeping to the plan: the walk burns down as
+  // the clock passes its scheduled arrival at the stop.
+  if (walk.arrivalMs != null) {
+    return clamp((walk.arrivalMs - nowMs) / 1000, 0, planned)
+  }
+
+  return planned
+}
+
+/**
+ * How a run reads on the board:
+ *   • departed     — already gone
+ *   • unreachable  — still upcoming, but not on foot from where the rider is
+ *   • hurry        — catchable only by leaving right now
+ *   • ok           — comfortable
+ *
+ * All four are cosmetic. Rebooking is never gated on them: the rider knows
+ * things we don't (they're on the platform, they'll run, they're being driven).
+ */
+export type DepartureReachability = 'departed' | 'unreachable' | 'hurry' | 'ok'
+
+export function departureReachability(
+  departureMs: number,
+  nowMs: number,
+  remainingWalkSec: number,
+): DepartureReachability {
+  const leadMs = departureMs - nowMs
+  if (leadMs < 0) return 'departed'
+  const walkMs = Math.max(0, remainingWalkSec) * 1000
+  if (leadMs < walkMs) return 'unreachable'
+  if (walkMs > 0 && leadMs < walkMs + HURRY_SLACK_MS) return 'hurry'
+  return 'ok'
+}
+
+function clamp(v: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, v))
+}

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -6,6 +6,12 @@ import { applyDepartureChange } from '@/lib/trip-rebooking'
 import { useDirectionsStore } from '@/stores/directions.store'
 import { useDirectionsService } from '@/services/directions.service'
 import { useMapService } from '@/services/map.service'
+import { useGeolocationService } from '@/services/geolocation.service'
+import {
+  departureReachability,
+  remainingAccessWalkSec,
+  type DepartureReachability,
+} from '@/lib/transit-reachability'
 import { Button } from '@/components/ui/button'
 import {
   Collapsible,
@@ -60,6 +66,9 @@ const directionsStore = useDirectionsStore()
 const directionsService = useDirectionsService()
 const mapService = useMapService()
 const themeStore = useThemeStore()
+// Live position, so the approach walk on the departure board decays as the
+// rider actually closes on the stop.
+const geo = useGeolocationService()
 const { formatDistance, formatElevation } = useUnits()
 
 // ── Upcoming departures per transit segment ─────────────────────────
@@ -88,7 +97,8 @@ const DEPARTURE_PAST_WINDOW_MS = 30 * 60_000
 // guards that to once per trip (refreshes/rebooks must not re-trigger it).
 const didAutoSelectDeparture = ref(false)
 
-// Clock driving missed/hurry chip states; departures re-fetch keeps the
+// Clock driving the departed/hurry chip states (and the decaying approach
+// walk behind them); departures re-fetch keeps the
 // realtime predictions fresh as vehicles move.
 const nowMs = ref(Date.now())
 const tickTimer = setInterval(() => { nowMs.value = Date.now() }, 10_000)
@@ -177,7 +187,7 @@ async function loadDepartures() {
         for (const d of pool) {
           const depMs = new Date(d.departureTime).getTime()
           // Keep already-departed runs (down to the past window) — they show as
-          // missed and give the rider useful "just missed it" context.
+          // departed and give the rider useful "just missed it" context.
           if (depMs < fetchFromMs) continue
           const prev = byMs.get(depMs)
           byMs.set(depMs, {
@@ -226,9 +236,10 @@ async function loadDepartures() {
   }
 }
 
-/** Default the first transit leg to its earliest catchable (not-missed) run —
- *  including a "hurry" one, so the rider lands on the soonest train they can
- *  still make. Runs once per trip; a no-op when that's already the planned run. */
+/** Default the first transit leg to its earliest catchable run — including a
+ *  "hurry" one, so the rider lands on the soonest train they can still make.
+ *  Runs once per trip; a no-op when that's already the planned run. (This is
+ *  only the default: the rider can still pick any run on the board.) */
 function selectFirstAvailableDeparture() {
   const t = trip.value
   if (!t) return
@@ -238,9 +249,10 @@ function selectFirstAvailableDeparture() {
     (s) => s.mode === 'transit' && s.departureStop?.location,
   )
   if (idx < 0) return
-  const firstCatchable = (segmentDepartures.value[idx] ?? []).find(
-    (d) => depState(idx, d) !== 'missed',
-  )
+  const firstCatchable = (segmentDepartures.value[idx] ?? []).find((d) => {
+    const state = depState(idx, d)
+    return state === 'ok' || state === 'hurry'
+  })
   if (firstCatchable && !isCurrentDeparture(segs[idx], firstCatchable.ms)) {
     void chooseDeparture(idx, firstCatchable.ms)
   }
@@ -370,14 +382,16 @@ async function chooseDeparture(segmentIndex: number, departureMs: number) {
 }
 
 // ── Departure chip states (Transit-app style) ────────────────────────
-// missed: the vehicle is gone (or, for the first boarding, you can no
-// longer walk there in time). hurry: catchable, but only just — the walk
+// departed: the vehicle is gone. unreachable: still upcoming, but not on
+// foot from where the rider is. hurry: catchable, but only just — the walk
 // leaves under 3 minutes of slack. live: time comes from GTFS-RT.
+// All of these are hints; none of them block a rebook.
 
-/** Walking seconds from the rider's position to this boarding, when this
- *  is the trip's first transit leg (0 otherwise — mid-trip positions
- *  depend on earlier legs, so only "departed" can be judged there). */
-function accessWalkSec(segmentIndex: number): number {
+/** Approach walk still ahead of the rider for this boarding, when it's the
+ *  trip's first transit leg (0 otherwise — mid-trip positions depend on
+ *  earlier legs, so only "departed" can be judged there). Decays as the rider
+ *  actually closes on the stop rather than staying pinned to the plan. */
+function remainingWalkSec(segmentIndex: number): number {
   const t = trip.value
   if (!t) return 0
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -385,27 +399,41 @@ function accessWalkSec(segmentIndex: number): number {
   const isFirst = !segs.slice(0, segmentIndex).some((s) => s.mode === 'transit')
   if (!isFirst) return 0
   const prev = segs[segmentIndex - 1]
-  return prev?.mode === 'walking' ? movingDuration(prev) : 0
+  if (prev?.mode !== 'walking') return 0
+  const planned = movingDuration(prev)
+  // Arrival at the stop excludes the platform wait folded into the walk leg.
+  const arrivalMs = asMs(prev.endTime) - (prev.waitSeconds ?? 0) * 1000
+  return remainingAccessWalkSec(
+    {
+      plannedSec: planned,
+      arrivalMs,
+      distanceM: prev.distance,
+      stop: segs[segmentIndex]?.departureStop?.location ?? null,
+      position: geo.lngLat.value,
+      accuracyM: geo.accuracy.value,
+    },
+    nowMs.value,
+  )
 }
 
-function depState(segmentIndex: number, dep: DepartureOption): 'missed' | 'hurry' | 'ok' {
-  const leadMs = dep.ms - nowMs.value
-  const walkMs = accessWalkSec(segmentIndex) * 1000
-  if (leadMs < walkMs) return 'missed'
-  if (walkMs > 0 && leadMs < walkMs + 180_000) return 'hurry'
-  return 'ok'
+function depState(segmentIndex: number, dep: DepartureOption): DepartureReachability {
+  return departureReachability(dep.ms, nowMs.value, remainingWalkSec(segmentIndex))
 }
 
 /** A board card's full visual state, derived once per render so the template
  *  stays declarative. The statuses are mutually legible at a glance:
- *   • planned  — the run the trip currently boards (line-coloured emphasis)
- *   • missed   — gone, or unreachable on foot in time (struck out, disabled)
- *   • hurry    — catchable only if you leave now (amber)
- *   • arriving — imminent, i.e. "now"
- *   • live     — the time is a GTFS-RT prediction rather than the schedule */
+ *   • planned     — the run the trip currently boards (line-coloured emphasis)
+ *   • departed    — already gone (struck out, muted)
+ *   • unreachable — upcoming, but probably not on foot in time (muted)
+ *   • hurry       — catchable only if you leave now (amber)
+ *   • arriving    — imminent, i.e. "now"
+ *   • live        — the time is a GTFS-RT prediction rather than the schedule
+ *  Every card stays selectable regardless — the rider may well know something
+ *  the estimate doesn't. */
 interface DepCard {
   planned: boolean
-  missed: boolean
+  departed: boolean
+  unreachable: boolean
   hurry: boolean
   arriving: boolean
   live: boolean
@@ -420,29 +448,34 @@ interface DepCard {
 function depCard(segment: any, segmentIndex: number, dep: DepartureOption): DepCard {
   const planned = isCurrentDeparture(segment, dep.ms)
   const state = depState(segmentIndex, dep)
-  const missed = !planned && state === 'missed'
-  // hurry stands even on the selected card — you still have to rush for it, so
-  // it isn't suppressed by `planned` the way `missed` is.
+  const departed = state === 'departed'
+  // The reachability hints stand even on the selected card — you still have to
+  // rush for (or have likely missed) it — so `planned` doesn't suppress them.
+  const unreachable = state === 'unreachable'
   const hurry = state === 'hurry'
   const { lead, sub } = depCountdown(dep.ms)
   const name = dep.route?.shortName ?? segment.lineName
+  const switchTo = `Switch to the ${name} at ${dep.label}`
   return {
     planned,
-    missed,
+    departed,
+    unreachable,
     hurry,
-    arriving: !missed && lead === 'now',
+    arriving: !departed && lead === 'now',
     live: dep.realTime,
-    clickable: !planned && !missed,
+    clickable: !planned,
     lead,
     sub,
     route: dep.route,
-    title: missed
-      ? 'Departed'
-      : planned
-        ? 'Planned departure'
-        : hurry
-          ? `Catchable if you hurry — the ${name} leaves at ${dep.label}`
-          : `Switch to the ${name} at ${dep.label}`,
+    title: planned
+      ? 'Planned departure'
+      : departed
+        ? `Departed at ${dep.label}`
+        : unreachable
+          ? `Tight — you may not reach the stop by ${dep.label}. ${switchTo}`
+          : hurry
+            ? `Catchable if you hurry — the ${name} leaves at ${dep.label}`
+            : switchTo,
   }
 }
 


### PR DESCRIPTION
## Summary

- Add searchable category shortcuts, attribute-based browsing, and clearer WiFi and bike repair labels.
- Load dashboard recents incrementally as the sheet scrolls and hydrate palette recents in the background.
- Keep all departure-board options selectable while showing departed and difficult connections as visual hints.
- Fix related-place card spacing and centralize scroll-ancestor detection.
- Document the user-facing changes in the unreleased changelog.

## Testing

- Added search-service coverage for attribute presets and wildcard tag handling.
- Added transit reachability tests covering approach-time and departure eligibility behavior.
- Automated test execution not reported.