### PR TITLE
Fix saved places disappearing from the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+* Saved places could go missing from the map entirely. A map marker that failed to draw — a tracked vehicle, most often — took the rest of the map's setup down with it, and the saved places layer was one of the things that never got built. Markers that can't draw are now contained to themselves
+
 ## [0.6.0] - 2026-08-18
 
 ### Added

--- a/web/src/lib/vue-marker.utils.ts
+++ b/web/src/lib/vue-marker.utils.ts
@@ -1,7 +1,22 @@
 import { createApp, Component, App } from 'vue'
+import { i18n } from '@/lib/i18n'
+import router from '@/router'
 
 /**
- * Convert a Vue component to a DOM element for use as a map marker
+ * Convert a Vue component to a DOM element for use as a map marker.
+ *
+ * Each marker is its own Vue app, so it inherits NOTHING from the main app's
+ * plugins — a marker component calling `useI18n()` or `useRouter()` throws at
+ * setup ("Need to install with `app.use` function"). The same instances are
+ * installed here so marker components can be written like any other
+ * component. Pinia needs no install: `createPinia()` sets the active pinia
+ * globally, so `useStore()` resolves without app context.
+ *
+ * Markers are mounted from map initialization, so a throw here used to
+ * propagate into `style.load` and abort every later step — the saved places
+ * source and layers among them, which left the map with no saved place
+ * markers at all. A marker that can't mount is contained to itself: it draws
+ * nothing, and the rest of the map still comes up.
  */
 export function createVueMarkerElement(
   component: Component,
@@ -12,12 +27,17 @@ export function createVueMarkerElement(
 
   // Create a Vue app instance with the component
   const app: App = createApp(component, props)
+  app.use(i18n)
+  app.use(router)
 
-  // Mount the app to the container
-  app.mount(container)
-
-  // Store the app instance on the element for cleanup
-  ;(container as any)._vueApp = app
+  try {
+    // Mount the app to the container
+    app.mount(container)
+    // Store the app instance on the element for cleanup
+    ;(container as any)._vueApp = app
+  } catch (error) {
+    console.error('Failed to mount map marker component:', error)
+  }
 
   return container
 }


### PR DESCRIPTION
## What

`createVueMarkerElement` mounts every map marker in its own `createApp()`, which inherits none of the main app's plugins. `TrackerMarker.vue` calls `useI18n()`, so it threw at setup:

> SyntaxError: Need to install with `app.use` function

Markers are mounted from `initializeMarkerLayers()` inside the map's `style.load` handler, so that throw aborted everything after it in `onStyleLoad` — including `initializeBookmarksLayer()`. The result: `bookmarks-source-internal` and both saved-places layers were never added to the map, so no saved place markers rendered at all (environment data, the timeline layer and `setConfigProperties()` were also skipped).

## Change

- Install the app's `i18n` and `router` instances on each marker app, so marker components can be written like any other component. Pinia needs no install — `createPinia()` sets the active pinia globally.
- Contain a failed mount to the marker itself, so one broken marker can never take down map initialization again.

## Verified

Driving the branch preview headlessly, before the change the map had no `bookmarks-source-internal` and no `bookmarks-circles-internal` / `bookmarks-icons-internal` layers, with the i18n error in the console. After it, the source and both layers are present. `web/src/lib` unit tests pass (643).

**Not yet confirmed:** whether this is the same thing as the fade-on-zoom-in reported from a phone. Nothing in the saved-places paint expressions fades above z10.5, and this is a real defect in the same path, but the two symptoms haven't been tied together — worth checking against the preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)