### PR TITLE
Refine transit boards, search recents, and place discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 
 ### Fixed
 
+* Recents on the Library home now include your searches, not just the places you opened. A category or brand you browsed showed up in the search palette's recents but was missing from the home list — the two now show the same history, newest first, and tapping a search there runs it again
 * The "Inside" and "Located in" rows on a place no longer run their first two cards together — every card in the row is evenly spaced
 * Aerial tramway, cable car and gondola stations are recognised as transit stations. The Roosevelt Island Tramway rendered as an ordinary building, with no departures and no lines served
 * A station's departure board is now that station's departures. Opening the Roosevelt Island Tramway listed mostly Q32, M15 and Q60 buses bound for Penn Station, from stops across the street — a stop standing on the place now claims the board, and its platforms travel with it

--- a/web/src/components/dashboard/DashboardHome.vue
+++ b/web/src/components/dashboard/DashboardHome.vue
@@ -21,7 +21,7 @@ import { Card } from '@/components/ui/card'
 import { ItemIcon } from '@/components/ui/item-icon'
 import { AppRoute } from '@/router'
 import type { ThemeColor } from '@/lib/utils'
-import type { RecentPlaceEntry } from '@/lib/recents'
+import { recentPlaceIdentity, recentSearchIdentity } from '@/lib/recents'
 import { capitalize } from '@/filters/text.filters'
 import Palette from '@/components/palette/Palette.vue'
 import PresetPlacesRow from '@/components/library/PresetPlacesRow.vue'
@@ -31,7 +31,11 @@ import dayjs from 'dayjs'
 import relativeTime from 'dayjs/plugin/relativeTime'
 import { PlaceCard } from '@/components/place/card'
 import { SectionHeader } from '@/components/ui/section-header'
-import { recentPlaceToDisplay } from '@/lib/place-display'
+import {
+  recentPlaceToDisplay,
+  recentSearchToDisplay,
+  type PlaceDisplay,
+} from '@/lib/place-display'
 
 dayjs.extend(relativeTime)
 
@@ -41,7 +45,7 @@ const isDark = useDark()
 const collectionsStore = useCollectionsStore()
 const layersStore = useLayersStore()
 const recentsStore = useRecentsStore()
-const { places: recentPlaces } = storeToRefs(recentsStore)
+const { places: recentPlaces, searches: recentSearches } = storeToRefs(recentsStore)
 const { isMobileScreen, isDesktopScreen } = useResponsive()
 
 const minimizeSheet = inject<() => void>('minimizeMobileSheet', () => {})
