### PR TITLE
Point preview clients at their own API origin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,27 +8,6 @@
 - **Parchment DB**: Docker container `parchment-db`
 - **Barrelman DB**: Docker container `barrelman-db`, port 5434
 
-## Remote dev box (vega5)
-
-There are two environments. The laptop is as described above. **vega5** (`vega5.tailc47d6.ts.net`, `100.70.133.121`) is the always-on box used for working from the field, and it is set up differently — check which one you are on before assuming a command applies.
-
-On vega5:
-
-- Repos live in `~/Documents/code/`. Only `parchment-db` runs in Docker; the server and web run as systemd user services, not containers.
-- **Barrelman is not local.** Parchment's barrelman integration points at the production instance on vega2 (`100.110.246.86:5001`) over the tailnet. Do not run barrelman imports here, and do not point anything on vega5 at vega2's database — it is production.
-- Each branch gets its own preview stack via `preview` (`scripts/preview.sh`): its own worktree, its own clone of the dev database, its own ports, and its own tailnet URL.
-
-### Working on a feature branch on vega5
-
-Run `preview up` from inside the worktree (or `preview up <branch>` from anywhere) when starting feature work, and give the user the link it prints — that link is how they review the change from a phone. Then:
-
-- `preview ls` — what is running, and where
-- `preview pr` — push the branch and put the preview link on its PR
-- `preview logs` — server + web logs for the current worktree
-- `preview down` — stop it, drop its database, free the slot
-
-Previews hot-reload, so a change pushed to the branch is live on the link immediately; there is no rebuild or redeploy step to tell the user about.
-
 ## When to restart what
 
 - **Client code changes** (`web/src/`): Vite HMR picks them up automatically

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -413,33 +413,46 @@ cmd_url() {
   else echo "http://$(ts_ip):$(web_port "$slot")"; fi
 }
 
