### PR TITLE
Fix preview pr's repo lookup, and say what isOpenAt is for

### DIFF
--- a/scripts/preview.sh
+++ b/scripts/preview.sh
@@ -423,7 +423,11 @@ cmd_pr() {
   ensure_state; resolve_target "${1:-}"
   local branch=$TARGET_BRANCH worktree=$TARGET_WORKTREE url repo visibility
   url=$(cmd_url "$branch")
-  repo=$(git -C "$worktree" remote get-url origin | sed -E 's#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#')
+  # owner/name from the remote URL, whatever form it takes. The `.git` suffix
+  # is stripped first: sed's ERE has no lazy quantifiers, so folding it into the
+  # capture leaves it attached, and every `gh` call below then fails against a
+  # repository named "parchment.git".
+  repo=$(git -C "$worktree" remote get-url origin | sed -E 's#\.git$##; s#.*[:/]([^/]+/[^/]+)$#\1#')
 
   git -C "$worktree" push --quiet -u origin "$branch"
 

--- a/server/src/lib/opening-hours.ts
+++ b/server/src/lib/opening-hours.ts
@@ -337,8 +337,18 @@ export function parseOpeningHours(
  * Whether a place is open at `instant`, per the raw value.
  *
  * Answers straight from the parsed value rather than the flattened weekly
- * schedule, so holiday and seasonal rules that the schedule can't express are
- * still honoured.
+ * schedule, so holiday and seasonal rules the schedule can't express are still
+ * honoured — `Nov Th[4] off` shuts on Thanksgiving here, which no seven-entry
+ * week can represent.
+ *
+ * No production path calls this, and that is deliberate rather than an
+ * oversight. The open/closed state a reader sees has to keep ticking after the
+ * response is sent, so it is derived on the client from `regularHours`. This is
+ * how that derivation gets checked: it is the spec-exact answer a flattened
+ * week can be measured against, and comparing the two across every real
+ * expression in a city is what turned up the overnight and prose-hours defects.
+ * The obvious production caller is a server-side "open now" search filter —
+ * today that filter can only ask whether a place has any hours at all.
  */
 export function isOpenAt(
   rawText: string | null | undefined,


### PR DESCRIPTION
Two loose ends found while working PAR-289 (#398). Unrelated to each other, both small, neither belonged in that PR.

## `preview pr` could not resolve the repository

Every `gh` call in `cmd_pr` ran against a repository named `parchment.git`, so the command failed outright:

```
GraphQL: Could not resolve to a Repository with the name 'alexwohlbruck/parchment.git'. (repository)
```

The name is derived from the remote URL with `s#.*[:/]([^/]+/[^/]+?)(\.git)?$#\1#`. That relies on `+?` being lazy, which it is in PCRE but not in POSIX ERE — sed has no lazy quantifiers, so `[^/]+` swallows `parchment.git` and the optional `(\.git)?` group matches empty. Stripping the suffix in its own expression first fixes it, and holds for every remote form:

| remote | before | after |
| --- | --- | --- |
| `https://github.com/o/r.git` | `o/r.git` | `o/r` |
| `git@github.com:o/r.git` | `o/r.git` | `o/r` |
| `ssh://git@github.com/o/r.git` | `o/r.git` | `o/r` |
| `https://github.com/o/r` | `o/r` | `o/r` |

Worth noting the failure mode was safe: `gh repo view` failing meant `visibility` fell back to `PUBLIC`, so a broken lookup could never have leaked a preview URL into a public PR. It just meant the command never worked.

## `isOpenAt` reads as dead code

It is exported and called from nowhere, which invites the next reader to delete it. It is worth keeping — it answers from the parsed expression rather than the flattened week, so `Nov Th[4] off` closes on Thanksgiving, which no seven-entry weekly schedule can represent. That makes it the reference answer the flattening can be checked against, and comparing the two across every real expression in a city is what surfaced the defects fixed in #398.

This commit says so in the doc comment, and names the obvious future caller: a server-side "open now" search filter, which today can only ask whether a place has hours at all. No behaviour change.

## Verification

`bash -n` on the script, the repo-name derivation checked against the four remote forms above, and the server suite green (3873 pass). The `preview pr` path itself is not exercised here — running it posts a comment to a PR, so that is left to the author.

🤖 Generated with [Claude Code](https://claude.com/claude-code)