@@ -69,6 +73,7 @@ const handlePaletteFocus = () => {
 onMounted(() => {
   appEventBus.on('palette:focus', handlePaletteFocus)
   recentsStore.ensurePlacesHydrated()
+  recentsStore.ensureSearchesHydrated()
 })
 
 onUnmounted(() => {
@@ -90,11 +95,42 @@ onUnmounted(() => {
 const RECENTS_PAGE_SIZE = 10
 const RECENTS_LOAD_MARGIN = 200
 const visibleRecentsCount = ref(RECENTS_PAGE_SIZE)
+
+/** A row in the recents list — either kind, already adapted for rendering. */
+interface RecentItem {
+  key: string
+  display: PlaceDisplay
+  subtitle: string
+}
+
+/**
+ * Searches and viewed places in one list, newest first — the same merge the
+ * palette's Recents section does. The two surfaces read the same history, so
+ * showing places here and both kinds there made a category or query you just
+ * ran look like it was never recorded.
+ */
+const recentItems = computed<RecentItem[]>(() =>
+  [
+    ...recentPlaces.value.map(place => ({
+      key: recentPlaceIdentity(place),
+      at: place.at,
+      display: recentPlaceToDisplay(place, { isDark: isDark.value }),
+      subtitle: recentSubtitle(place.subtitle, place.at),
+    })),
+    ...recentSearches.value.map(search => ({
+      key: recentSearchIdentity(search),
+      at: search.at,
+      display: recentSearchToDisplay(search, { isDark: isDark.value }),
+      subtitle: recentSubtitle(null, search.at),
+    })),
+  ].sort((a, b) => b.at - a.at),
+)
+
 const visibleRecents = computed(() =>
-  recentPlaces.value.slice(0, visibleRecentsCount.value),
+  recentItems.value.slice(0, visibleRecentsCount.value),
 )
 const hasMoreRecents = computed(
-  () => visibleRecentsCount.value < recentPlaces.value.length,
+  () => visibleRecentsCount.value < recentItems.value.length,
 )
 
 const rootEl = ref<HTMLElement | null>(null)
@@ -129,8 +165,9 @@ onMounted(() => {
 
 onUnmounted(() => scrollEl?.removeEventListener('scroll', onSheetScroll))
 
-// Recents decrypt asynchronously, so the list usually lands after mount.
-watch(recentPlaces, fillUnscrollableSheet)
+// Recents decrypt asynchronously, so the list usually lands after mount — and
+// each kind lands on its own, so this watches the merged result.
+watch(recentItems, fillUnscrollableSheet)
 
 const libraryTabs = computed(() => [
   {
@@ -175,11 +212,9 @@ function navigateToRoute(routeName: AppRoute) {
   router.push({ name: routeName })
 }
 
-/** A recent's own subtitle, with how long ago it was viewed appended. */
-function recentSubtitle(place: RecentPlaceEntry): string {
-  return [place.subtitle, place.at && dayjs(place.at).fromNow()]
-    .filter(Boolean)
-    .join(' · ')
+/** A recent's own subtitle, with how long ago it happened appended. */
+function recentSubtitle(subtitle: string | null | undefined, at: number): string {
+  return [subtitle, at && dayjs(at).fromNow()].filter(Boolean).join(' · ')
 }
 </script>
 
@@ -267,18 +302,18 @@ function recentSubtitle(place: RecentPlaceEntry): string {
         </div>
       </div>
 
-      <!-- Recently viewed places -->
-      <div v-if="recentPlaces.length > 0">
+      <!-- Recent searches and viewed places, interleaved newest-first -->
+      <div v-if="recentItems.length > 0">
         <SectionHeader size="lg" :title="t('general.recents')" class="mb-1.5 px-1" />
         <div class="space-y-2">
           <PlaceCard
-            v-for="place in visibleRecents"
-            :key="place.id"
-            :display="recentPlaceToDisplay(place, { isDark })"
+            v-for="item in visibleRecents"
+            :key="item.key"
+            :display="item.display"
             variant="row"
             size="sm"
             icon-variant="ghost"
-            :subtitle="recentSubtitle(place)"
+            :subtitle="item.subtitle"
             @click="minimizeSheet()"
           />
         </div>

--- a/web/src/lib/place-display.test.ts
+++ b/web/src/lib/place-display.test.ts
@@ -4,6 +4,8 @@ import {
   placeToDisplay,
   bookmarkToDisplay,
   recentPlaceToDisplay,
+  recentSearchToDisplay,
+  recentSearchRoute,
   makePlaceDisplay,
 } from './place-display'
 import type { Place } from '@/types/place.types'
@@ -164,5 +166,82 @@ describe('recentPlaceToDisplay', () => {
     expect(d.icon).toBe('MapPin')
     expect(d.address).toBe('Art museum')
     expect(d.route).not.toBeNull()
+  })
+})
+
+describe('recentSearchRoute', () => {
+  it('re-runs a category as a category browse, not a text search', () => {
+    const route = recentSearchRoute({
+      query: 'Coffee',
+      kind: 'category',
+      categoryId: 'amenity/cafe',
+      iconCategory: 'food_and_drink',
+      at: 1,
+    }) as { query: Record<string, string> }
+    expect(route.query).toEqual({
+      categoryId: 'amenity/cafe',
+      categoryName: 'Coffee',
+      categoryIconCategory: 'food_and_drink',
+    })
+  })
+
+  it('re-runs a brand browse by key, carrying the original-cased name', () => {
+    const route = recentSearchRoute({
+      query: "McDonald's",
+      kind: 'brand',
+      brandKey: 'Q38076',
+      brandName: "McDonald's",
+      at: 1,
+    }) as { query: Record<string, string> }
+    expect(route.query).toEqual({ brandKey: 'Q38076', brandName: "McDonald's" })
+  })
+
+  it('falls back to a text search, including for a category missing its id', () => {
+    expect((recentSearchRoute({ query: 'tacos', at: 1 }) as any).query).toEqual({
+      q: 'tacos',
+    })
+    // A half-formed category entry must not navigate to an empty browse.
+    expect(
+      (recentSearchRoute({ query: 'Cafe', kind: 'category', at: 1 }) as any).query,
+    ).toEqual({ q: 'Cafe' })
+  })
+})
+
+describe('recentSearchToDisplay', () => {
+  it('gives a text search the history glyph', () => {
+    const d = recentSearchToDisplay({ query: 'tacos', at: 1 }, { isDark: false })
+    expect(d.title).toBe('tacos')
+    expect(d.icon).toBe('History')
+  })
+
+  it('keeps the stored category icon so it matches the palette', () => {
+    const d = recentSearchToDisplay(
+      {
+        query: 'Bicycle Parking',
+        kind: 'category',
+        categoryId: 'amenity/bicycle_parking',
+        iconName: 'bicycle',
+        iconPack: 'maki',
+        at: 1,
+      },
+      { isDark: false },
+    )
+    expect(d.icon).toBe('bicycle')
+    expect(d.iconPack).toBe('maki')
+  })
+
+  it('renders a brand with its logo', () => {
+    const d = recentSearchToDisplay(
+      {
+        query: 'Target',
+        kind: 'brand',
+        brandKey: 'Q1046951',
+        brandLogoUrl: 'https://example.com/target.svg',
+        at: 1,
+      },
+      { isDark: false },
+    )
+    expect(d.imageUrl).toBe('https://example.com/target.svg')
+    expect(d.icon).toBe('Store')
   })
 })

--- a/web/src/lib/place-display.ts
+++ b/web/src/lib/place-display.ts
@@ -1,8 +1,9 @@
 import type { RouteLocationRaw } from 'vue-router'
-import type { Place } from '@/types/place.types'
+import type { Place, PlaceCategory } from '@/types/place.types'
 import type { Bookmark } from '@/types/library.types'
-import type { RecentPlaceEntry } from '@/lib/recents'
+import type { RecentPlaceEntry, RecentSearchEntry } from '@/lib/recents'
 import type { ThemeColor } from '@/lib/utils'
+import { AppRoute } from '@/router'
 import { getPlaceRoute, getPlaceRouteFromExternalIds, formatAddress } from '@/lib/place.utils'
 import { getCategoryColor } from '@/lib/place-colors'
 import { frequentChipMeta } from '@/lib/frequents'
@@ -186,6 +187,61 @@ export function recentPlaceToDisplay(
     hoursText: null,
     route: getPlaceRoute(entry.id),
   }
+}
+
+/**
+ * Where re-selecting a recent search goes. Mirrors the palette's search action:
+ * a category or brand recent re-runs that browse rather than searching for its
+ * label as text, which would return places named after the category.
+ */
+export function recentSearchRoute(entry: RecentSearchEntry): RouteLocationRaw {
+  if (entry.kind === 'category' && entry.categoryId) {
+    return {
+      name: AppRoute.SEARCH_RESULTS,
+      query: {
+        categoryId: entry.categoryId,
+        ...(entry.query ? { categoryName: entry.query } : {}),
+        ...(entry.iconCategory ? { categoryIconCategory: entry.iconCategory } : {}),
+      },
+    }
+  }
+  if (entry.kind === 'brand' && entry.brandKey) {
+    return {
+      name: AppRoute.SEARCH_RESULTS,
+      query: {
+        brandKey: entry.brandKey,
+        ...(entry.brandName ? { brandName: entry.brandName } : {}),
+      },
+    }
+  }
+  return { name: AppRoute.SEARCH_RESULTS, query: { q: entry.query } }
+}
+
+/**
+ * A recent search — a typed query, a POI category, or a brand browse. Adapted
+ * to the same display record as a recent place so both kinds render as one
+ * interleaved list; only the route differs (re-run a search vs open a place).
+ */
+export function recentSearchToDisplay(
+  entry: RecentSearchEntry,
+  { isDark }: Pick<PlaceDisplayOptions, 'isDark'>,
+): PlaceDisplay {
+  // Text searches have no icon of their own — they get the history glyph, the
+  // same one the palette gives them.
+  const fallbackIcon =
+    entry.kind === 'category' ? 'MapPin' : entry.kind === 'brand' ? 'Store' : 'History'
+
+  return makePlaceDisplay({
+    title: entry.query,
+    icon: entry.iconName || fallbackIcon,
+    iconPack: entry.iconPack ?? 'lucide',
+    customColor: getCategoryColor(
+      (entry.iconCategory || 'default') as PlaceCategory,
+      isDark,
+    ),
+    imageUrl: entry.brandLogoUrl ?? null,
+    route: recentSearchRoute(entry),
+  })
 }
 
 /**

--- a/web/src/lib/recents/index.ts
+++ b/web/src/lib/recents/index.ts
@@ -53,25 +53,35 @@ export interface RecentPlaceEntry {
 }
 
 /**
+ * Stable identity for a recent search, in one key space across all three kinds
+ * so they never collide even when they share a label ("Cafe" the category vs
+ * "cafe" the typed query). Used to dedupe the stored list, to dedupe recents
+ * against live palette results, and to key the dashboard's recents list.
+ */
+export function recentSearchIdentity(e: RecentSearchEntry): string {
+  if (e.kind === 'category' && e.categoryId) return `category:${e.categoryId}`
+  if (e.kind === 'brand' && e.brandKey) return `brand:${e.brandKey}`
+  return `text:${e.query.trim().toLowerCase()}`
+}
+
+/** Stable identity for a recently-viewed place — the same key space as above. */
+export function recentPlaceIdentity(e: RecentPlaceEntry): string {
+  return `place:${e.id}`
+}
+
+/**
  * Recent searches. Keeps the historical `search-history` blob type so existing
  * synced blobs and the K_m rotation orchestrator keep working unchanged.
  */
 export const recentSearches = createRecentsStore<RecentSearchEntry>({
   blobType: 'search-history',
   maxEntries: 100,
-  // Category, brand, and text searches never collide, even with the same label
-  // ("Cafe" the category vs "cafe" the typed query).
-  identityOf: e =>
-    e.kind === 'category' && e.categoryId
-      ? `category:${e.categoryId}`
-      : e.kind === 'brand' && e.brandKey
-        ? `brand:${e.brandKey}`
-        : `text:${e.query.trim().toLowerCase()}`,
+  identityOf: recentSearchIdentity,
 })
 
 /** Recently-viewed places. */
 export const recentPlaces = createRecentsStore<RecentPlaceEntry>({
   blobType: 'recent-places',
   maxEntries: 100,
-  identityOf: e => e.id,
+  identityOf: recentPlaceIdentity,
 })

--- a/web/src/stores/command.store.ts
+++ b/web/src/stores/command.store.ts
@@ -33,7 +33,12 @@ import { getCategoryColor } from '@/lib/place-colors'
 import type { PlaceCategory } from '@/types/place.types'
 import { useCategoryStore } from '@/stores/category.store'
 import { useRecentsStore } from '@/stores/recents.store'
-import type { RecentSearchEntry, RecentPlaceEntry } from '@/lib/recents'
+import {
+  recentPlaceIdentity,
+  recentSearchIdentity,
+  type RecentSearchEntry,
+  type RecentPlaceEntry,
+} from '@/lib/recents'
 import { useBookmarksStore } from '@/stores/library/bookmarks.store'
 import { getBookmarkPlaceId } from '@/lib/place.utils'
 import { frequentChipMeta } from '@/lib/frequents'
@@ -212,7 +217,7 @@ export const useCommandStore = defineStore('command', () => {
                 if (e.kind === 'category' && e.categoryId) {
                   return {
                     at: e.at,
-                    identity: `category:${e.categoryId}`,
+                    identity: recentSearchIdentity(e),
                     option: {
                       value: `category:${e.categoryId}`,
                       name: e.query,
@@ -229,7 +234,7 @@ export const useCommandStore = defineStore('command', () => {
                 if (e.kind === 'brand' && e.brandKey) {
                   return {
                     at: e.at,
-                    identity: `brand:${e.brandKey}`,
+                    identity: recentSearchIdentity(e),
                     option: {
                       value: `brand:${encodeURIComponent(
                         JSON.stringify({ key: e.brandKey, name: e.brandName || e.query }),
@@ -245,7 +250,7 @@ export const useCommandStore = defineStore('command', () => {
                 }
                 return {
                   at: e.at,
-                  identity: `text:${e.query.trim().toLowerCase()}`,
+                  identity: recentSearchIdentity(e),
                   option: {
                     value: `recent-search:${e.query}`,
                     name: e.query,
@@ -258,7 +263,7 @@ export const useCommandStore = defineStore('command', () => {
 
               const recentPlaceToEntry = (e: RecentPlaceEntry): RecentEntry => ({
                 at: e.at,
-                identity: `place:${e.id}`,
+                identity: recentPlaceIdentity(e),
                 option: {
                   value: e.id,
                   name: e.title,


### PR DESCRIPTION
## Summary

- Show recent searches alongside recent places on the dashboard and load recents as the sheet scrolls
- Improve transit station matching, aerialway support, route labels, delays, cancellations, and departure-board presentation
- Expand category browsing with attribute presets, updated place names, and broader search aliases
- Update OpenAPI documentation and add changelog coverage for user-facing changes

## Testing

- Added and updated transit, search, place-display, reachability, and departure-board tests
- Updated OpenAPI specification
- Not run: full test suite