-# Push the branch and put the preview link on the pull request, so reviewing
-# from a phone is: open PR notification → tap link → look at the running app.
-# The link is tailnet-only, so it is useless to anyone who isn't on the tailnet.
+# Push the branch and open (or update) its pull request.
+#
+# The preview URL is a hostname on a private network. That is a useless link to
+# anyone who isn't on it, but it still describes infrastructure — so it is only
+# written into the PR when the repository is private. On a public repository the
+# link is printed here instead, for the author to open directly.
 cmd_pr() {
   ensure_state; resolve_target "${1:-}"
-  local branch=$TARGET_BRANCH worktree=$TARGET_WORKTREE url
+  local branch=$TARGET_BRANCH worktree=$TARGET_WORKTREE url repo visibility
   url=$(cmd_url "$branch")
+  repo=$(git -C "$worktree" remote get-url origin | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
 
   git -C "$worktree" push --quiet -u origin "$branch"
 
-  local marker="<!-- preview-link -->"
-  local body="$marker
+  visibility=$(gh repo view "$repo" --json visibility -q .visibility 2>/dev/null || echo PUBLIC)
+
+  local body
+  if [ "$visibility" = PRIVATE ]; then
+    body="<!-- preview-link -->
 **Preview:** $url
 
-Running from the \`$branch\` worktree on vega5 with a clone of the dev database.
+Running from the \`$branch\` worktree with a clone of the dev database.
 Hot-reloads on every push to this branch — no rebuild needed to see a change.
-Reachable from the tailnet only."
-
-  if gh pr view "$branch" --repo alexwohlbruck/parchment >/dev/null 2>&1; then
-    gh pr comment "$branch" --repo alexwohlbruck/parchment --body "$body" >/dev/null
-    log "commented preview link on the existing PR"
+Reachable from the private network only."
   else
-    gh pr create --repo alexwohlbruck/parchment --base dev --head "$branch" \
+    body="A live preview of this branch is running on the author's development
+machine, hot-reloading on every push. The link is on a private network and is
+deliberately not published here."
+  fi
+
+  if gh pr view "$branch" --repo "$repo" >/dev/null 2>&1; then
+    gh pr comment "$branch" --repo "$repo" --body "$body" >/dev/null
+    log "commented on the existing PR"
+  else
+    gh pr create --repo "$repo" --base dev --head "$branch" \
       --title "$(git -C "$worktree" log -1 --pretty=%s)" --body "$body" >/dev/null
     log "opened a PR"
   fi
-  gh pr view "$branch" --repo alexwohlbruck/parchment --json url -q .url
+  gh pr view "$branch" --repo "$repo" --json url -q .url
+  [ "$visibility" = PRIVATE ] || log "preview (not posted — public repo): $url"
 }
 
 cmd_logs() {

--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -280,12 +280,20 @@ EOF
 }
 
 write_unit_env() {
-  local slot=$1 worktree=$2 wport=$3 pub_host=$4 pub_scheme=$5 pub_web_port=$6
+  local slot=$1 worktree=$2 wport=$3 pub_host=$4 pub_scheme=$5 pub_web_port=$6 api_origin=$7
   mkdir -p "$STATE_DIR/$slot"
   cat > "$STATE_DIR/$slot/env" <<EOF
 PREVIEW_WORKTREE=$worktree
 PREVIEW_BUN=$BUN
 VITE_PORT=$wport
+# The client reads its API base from VITE_SERVER_ORIGIN at dev-server start.
+# It has to be in this process environment: Vite only loads .env/.env.local
+# from web/, so it never sees the .env.preview the server is started with.
+# Without it the client falls back to http://localhost:5000 — which, from a
+# phone, is the phone itself, and from a laptop is that laptop's own dev
+# server. Either way the session cookie lands on the wrong origin and sign-in
+# appears not to persist.
+VITE_SERVER_ORIGIN=$api_origin
 # Vite refuses Host headers it does not know, and its HMR client would dial the
 # origin port directly instead of the public one it was actually loaded from.
 VITE_ALLOWED_HOSTS=$pub_host,.ts.net,localhost
@@ -339,7 +347,7 @@ cmd_up() {
   fi
 
   write_env "$worktree" "$dbname" "$sport" "$wport" "$base_api" "$base_web"
-  write_unit_env "$slot" "$worktree" "$wport" "$host" "${scheme_web}" "$wpub"
+  write_unit_env "$slot" "$worktree" "$wport" "$host" "${scheme_web}" "$wpub" "$base_api"
 
   systemctl --user restart "parchment-preview-server@$slot" "parchment-preview-web@$slot"
   registry_put "$slot" "$branch" "$worktree" "${scheme_web}" "$host"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -93,6 +93,27 @@ export async function getIsTauri(): Promise<boolean> {
 // Reactive server URL from localStorage, defaults to api.parchment.app
 const serverUrl = useStorage('parchment-selected-server', DEFAULT_SERVER_URL)
 
+// Which build-time default the stored selection came from. `useStorage` only
+// consults the default when the key is absent, so a deployment that later
+// declares a different API origin (a branch preview moving to its own host, a
+// self-hosted instance changing address) would be ignored forever in favour of
+// a stale value — the app keeps calling a server that isn't there, and sign-in
+// appears not to persist because the session cookie belongs to another origin.
+//
+// Adopt a changed default only when the user was still on the previous one:
+// an explicitly chosen server (via the sign-in screen's server picker) is a
+// deliberate choice and must survive.
+const defaultServerUrl = useStorage(
+  'parchment-default-server',
+  DEFAULT_SERVER_URL,
+)
+if (defaultServerUrl.value !== DEFAULT_SERVER_URL) {
+  if (serverUrl.value === defaultServerUrl.value) {
+    serverUrl.value = DEFAULT_SERVER_URL
+  }
+  defaultServerUrl.value = DEFAULT_SERVER_URL
+}
+
 /** Request timeout (ms). Prevents "loads forever" when the server doesn't respond. */
 const REQUEST_TIMEOUT_MS = 15000
 


### PR DESCRIPTION
Preview web servers never received VITE_SERVER_ORIGIN, so the client fell back to http://localhost:5000 — the phone own localhost, or the laptop own dev server. Sign-in and its session cookie went to the wrong origin, so the app appeared to forget the session on every refresh.

It was written into .env.preview, which only the API process reads via bun --env-file; Vite only loads .env/.env.local from web/, so it never saw it. It now goes into the web unit process environment.