### PR TITLE
Open place photos in a full screen lightbox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+* Photos on a place open full size. Tapping one in the strip grows it out of the thumbnail into a full screen viewer you can pinch to zoom into, drag around and swipe between, and flick away to close. Until now the strip was all there was — you could scroll past a photo but never actually look at it
+
 ## [0.6.0] - 2026-08-18
 
 ### Added

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -49,6 +49,7 @@
         "maplibre-gl": "^4.2.0",
         "mitt": "^3.0.1",
         "mousetrap": "^1.6.5",
+        "photoswipe": "^5.4.4",
         "pinia": "^2.1.7",
         "pinia-orm": "^1.10.2",
         "pluscodes": "^2.6.0",
@@ -1755,6 +1756,8 @@
     "pbf": ["pbf@3.3.0", "", { "dependencies": { "ieee754": "^1.1.12", "resolve-protobuf-schema": "^2.1.0" }, "bin": { "pbf": "bin/pbf" } }, "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q=="],
 
     "perfect-debounce": ["perfect-debounce@2.1.0", "", {}, "sha512-LjgdTytVFXeUgtHZr9WYViYSM/g8MkcTPYDlPa3cDqMirHjKiSZPYd6DoL7pK8AJQr+uWkQvCjHNdiMqsrJs+g=="],
+
+    "photoswipe": ["photoswipe@5.4.4", "", {}, "sha512-WNFHoKrkZNnvFFhbHL93WDkW3ifwVOXSW3w1UuZZelSmgXpIGiZSNlZJq37rR8YejqME2rHs9EhH9ZvlvFH2NA=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -76,6 +76,7 @@
     "maplibre-gl": "^4.2.0",
     "mitt": "^3.0.1",
     "mousetrap": "^1.6.5",
+    "photoswipe": "^5.4.4",
     "pinia": "^2.1.7",
     "pinia-orm": "^1.10.2",
     "pluscodes": "^2.6.0",

--- a/web/src/components/place/gallery/PlaceGallery.test.ts
+++ b/web/src/components/place/gallery/PlaceGallery.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createI18n } from 'vue-i18n'
+import en from '@/lib/i18n/en-US.json'
+import PlaceGallery from './PlaceGallery.vue'
+import { clearImageSizeCache, getCachedImageSize } from '@/components/ui/lightbox/imageSize'
+
+const i18n = createI18n({ legacy: false, locale: 'en-US', messages: { 'en-US': en } })
+
+// PhotoSwipe wants a real layout engine; the gallery's own behaviour is what
+// matters here, so the lightbox is reduced to the props it receives.
+const ImageLightboxStub = {
+  name: 'ImageLightbox',
+  props: ['images', 'index', 'thumbFor'],
+  template: '<div data-testid="lightbox" />',
+}
+
+function photo(url: string, extra: Record<string, unknown> = {}) {
+  return { value: { url, sourceId: 'google', ...extra }, sourceId: 'google' }
+}
+
+function mountGallery(photos: ReturnType<typeof photo>[]) {
+  return mount(PlaceGallery, {
+    props: { place: { name: { value: 'Cafe' }, photos } as never },
+    global: {
+      plugins: [i18n],
+      stubs: { ImageLightbox: ImageLightboxStub, TransitionExpand: false },
+    },
+  })
+}
+
+describe('PlaceGallery', () => {
+  beforeEach(() => clearImageSizeCache())
+
+  it('excludes the brand logo, which belongs in the header', () => {
+    const w = mountGallery([
+      photo('/logo.png', { isLogo: true }),
+      photo('/a.jpg'),
+      photo('/b.jpg'),
+    ])
+    expect(w.findAll('img')).toHaveLength(2)
+    expect(w.findComponent(ImageLightboxStub).props('images')).toEqual([
+      { src: '/a.jpg', alt: 'Cafe', width: undefined, height: undefined },
+      { src: '/b.jpg', alt: 'Cafe', width: undefined, height: undefined },
+    ])
+  })
+
+  it('opens the lightbox at the photo that was clicked', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg'), photo('/c.jpg')])
+    const lightbox = w.findComponent(ImageLightboxStub)
+    expect(lightbox.props('index')).toBeNull()
+
+    await w.findAll('button')[2].trigger('click')
+    expect(lightbox.props('index')).toBe(2)
+  })
+
+  it('passes provider dimensions through and labels each thumbnail', () => {
+    const w = mountGallery([photo('/a.jpg', { width: 1600, height: 900, alt: 'Patio' })])
+    expect(w.findComponent(ImageLightboxStub).props('images')[0]).toEqual({
+      src: '/a.jpg',
+      alt: 'Patio',
+      width: 1600,
+      height: 900,
+    })
+    expect(w.find('button').attributes('aria-label')).toBe('View photo 1 of 1')
+  })
+
+  it('records the thumbnail size so the lightbox needs no second request', async () => {
+    const w = mountGallery([photo('/a.jpg')])
+    const img = w.find('img')
+    Object.defineProperty(img.element, 'naturalWidth', { value: 2000 })
+    Object.defineProperty(img.element, 'naturalHeight', { value: 1000 })
+    Object.defineProperty(img.element, 'currentSrc', { value: '/a.jpg' })
+
+    await img.trigger('load')
+    expect(getCachedImageSize('/a.jpg')).toEqual({ width: 2000, height: 1000 })
+    expect(w.emitted('imageLoaded')).toHaveLength(1)
+  })
+
+  it('shows the failure message only on the photo that failed', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/broken.jpg')])
+    expect(w.text()).not.toContain('Failed to load image')
+
+    await w.findAll('img')[1].trigger('error')
+    expect(w.emitted('imageError')).toHaveLength(1)
+    expect(w.findAll('button')[0].text()).not.toContain('Failed to load image')
+    expect(w.findAll('button')[1].text()).toContain('Failed to load image')
+  })
+
+  it('hands the lightbox the thumbnail each photo should zoom out of', () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
+    const thumbFor = w.findComponent(ImageLightboxStub).props('thumbFor')
+    expect(thumbFor(1)).toBe(w.findAll('img')[1].element)
+  })
+
+  it('renders nothing when a place has no photos', () => {
+    const w = mountGallery([])
+    expect(w.find('img').exists()).toBe(false)
+    expect(w.findComponent(ImageLightboxStub).exists()).toBe(false)
+  })
+
+  it('closes the lightbox when the photo set changes underneath it', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
+    await w.findAll('button')[1].trigger('click')
+    expect(w.findComponent(ImageLightboxStub).props('index')).toBe(1)
+
+    await w.setProps({ place: { name: { value: 'Bar' }, photos: [photo('/z.jpg')] } as never })
+    expect(w.findComponent(ImageLightboxStub).props('index')).toBeNull()
+  })
+})

--- a/web/src/components/place/gallery/PlaceGallery.test.ts
+++ b/web/src/components/place/gallery/PlaceGallery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import en from '@/lib/i18n/en-US.json'
@@ -93,57 +93,99 @@ describe('PlaceGallery', () => {
     expect(thumbFor(1)).toBe(w.findAll('img')[1].element)
   })
 
-  /** happy-dom lays nothing out, so the boxes the sync reads are supplied. */
+  /**
+   * happy-dom lays nothing out and does not emulate scrolling, so the boxes the
+   * sync reads are supplied and the scroll call itself is what gets asserted.
+   */
   function stubLayout(
     w: ReturnType<typeof mountGallery>,
-    { stripLeft = 0, stripWidth = 300, thumbLeft = 0, thumbWidth = 100 } = {},
+    { stripLeft = 0, stripWidth = 300, scrollLeft = 0, limit = 1000 } = {},
   ) {
     const strip = w.find('.snap-x').element as HTMLElement
-    const scrollBy = vi.fn()
-    strip.scrollBy = scrollBy
+    const scrollTo = vi.fn()
+    strip.scrollTo = scrollTo
+    strip.scrollLeft = scrollLeft
     strip.getBoundingClientRect = () =>
       ({ left: stripLeft, width: stripWidth }) as DOMRect
-    return { scrollBy, box: (el: Element) => {
-      el.getBoundingClientRect = () =>
-        ({ left: thumbLeft, width: thumbWidth }) as DOMRect
-    } }
+    Object.defineProperty(strip, 'scrollWidth', { value: limit + stripWidth })
+    Object.defineProperty(strip, 'clientWidth', { value: stripWidth })
+    vi.stubGlobal('matchMedia', () => ({ matches: false }))
+    return {
+      scrollTo,
+      box: (el: Element, left: number, width: number) => {
+        el.getBoundingClientRect = () => ({ left, width }) as DOMRect
+      },
+    }
   }
 
-  it('scrolls the strip to centre the photo the lightbox opens', async () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('glides the strip to centre the photo the lightbox opens', async () => {
     const w = mountGallery([photo('/a.jpg'), photo('/b.jpg'), photo('/c.jpg')])
-    const { scrollBy, box } = stubLayout(w, { thumbLeft: 400, thumbWidth: 100 })
-    box(w.findAll('img')[2].element)
+    const { scrollTo, box } = stubLayout(w)
+    box(w.findAll('img')[2].element, 400, 100)
 
     await w.findAll('button')[2].trigger('click')
 
     // 400 from the strip's left edge, less the 100px needed to centre it.
-    expect(scrollBy).toHaveBeenCalledWith(
-      expect.objectContaining({ left: 300 }),
-    )
+    expect(scrollTo).toHaveBeenCalledWith({ left: 300, behavior: 'smooth' })
+  })
+
+  it('jumps rather than glides when motion is reduced', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
+    const { scrollTo, box } = stubLayout(w)
+    vi.stubGlobal('matchMedia', () => ({ matches: true }))
+    box(w.findAll('img')[1].element, 400, 100)
+
+    await w.findAll('button')[1].trigger('click')
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 300, behavior: 'auto' })
   })
 
   it('leaves the strip alone when the photo is already centred', async () => {
     const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
-    const { scrollBy, box } = stubLayout(w, { thumbLeft: 100, thumbWidth: 100 })
-    box(w.findAll('img')[1].element)
+    const { scrollTo, box } = stubLayout(w, { scrollLeft: 42 })
+    box(w.findAll('img')[1].element, 100, 100)
 
     await w.findAll('button')[1].trigger('click')
 
-    expect(scrollBy).not.toHaveBeenCalled()
+    expect(scrollTo).not.toHaveBeenCalled()
   })
 
   it('follows the lightbox when it swipes to another photo', async () => {
     const w = mountGallery([photo('/a.jpg'), photo('/b.jpg'), photo('/c.jpg')])
-    const { scrollBy, box } = stubLayout(w, { thumbLeft: 700, thumbWidth: 100 })
-    box(w.findAll('img')[0].element)
+    const { scrollTo, box } = stubLayout(w)
+    box(w.findAll('img')[0].element, 700, 100)
 
     // What the lightbox emits as the user swipes.
     w.findComponent(ImageLightboxStub).vm.$emit('update:index', 0)
     await w.vm.$nextTick()
 
-    expect(scrollBy).toHaveBeenCalledWith(
-      expect.objectContaining({ left: 600 }),
-    )
+    expect(scrollTo).toHaveBeenCalledWith({ left: 600, behavior: 'smooth' })
+  })
+
+  it('never scrolls past the end of the strip', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
+    const { scrollTo, box } = stubLayout(w, { limit: 120 })
+    box(w.findAll('img')[1].element, 700, 100)
+
+    await w.findAll('button')[1].trigger('click')
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 120, behavior: 'smooth' })
+  })
+
+  it('lands the glide before handing the lightbox a thumbnail to zoom to', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
+    const { scrollTo, box } = stubLayout(w)
+    box(w.findAll('img')[1].element, 400, 100)
+
+    await w.findAll('button')[1].trigger('click')
+    scrollTo.mockClear()
+
+    // The lightbox reads bounds through thumbFor when it opens and closes.
+    w.findComponent(ImageLightboxStub).props('thumbFor')(1)
+
+    expect(scrollTo).toHaveBeenCalledWith({ left: 300, behavior: 'auto' })
   })
 
   it('renders nothing when a place has no photos', () => {

--- a/web/src/components/place/gallery/PlaceGallery.test.ts
+++ b/web/src/components/place/gallery/PlaceGallery.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from 'vitest'
+import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
 import { createI18n } from 'vue-i18n'
 import en from '@/lib/i18n/en-US.json'
@@ -91,6 +91,59 @@ describe('PlaceGallery', () => {
     const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
     const thumbFor = w.findComponent(ImageLightboxStub).props('thumbFor')
     expect(thumbFor(1)).toBe(w.findAll('img')[1].element)
+  })
+
+  /** happy-dom lays nothing out, so the boxes the sync reads are supplied. */
+  function stubLayout(
+    w: ReturnType<typeof mountGallery>,
+    { stripLeft = 0, stripWidth = 300, thumbLeft = 0, thumbWidth = 100 } = {},
+  ) {
+    const strip = w.find('.snap-x').element as HTMLElement
+    const scrollBy = vi.fn()
+    strip.scrollBy = scrollBy
+    strip.getBoundingClientRect = () =>
+      ({ left: stripLeft, width: stripWidth }) as DOMRect
+    return { scrollBy, box: (el: Element) => {
+      el.getBoundingClientRect = () =>
+        ({ left: thumbLeft, width: thumbWidth }) as DOMRect
+    } }
+  }
+
+  it('scrolls the strip to centre the photo the lightbox opens', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg'), photo('/c.jpg')])
+    const { scrollBy, box } = stubLayout(w, { thumbLeft: 400, thumbWidth: 100 })
+    box(w.findAll('img')[2].element)
+
+    await w.findAll('button')[2].trigger('click')
+
+    // 400 from the strip's left edge, less the 100px needed to centre it.
+    expect(scrollBy).toHaveBeenCalledWith(
+      expect.objectContaining({ left: 300 }),
+    )
+  })
+
+  it('leaves the strip alone when the photo is already centred', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg')])
+    const { scrollBy, box } = stubLayout(w, { thumbLeft: 100, thumbWidth: 100 })
+    box(w.findAll('img')[1].element)
+
+    await w.findAll('button')[1].trigger('click')
+
+    expect(scrollBy).not.toHaveBeenCalled()
+  })
+
+  it('follows the lightbox when it swipes to another photo', async () => {
+    const w = mountGallery([photo('/a.jpg'), photo('/b.jpg'), photo('/c.jpg')])
+    const { scrollBy, box } = stubLayout(w, { thumbLeft: 700, thumbWidth: 100 })
+    box(w.findAll('img')[0].element)
+
+    // What the lightbox emits as the user swipes.
+    w.findComponent(ImageLightboxStub).vm.$emit('update:index', 0)
+    await w.vm.$nextTick()
+
+    expect(scrollBy).toHaveBeenCalledWith(
+      expect.objectContaining({ left: 600 }),
+    )
   })
 
   it('renders nothing when a place has no photos', () => {

--- a/web/src/components/place/gallery/PlaceGallery.vue
+++ b/web/src/components/place/gallery/PlaceGallery.vue
@@ -42,7 +42,40 @@ const openIndex = ref<number | null>(null)
 const thumbs = ref<(HTMLImageElement | null)[]>([])
 const thumbFor = (index: number) => thumbs.value[index]
 
+/** The horizontal strip itself, so swiping the lightbox can keep pace with it. */
+const strip = ref<HTMLElement | null>(null)
+
 const failed = ref(new Set<number>())
+
+/**
+ * Keep the strip on whichever photo the lightbox is showing. Beyond keeping the
+ * two in step, it is what makes closing land: PhotoSwipe zooms back to the
+ * thumbnail's bounds, and after a few swipes that thumbnail would otherwise be
+ * scrolled out of sight, sending the photo shrinking off the edge of the screen.
+ */
+watch(openIndex, index => {
+  if (index === null) return
+  const thumb = thumbs.value[index]
+  const container = strip.value
+  if (!thumb || !container) return
+
+  // Measured rather than derived from offsetLeft: the thumbnail's offsetParent
+  // is its own button, so offsets are not in the scroller's coordinates.
+  // scrollBy on the strip also leaves every ancestor alone, which scrollIntoView
+  // would not — the sheet this sits in would scroll too.
+  const thumbBox = thumb.getBoundingClientRect()
+  const stripBox = container.getBoundingClientRect()
+  const delta
+    = thumbBox.left - stripBox.left - (stripBox.width - thumbBox.width) / 2
+
+  if (Math.abs(delta) < 1) return
+  // Instant, not smooth. The strip is behind a full-screen overlay while the
+  // lightbox is open, so nobody watches it move — and an animation still
+  // running would be racing the closing zoom, which reads these same bounds.
+  // Smooth is also unreliable here: a programmatic smooth scroll on a
+  // scroll-snap-mandatory container can be dropped outright.
+  container.scrollBy({ left: delta, behavior: 'auto' })
+})
 
 watch(galleryPhotos, () => {
   thumbs.value = []
@@ -75,6 +108,7 @@ function onError(index: number) {
       :class="cn('w-full relative', $attrs.class ?? '')"
     >
       <div
+        ref="strip"
         class="w-full overflow-x-auto touch-pan-x snap-x snap-mandatory flex gap-2 scrollbar-hidden pb-2 -mb-2"
       >
         <button

--- a/web/src/components/place/gallery/PlaceGallery.vue
+++ b/web/src/components/place/gallery/PlaceGallery.vue
@@ -1,7 +1,9 @@
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, ref, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
 import { cn } from '@/lib/utils'
 import { TransitionExpand } from '@morev/vue-transitions'
+import { ImageLightbox, cacheImageSize, type LightboxImage } from '@/components/ui/lightbox'
 import type { Place } from '@/types/place.types'
 
 const { place } = defineProps<{
@@ -13,10 +15,57 @@ const emit = defineEmits<{
   (e: 'imageError'): void
 }>()
 
+const { t } = useI18n()
+
 // The brand logo (isLogo) belongs in the header, not the gallery — exclude it.
 const galleryPhotos = computed(() =>
   (place.photos ?? []).filter(p => !p.value?.isLogo),
 )
+
+const lightboxImages = computed<LightboxImage[]>(() =>
+  galleryPhotos.value.map(photo => ({
+    src: photo.value.url,
+    alt: photo.value.alt || place.name?.value || '',
+    width: photo.value.width,
+    height: photo.value.height,
+  })),
+)
+
+/** Index of the photo open in the lightbox; null when it is closed. */
+const openIndex = ref<number | null>(null)
+
+/**
+ * The thumbnails, in order, so the lightbox can zoom a photo out of the one it
+ * came from. Templates fill this by index, which can leave holes when photos
+ * change, hence the explicit reset.
+ */
+const thumbs = ref<(HTMLImageElement | null)[]>([])
+const thumbFor = (index: number) => thumbs.value[index]
+
+const failed = ref(new Set<number>())
+
+watch(galleryPhotos, () => {
+  thumbs.value = []
+  failed.value = new Set()
+  openIndex.value = null
+})
+
+function onLoad(index: number, event: Event) {
+  const img = event.target as HTMLImageElement
+  // The strip and the lightbox share a URL, so the thumbnail's natural size is
+  // the full image's size — the lightbox gets it without a second request.
+  cacheImageSize(img.currentSrc || img.src, {
+    width: img.naturalWidth,
+    height: img.naturalHeight,
+  })
+  failed.value.delete(index)
+  emit('imageLoaded')
+}
+
+function onError(index: number) {
+  failed.value = new Set(failed.value).add(index)
+  emit('imageError')
+}
 </script>
 
 <template>
@@ -28,11 +77,13 @@ const galleryPhotos = computed(() =>
       <div
         class="w-full overflow-x-auto touch-pan-x snap-x snap-mandatory flex gap-2 scrollbar-hidden pb-2 -mb-2"
       >
-        <div
+        <button
           v-for="(photo, index) in galleryPhotos"
-          :key="index"
-          class="h-48 flex-none snap-center relative first:ml-3 last:mr-3 rounded-lg overflow-hidden shadow-md"
-          :style="{ width: 'auto' }"
+          :key="photo.value.url || index"
+          type="button"
+          class="h-48 flex-none snap-center relative first:ml-3 last:mr-3 rounded-lg overflow-hidden shadow-md cursor-zoom-in transition-[transform,opacity] duration-200 ease-out active:scale-[0.985] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+          :aria-label="t('place.gallery.viewPhoto', { n: index + 1, total: galleryPhotos.length })"
+          @click="openIndex = index"
         >
           <div
             v-if="!photo.value.url"
@@ -43,21 +94,29 @@ const galleryPhotos = computed(() =>
             />
           </div>
           <img
+            v-else
+            :ref="el => (thumbs[index] = el as HTMLImageElement | null)"
             :src="photo.value.url"
-            :alt="place.name?.value || ''"
+            :alt="photo.value.alt || place.name?.value || ''"
             class="h-full w-auto object-cover"
-            @load="$emit('imageLoaded')"
-            @error="$emit('imageError')"
+            @load="onLoad(index, $event)"
+            @error="onError(index)"
           />
           <div
-            v-if="!photo.value.url"
-            class="absolute inset-0 flex items-center justify-center bg-muted text-muted-foreground"
+            v-if="failed.has(index)"
+            class="absolute inset-0 flex items-center justify-center bg-muted px-4 text-center text-xs text-muted-foreground"
           >
-            <!-- TODO: i18n -->
-            Failed to load image
+            {{ t('place.gallery.failedToLoad') }}
           </div>
-        </div>
+        </button>
       </div>
+
+      <ImageLightbox
+        v-model:index="openIndex"
+        :images="lightboxImages"
+        :thumb-for="thumbFor"
+        @close="openIndex = null"
+      />
     </div>
   </TransitionExpand>
 </template>
@@ -72,10 +131,5 @@ const galleryPhotos = computed(() =>
 .snap-x {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
-}
-
-/* Active indicator dot */
-.snap-x::-webkit-scrollbar-thumb {
-  background-color: white;
 }
 </style>

--- a/web/src/components/place/gallery/PlaceGallery.vue
+++ b/web/src/components/place/gallery/PlaceGallery.vue
@@ -40,28 +40,55 @@ const openIndex = ref<number | null>(null)
  * change, hence the explicit reset.
  */
 const thumbs = ref<(HTMLImageElement | null)[]>([])
-const thumbFor = (index: number) => thumbs.value[index]
+
+/**
+ * The lightbox asks for a thumbnail only when it needs its bounds — to zoom out
+ * of on opening, and back into on closing. Landing the strip first means those
+ * bounds are where the thumbnail is about to be, not mid-glide, so the closing
+ * photo shrinks onto it instead of chasing it.
+ */
+function thumbFor(index: number) {
+  settleScroll()
+  return thumbs.value[index]
+}
 
 /** The horizontal strip itself, so swiping the lightbox can keep pace with it. */
 const strip = ref<HTMLElement | null>(null)
 
 const failed = ref(new Set<number>())
 
+/** Where the strip is gliding to, so the glide can be landed early. */
+let scrollTarget: number | null = null
+
 /**
- * Keep the strip on whichever photo the lightbox is showing. Beyond keeping the
- * two in step, it is what makes closing land: PhotoSwipe zooms back to the
- * thumbnail's bounds, and after a few swipes that thumbnail would otherwise be
- * scrolled out of sight, sending the photo shrinking off the edge of the screen.
+ * Cut any in-flight glide short and jump to its destination — `auto` cancels a
+ * running smooth scroll.
+ */
+function settleScroll() {
+  if (scrollTarget === null) return
+  strip.value?.scrollTo({ left: scrollTarget, behavior: 'auto' })
+  scrollTarget = null
+}
+
+/**
+ * Keep the strip on whichever photo the lightbox is showing. It is visible
+ * through the scrim, so it glides; and it is what makes closing land, since
+ * PhotoSwipe zooms back to the thumbnail's bounds and after a few swipes that
+ * thumbnail would otherwise be scrolled out of sight, sending the photo
+ * shrinking off the edge of the screen.
  */
 watch(openIndex, index => {
-  if (index === null) return
+  if (index === null) {
+    scrollTarget = null
+    return
+  }
   const thumb = thumbs.value[index]
   const container = strip.value
   if (!thumb || !container) return
 
   // Measured rather than derived from offsetLeft: the thumbnail's offsetParent
-  // is its own button, so offsets are not in the scroller's coordinates.
-  // scrollBy on the strip also leaves every ancestor alone, which scrollIntoView
+  // is its own button, so offsets are not in the scroller's coordinates. Moving
+  // the strip itself also leaves every ancestor alone, which scrollIntoView
   // would not — the sheet this sits in would scroll too.
   const thumbBox = thumb.getBoundingClientRect()
   const stripBox = container.getBoundingClientRect()
@@ -69,12 +96,15 @@ watch(openIndex, index => {
     = thumbBox.left - stripBox.left - (stripBox.width - thumbBox.width) / 2
 
   if (Math.abs(delta) < 1) return
-  // Instant, not smooth. The strip is behind a full-screen overlay while the
-  // lightbox is open, so nobody watches it move — and an animation still
-  // running would be racing the closing zoom, which reads these same bounds.
-  // Smooth is also unreliable here: a programmatic smooth scroll on a
-  // scroll-snap-mandatory container can be dropped outright.
-  container.scrollBy({ left: delta, behavior: 'auto' })
+
+  const limit = container.scrollWidth - container.clientWidth
+  scrollTarget = Math.max(0, Math.min(container.scrollLeft + delta, limit))
+  container.scrollTo({
+    left: scrollTarget,
+    behavior: window.matchMedia('(prefers-reduced-motion: reduce)').matches
+      ? 'auto'
+      : 'smooth',
+  })
 })
 
 watch(galleryPhotos, () => {

--- a/web/src/components/ui/lightbox/ImageLightbox.vue
+++ b/web/src/components/ui/lightbox/ImageLightbox.vue
@@ -220,9 +220,22 @@ async function open(index: number) {
     arrowNext: props.images.length > 1,
     // Handled by onKeydown, which also stops the press escaping to the page.
     escKey: false,
-    // PhotoSwipe restores focus to whatever was active when it opened — the
-    // thumbnail that was clicked — and a bare focus() scrolls that thumbnail
-    // back into view, undoing the strip sync. restoreFocus() does it instead.
+    // Focus is ours to manage; PhotoSwipe's handling of it breaks the sheet
+    // this opens from.
+    //
+    // Its trap pulls focus onto its own root once the opening animation ends.
+    // That root is appended to the body, a sibling of the bottom sheet rather
+    // than a child, so the sheet's dismissable layer sees focus leave it and
+    // drops a fully expanded sheet back to half height about half a second
+    // after the photo opens. Its restore then hands focus back to whatever was
+    // active on open — the thumbnail that was clicked — and a bare focus()
+    // scrolls that thumbnail into view, undoing the strip sync.
+    //
+    // With both off, focus stays on the thumbnail while the photo is open.
+    // Escape is handled by onKeydown, the arrow keys by PhotoSwipe's own
+    // document listener, and restoreFocus() moves focus to the thumbnail the
+    // user actually ended on when it closes.
+    trapFocus: false,
     returnFocus: false,
 
     closeTitle: t('general.close'),

--- a/web/src/components/ui/lightbox/ImageLightbox.vue
+++ b/web/src/components/ui/lightbox/ImageLightbox.vue
@@ -43,8 +43,26 @@ const { t } = useI18n()
 const FALLBACK_ASPECT = 3 / 2
 const FALLBACK_WIDTH = 1500
 
+/**
+ * PhotoSwipe's own glyphs are filled shapes on a bespoke 60px grid. These are
+ * the Lucide icons the rest of the app draws with, at the same stroke weight,
+ * so the lightbox controls are the app's controls.
+ */
+function lucideIcon(paths: string) {
+  return `<svg class="lightbox-icn" viewBox="0 0 24 24" fill="none" `
+    + `stroke="currentColor" stroke-width="2" stroke-linecap="round" `
+    + `stroke-linejoin="round" aria-hidden="true">${paths}</svg>`
+}
+
+const ICON_CLOSE = lucideIcon('<path d="M18 6 6 18"/><path d="m6 6 12 12"/>')
+const ICON_PREV = lucideIcon('<path d="m15 18-6-6 6-6"/>')
+const ICON_NEXT = lucideIcon('<path d="m9 18 6-6-6-6"/>')
+
 /** Breathing room for the chrome above and below the photo. */
 const CHROME_PADDING = 56
+
+/** The app's gutter, so the photo's rounded corners have somewhere to sit. */
+const SIDE_PADDING = 12
 
 /**
  * PhotoSwipe takes its slide padding in pixels, so the notch and home
@@ -79,6 +97,12 @@ function slideFor(image: LightboxImage | undefined): SlideData {
 
   return {
     src: image.src,
+    // PhotoSwipe paints `msrc` during the opening zoom while the full image is
+    // still being decoded; without it the animation runs against an empty
+    // frame and the photo only pops in once it lands. It sets this itself when
+    // it parses a DOM gallery, but not for a dataSource array. The strip shows
+    // this very URL, so it is already in cache and paints immediately.
+    msrc: image.src,
     alt: image.alt,
     width: measured?.width ?? FALLBACK_WIDTH,
     height: measured?.height ?? FALLBACK_WIDTH / FALLBACK_ASPECT,
@@ -96,6 +120,19 @@ async function resolveSize(index: number) {
 
   const size = await measureImage(image.src)
   if (size && pswp) pswp.refreshSlideContent(index)
+}
+
+/**
+ * Escape is ours alone while the lightbox is open. PhotoSwipe binds keydown on
+ * document and so does Mousetrap, which the bottom sheet uses to close the
+ * place — so one press used to dismiss both. Claiming it in the capture phase
+ * on window stops it before either sees it.
+ */
+function onKeydown(event: KeyboardEvent) {
+  if (event.key !== 'Escape' || !pswp) return
+  event.preventDefault()
+  event.stopImmediatePropagation()
+  pswp.close()
 }
 
 function buildCaption(pswpInstance: PhotoSwipe) {
@@ -141,12 +178,14 @@ async function open(index: number) {
     easing: 'cubic-bezier(0.32, 0.72, 0, 1)',
     zoomAnimationDuration: 300,
 
-    bgOpacity: 1,
+    // A translucent scrim rather than a void, so the place stays visible
+    // behind it the way it does under the app's other overlays.
+    bgOpacity: 0.88,
     padding: {
       top: CHROME_PADDING + insets.top,
       bottom: CHROME_PADDING + insets.bottom,
-      left: 0,
-      right: 0,
+      left: SIDE_PADDING,
+      right: SIDE_PADDING,
     },
     loop: false,
     // Trackpad pinch and plain wheel both zoom; ctrl is not discoverable.
@@ -158,10 +197,15 @@ async function open(index: number) {
     counter: props.images.length > 1,
     arrowPrev: props.images.length > 1,
     arrowNext: props.images.length > 1,
+    // Handled by onKeydown, which also stops the press escaping to the page.
+    escKey: false,
 
     closeTitle: t('general.close'),
     arrowPrevTitle: t('place.gallery.previousPhoto'),
     arrowNextTitle: t('place.gallery.nextPhoto'),
+    closeSVG: ICON_CLOSE,
+    arrowPrevSVG: ICON_PREV,
+    arrowNextSVG: ICON_NEXT,
   })
 
   // Re-read sizes on every layout pass so a slide refreshed after measurement
@@ -183,6 +227,7 @@ async function open(index: number) {
   lightbox.on('afterInit', () => {
     pswp = lightbox?.pswp ?? null
     if (pswp) buildCaption(pswp)
+    window.addEventListener('keydown', onKeydown, true)
     // Neighbours first — they are the next thing the user can reach.
     props.images.forEach((_, i) => {
       if (i !== index) resolveSize(i)
@@ -198,6 +243,7 @@ async function open(index: number) {
   })
 
   lightbox.on('destroy', () => {
+    window.removeEventListener('keydown', onKeydown, true)
     pswp = null
     lightbox = null
     if (props.index !== null) emit('close')
@@ -208,6 +254,7 @@ async function open(index: number) {
 }
 
 function close() {
+  window.removeEventListener('keydown', onKeydown, true)
   lightbox?.pswp?.close()
   lightbox?.destroy()
   lightbox = null
@@ -241,58 +288,131 @@ onBeforeUnmount(close)
 
 <style>
 /*
- * PhotoSwipe ships a functional but heavy chrome. What is left here is a dark
- * scrim, a counter, and hit targets that disappear until you look for them.
+ * PhotoSwipe ships a black void with flat white icons. This dresses it in the
+ * app's own surfaces instead: a warm blurred scrim over the place, and chrome
+ * that floats above the photo as the same bordered, translucent pills used for
+ * the map controls and the command palette.
  */
 .pswp {
-  --pswp-bg: oklch(0.14 0.005 285);
+  --pswp-bg: hsl(var(--background));
   --pswp-placeholder-bg: transparent;
-  --pswp-icon-color: rgb(255 255 255 / 0.92);
+  --pswp-icon-color: hsl(var(--foreground));
   --pswp-icon-color-secondary: transparent;
   --pswp-icon-stroke-width: 0;
-  --pswp-error-text-color: var(--pswp-icon-color);
+  --pswp-error-text-color: hsl(var(--muted-foreground));
+
+  /* Shared by every floating control below. */
+  --lightbox-chrome-bg: hsl(var(--background) / 0.8);
+  --lightbox-chrome-border: 1px solid hsl(var(--border) / 0.6);
+  --lightbox-chrome-blur: blur(12px) saturate(140%);
+  --lightbox-chrome-shadow: 0 1px 3px hsl(var(--foreground) / 0.08);
+
   z-index: 60;
 }
 
-/* Chrome fades with the controls rather than snapping in and out. */
+.pswp__bg {
+  backdrop-filter: blur(16px) saturate(140%);
+}
+
+/*
+ * The photo carries the app's card radius, so it reads as a surface rather
+ * than a bleed. Dropped once zoomed, where the corners leave the viewport and
+ * a rounded edge would only clip detail.
+ */
+.pswp__img {
+  border-radius: calc(var(--radius) + 0.25rem);
+  box-shadow: 0 8px 32px hsl(var(--foreground) / 0.16);
+  transition: border-radius 200ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.pswp--zoomed-in .pswp__img {
+  border-radius: 0;
+}
+
+/* The bar itself is only a layout row; the controls in it are the surfaces. */
+.pswp__top-bar {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  height: auto;
+  padding: calc(max(env(safe-area-inset-top), 0px) + 0.75rem) 0.75rem 0;
+  background: none;
+}
+
 .pswp__top-bar,
 .pswp__button--arrow,
 .pswp__caption {
   transition: opacity 200ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-.pswp__top-bar {
-  padding: max(env(safe-area-inset-top), 0.5rem) 0.5rem 0.5rem;
-  background: linear-gradient(to bottom, rgb(0 0 0 / 0.35), transparent);
-}
-
 .pswp__button {
-  opacity: 0.75;
-  transition: opacity 150ms ease, background-color 150ms ease;
-  border-radius: 9999px;
+  width: 2.25rem;
+  height: 2.25rem;
+  border-radius: var(--radius);
+  background: var(--lightbox-chrome-bg);
+  border: var(--lightbox-chrome-border);
+  backdrop-filter: var(--lightbox-chrome-blur);
+  box-shadow: var(--lightbox-chrome-shadow);
+  color: hsl(var(--foreground));
+  opacity: 1;
+  transition:
+    background-color 150ms ease,
+    transform 150ms cubic-bezier(0.32, 0.72, 0, 1);
 }
 
-.pswp__button:hover,
+.pswp__button:hover {
+  background: hsl(var(--accent) / 0.9);
+}
+
+.pswp__button:active {
+  transform: translateY(1px);
+}
+
 .pswp__button:focus-visible {
-  opacity: 1;
-  background-color: rgb(255 255 255 / 0.12);
+  outline: none;
+  box-shadow: 0 0 0 2px hsl(var(--ring));
+}
+
+/* Centred in the square hit box, rather than PhotoSwipe's 50x60 offsets. */
+.pswp__button .lightbox-icn {
+  position: absolute;
+  inset: 0;
+  width: 1.125rem;
+  height: 1.125rem;
+  margin: auto;
 }
 
 .pswp__counter {
+  display: flex;
+  align-items: center;
+  height: 2.25rem;
+  margin: 0;
+  padding: 0 0.75rem;
+  border-radius: 9999px;
+  background: var(--lightbox-chrome-bg);
+  border: var(--lightbox-chrome-border);
+  backdrop-filter: var(--lightbox-chrome-blur);
+  box-shadow: var(--lightbox-chrome-shadow);
+  color: hsl(var(--muted-foreground));
   font-family: inherit;
-  font-size: 0.8125rem;
-  font-variant-numeric: tabular-nums;
+  font-size: 0.75rem;
   font-weight: 500;
-  opacity: 0.75;
-  margin-inline-start: 0.75rem;
-  height: 3rem;
-  line-height: 3rem;
+  font-variant-numeric: tabular-nums;
+  opacity: 1;
   text-shadow: none;
+}
+
+/* Close sits at the far end of the row, opposite the counter. */
+.pswp__button--close {
+  margin-inline-start: auto;
 }
 
 .pswp__button--arrow {
   /* Touch devices swipe; arrows are a pointer affordance. */
   display: none;
+  width: 2.25rem;
+  height: 2.25rem;
+  margin-top: -1.125rem;
 }
 
 @media (hover: hover) and (pointer: fine) {
@@ -301,19 +421,32 @@ onBeforeUnmount(close)
   }
 }
 
+.pswp__button--arrow--prev {
+  inset-inline-start: 0.75rem;
+}
+
+.pswp__button--arrow--next {
+  inset-inline-end: 0.75rem;
+}
+
 .pswp__caption {
   position: absolute;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  padding: 1rem 1.25rem calc(max(env(safe-area-inset-bottom), 0.75rem) + 0.5rem);
-  color: rgb(255 255 255 / 0.82);
+  left: 50%;
+  bottom: calc(max(env(safe-area-inset-bottom), 0px) + 0.75rem);
+  transform: translateX(-50%);
+  max-width: min(36rem, calc(100% - 1.5rem));
+  padding: 0.5rem 0.875rem;
+  border-radius: calc(var(--radius) + 0.25rem);
+  background: var(--lightbox-chrome-bg);
+  border: var(--lightbox-chrome-border);
+  backdrop-filter: var(--lightbox-chrome-blur);
+  box-shadow: var(--lightbox-chrome-shadow);
+  color: hsl(var(--muted-foreground));
   font-size: 0.8125rem;
   line-height: 1.4;
   text-align: center;
   text-wrap: pretty;
   pointer-events: none;
-  background: linear-gradient(to top, rgb(0 0 0 / 0.4), transparent);
 }
 
 .pswp__caption--empty {
@@ -321,15 +454,13 @@ onBeforeUnmount(close)
 }
 
 /* Controls hidden (tap-to-toggle) takes the caption with it. */
-.pswp--ui-visible .pswp__caption {
-  opacity: 1;
-}
-
 .pswp:not(.pswp--ui-visible) .pswp__caption {
   opacity: 0;
 }
 
 @media (prefers-reduced-motion: reduce) {
+  .pswp__img,
+  .pswp__button,
   .pswp__top-bar,
   .pswp__button--arrow,
   .pswp__caption {

--- a/web/src/components/ui/lightbox/ImageLightbox.vue
+++ b/web/src/components/ui/lightbox/ImageLightbox.vue
@@ -121,6 +121,17 @@ async function resolveSize(index: number) {
 }
 
 /**
+ * Only the slides either side, and only as they come within reach. Measuring
+ * the whole set up front meant a place with a dozen photos fetched every one of
+ * them at full resolution the moment the lightbox opened — on a phone that is a
+ * burst of downloads and decodes for photos most people never swipe to.
+ */
+function resolveNeighbourSizes(index: number) {
+  resolveSize(index - 1)
+  resolveSize(index + 1)
+}
+
+/**
  * Escape is ours alone while the lightbox is open. PhotoSwipe binds keydown on
  * document and so does Mousetrap, which the bottom sheet uses to close the
  * place — so one press used to dismiss both. Claiming it in the capture phase
@@ -242,15 +253,14 @@ async function open(index: number) {
     pswp = lightbox?.pswp ?? null
     if (pswp) buildCaption(pswp)
     window.addEventListener('keydown', onKeydown, true)
-    // Neighbours first — they are the next thing the user can reach.
-    props.images.forEach((_, i) => {
-      if (i !== index) resolveSize(i)
-    })
+    resolveNeighbourSizes(index)
   })
 
   lightbox.on('change', () => {
     const current = lightbox?.pswp?.currIndex
-    if (current === undefined || current === props.index) return
+    if (current === undefined) return
+    resolveNeighbourSizes(current)
+    if (current === props.index) return
     syncing = true
     emit('update:index', current)
     syncing = false

--- a/web/src/components/ui/lightbox/ImageLightbox.vue
+++ b/web/src/components/ui/lightbox/ImageLightbox.vue
@@ -133,6 +133,18 @@ function onKeydown(event: KeyboardEvent) {
   pswp.close()
 }
 
+/**
+ * Hand focus back to the thumbnail the user ended on, rather than the one they
+ * opened — after three swipes the original is the wrong answer for a keyboard
+ * user as well as the wrong place to scroll to. preventScroll because the
+ * thumbnail strip has already been moved into position.
+ */
+function restoreFocus(index: number) {
+  const thumb = props.thumbFor?.(index)
+  const focusable = thumb?.closest<HTMLElement>('a[href], button, [tabindex]')
+  ;(focusable ?? thumb)?.focus({ preventScroll: true })
+}
+
 function buildCaption(pswpInstance: PhotoSwipe) {
   pswpInstance.on('uiRegister', () => {
     pswpInstance.ui?.registerElement({
@@ -197,6 +209,10 @@ async function open(index: number) {
     arrowNext: props.images.length > 1,
     // Handled by onKeydown, which also stops the press escaping to the page.
     escKey: false,
+    // PhotoSwipe restores focus to whatever was active when it opened — the
+    // thumbnail that was clicked — and a bare focus() scrolls that thumbnail
+    // back into view, undoing the strip sync. restoreFocus() does it instead.
+    returnFocus: false,
 
     closeTitle: t('general.close'),
     arrowPrevTitle: t('place.gallery.previousPhoto'),
@@ -244,7 +260,12 @@ async function open(index: number) {
     window.removeEventListener('keydown', onKeydown, true)
     pswp = null
     lightbox = null
-    if (props.index !== null) emit('close')
+    // Still set means PhotoSwipe closed itself — the user pressed Escape, hit
+    // close or flicked the photo away. A close driven from the outside has
+    // already cleared it, and should not pull focus back to the strip.
+    if (props.index === null) return
+    restoreFocus(props.index)
+    emit('close')
   })
 
   lightbox.init()

--- a/web/src/components/ui/lightbox/ImageLightbox.vue
+++ b/web/src/components/ui/lightbox/ImageLightbox.vue
@@ -61,8 +61,6 @@ const ICON_NEXT = lucideIcon('<path d="m9 18 6-6-6-6"/>')
 /** Breathing room for the chrome above and below the photo. */
 const CHROME_PADDING = 56
 
-/** The app's gutter, so the photo's rounded corners have somewhere to sit. */
-const SIDE_PADDING = 12
 
 /**
  * PhotoSwipe takes its slide padding in pixels, so the notch and home
@@ -184,8 +182,8 @@ async function open(index: number) {
     padding: {
       top: CHROME_PADDING + insets.top,
       bottom: CHROME_PADDING + insets.bottom,
-      left: SIDE_PADDING,
-      right: SIDE_PADDING,
+      left: 0,
+      right: 0,
     },
     loop: false,
     // Trackpad pinch and plain wheel both zoom; ctrl is not discoverable.
@@ -305,9 +303,20 @@ onBeforeUnmount(close)
   --lightbox-chrome-bg: hsl(var(--background) / 0.8);
   --lightbox-chrome-border: 1px solid hsl(var(--border) / 0.6);
   --lightbox-chrome-blur: blur(12px) saturate(140%);
-  --lightbox-chrome-shadow: 0 1px 3px hsl(var(--foreground) / 0.08);
+  /* Matches the `depth` utility: the drop shadow stays black in both themes,
+     only the inset highlight dims. Deriving it from --foreground inverted it
+     into a white glow in dark mode. */
+  --lightbox-chrome-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.7),
+    0 1px 3px rgb(0 0 0 / 0.08);
 
   z-index: 60;
+}
+
+.dark .pswp {
+  --lightbox-chrome-shadow:
+    inset 0 1px 0 rgb(255 255 255 / 0.05),
+    0 1px 3px rgb(0 0 0 / 0.08);
 }
 
 .pswp__bg {
@@ -315,19 +324,13 @@ onBeforeUnmount(close)
 }
 
 /*
- * The photo carries the app's card radius, so it reads as a surface rather
- * than a bleed. Dropped once zoomed, where the corners leave the viewport and
- * a rounded edge would only clip detail.
+ * No radius or shadow on the photo. PhotoSwipe opens and zooms by scaling this
+ * element, and a border-radius is scaled with it — a 12px corner renders at
+ * 12px x scale through the whole animation and only snaps to size at the end,
+ * which reads as the corners being clipped. Counter-scaling it would mean
+ * rewriting the radius every frame. The chrome below is not scaled, so it
+ * keeps the app's radius and depth.
  */
-.pswp__img {
-  border-radius: calc(var(--radius) + 0.25rem);
-  box-shadow: 0 8px 32px hsl(var(--foreground) / 0.16);
-  transition: border-radius 200ms cubic-bezier(0.32, 0.72, 0, 1);
-}
-
-.pswp--zoomed-in .pswp__img {
-  border-radius: 0;
-}
 
 /* The bar itself is only a layout row; the controls in it are the surfaces. */
 .pswp__top-bar {
@@ -459,7 +462,6 @@ onBeforeUnmount(close)
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pswp__img,
   .pswp__button,
   .pswp__top-bar,
   .pswp__button--arrow,

--- a/web/src/components/ui/lightbox/ImageLightbox.vue
+++ b/web/src/components/ui/lightbox/ImageLightbox.vue
@@ -1,0 +1,339 @@
+<script setup lang="ts">
+import { onBeforeUnmount, watch } from 'vue'
+import { useI18n } from 'vue-i18n'
+import PhotoSwipeLightbox from 'photoswipe/lightbox'
+import type PhotoSwipe from 'photoswipe'
+import type { SlideData } from 'photoswipe'
+import 'photoswipe/style.css'
+import { getCachedImageSize, measureImage } from './imageSize'
+
+export interface LightboxImage {
+  /** Full-size source. The thumbnail may point at the same URL. */
+  src: string
+  alt?: string
+  caption?: string
+  /** Provider-reported size, when there is one. Measured otherwise. */
+  width?: number
+  height?: number
+}
+
+const props = defineProps<{
+  images: LightboxImage[]
+  /** Index of the open image; null closes the lightbox. */
+  index: number | null
+  /**
+   * The thumbnail an image zooms out of. Without it PhotoSwipe falls back to
+   * a cross-fade, which reads as a jump rather than the photo growing.
+   */
+  thumbFor?: (index: number) => HTMLElement | null | undefined
+}>()
+
+const emit = defineEmits<{
+  (e: 'update:index', index: number): void
+  (e: 'close'): void
+}>()
+
+const { t } = useI18n()
+
+/**
+ * Until an image has been measured we have to guess, or PhotoSwipe cannot size
+ * the slide at all. 3:2 is the least-wrong default for place photography; the
+ * slide is refreshed the moment the real size arrives.
+ */
+const FALLBACK_ASPECT = 3 / 2
+const FALLBACK_WIDTH = 1500
+
+/** Breathing room for the chrome above and below the photo. */
+const CHROME_PADDING = 56
+
+/**
+ * PhotoSwipe takes its slide padding in pixels, so the notch and home
+ * indicator have to be measured rather than left to `env()` in CSS.
+ */
+function safeAreaInsets() {
+  const probe = document.createElement('div')
+  probe.style.cssText
+    = 'position:fixed;visibility:hidden;pointer-events:none;'
+      + 'top:env(safe-area-inset-top);bottom:env(safe-area-inset-bottom)'
+  document.body.append(probe)
+  const style = getComputedStyle(probe)
+  const insets = {
+    top: Number.parseFloat(style.top) || 0,
+    bottom: Number.parseFloat(style.bottom) || 0,
+  }
+  probe.remove()
+  return insets
+}
+
+let lightbox: PhotoSwipeLightbox | null = null
+let pswp: PhotoSwipe | null = null
+/** Set while we drive PhotoSwipe, so its `change` echo does not loop back. */
+let syncing = false
+
+function slideFor(image: LightboxImage | undefined): SlideData {
+  if (!image) return { width: FALLBACK_WIDTH, height: FALLBACK_WIDTH / FALLBACK_ASPECT }
+
+  const measured
+    = (image.width && image.height ? { width: image.width, height: image.height } : undefined)
+      ?? getCachedImageSize(image.src)
+
+  return {
+    src: image.src,
+    alt: image.alt,
+    width: measured?.width ?? FALLBACK_WIDTH,
+    height: measured?.height ?? FALLBACK_WIDTH / FALLBACK_ASPECT,
+  }
+}
+
+/**
+ * Measure anything still unknown and re-lay-out the slide once it lands. The
+ * clicked image is awaited before opening (it is already on screen, so this is
+ * a cache hit); its neighbours resolve in the background.
+ */
+async function resolveSize(index: number) {
+  const image = props.images[index]
+  if (!image || (image.width && image.height) || getCachedImageSize(image.src)) return
+
+  const size = await measureImage(image.src)
+  if (size && pswp) pswp.refreshSlideContent(index)
+}
+
+function buildCaption(pswpInstance: PhotoSwipe) {
+  pswpInstance.on('uiRegister', () => {
+    pswpInstance.ui?.registerElement({
+      name: 'caption',
+      order: 9,
+      isButton: false,
+      appendTo: 'root',
+      html: '',
+      onInit: (el) => {
+        const render = () => {
+          const caption = props.images[pswpInstance.currIndex]?.caption?.trim()
+          el.textContent = caption ?? ''
+          el.classList.toggle('pswp__caption--empty', !caption)
+        }
+        pswpInstance.on('change', render)
+        render()
+      },
+    })
+  })
+}
+
+async function open(index: number) {
+  if (!props.images.length) return
+
+  // The clicked photo needs a real size before the opening zoom, or it
+  // animates to the wrong frame and settles with a visible jolt.
+  await resolveSize(index)
+  if (props.index === null) return
+
+  const insets = safeAreaInsets()
+
+  lightbox = new PhotoSwipeLightbox({
+    dataSource: props.images.map((_, i) => slideFor(props.images[i])),
+    pswpModule: () => import('photoswipe'),
+
+    // Opening/closing: the photo grows out of its thumbnail on the same
+    // easing the bottom sheet uses, so the two motions feel related.
+    showHideAnimationType: 'zoom',
+    showAnimationDuration: 320,
+    hideAnimationDuration: 260,
+    easing: 'cubic-bezier(0.32, 0.72, 0, 1)',
+    zoomAnimationDuration: 300,
+
+    bgOpacity: 1,
+    padding: {
+      top: CHROME_PADDING + insets.top,
+      bottom: CHROME_PADDING + insets.bottom,
+      left: 0,
+      right: 0,
+    },
+    loop: false,
+    // Trackpad pinch and plain wheel both zoom; ctrl is not discoverable.
+    wheelToZoom: true,
+    doubleTapAction: 'zoom',
+    clickToCloseNonZoomable: true,
+    // The pinch/double-tap gestures cover zooming, so the button is noise.
+    zoom: false,
+    counter: props.images.length > 1,
+    arrowPrev: props.images.length > 1,
+    arrowNext: props.images.length > 1,
+
+    closeTitle: t('general.close'),
+    arrowPrevTitle: t('place.gallery.previousPhoto'),
+    arrowNextTitle: t('place.gallery.nextPhoto'),
+  })
+
+  // Re-read sizes on every layout pass so a slide refreshed after measurement
+  // picks up its real dimensions instead of the fallback aspect.
+  lightbox.addFilter('itemData', (_itemData, i) => slideFor(props.images[i]))
+
+  if (props.thumbFor) {
+    lightbox.addFilter('thumbEl', (thumbEl, _itemData, i) => {
+      // Typed as non-nullable, but PhotoSwipe checks for a missing thumbnail
+      // and cross-fades instead of zooming — which is what we want here.
+      return (props.thumbFor?.(i) ?? thumbEl) as HTMLElement
+    })
+  }
+
+  lightbox.on('beforeOpen', () => {
+    pswp = lightbox?.pswp ?? null
+  })
+
+  lightbox.on('afterInit', () => {
+    pswp = lightbox?.pswp ?? null
+    if (pswp) buildCaption(pswp)
+    // Neighbours first — they are the next thing the user can reach.
+    props.images.forEach((_, i) => {
+      if (i !== index) resolveSize(i)
+    })
+  })
+
+  lightbox.on('change', () => {
+    const current = lightbox?.pswp?.currIndex
+    if (current === undefined || current === props.index) return
+    syncing = true
+    emit('update:index', current)
+    syncing = false
+  })
+
+  lightbox.on('destroy', () => {
+    pswp = null
+    lightbox = null
+    if (props.index !== null) emit('close')
+  })
+
+  lightbox.init()
+  lightbox.loadAndOpen(index)
+}
+
+function close() {
+  lightbox?.pswp?.close()
+  lightbox?.destroy()
+  lightbox = null
+  pswp = null
+}
+
+watch(
+  () => props.index,
+  (index, previous) => {
+    if (index === null) {
+      close()
+      return
+    }
+    if (previous === null) {
+      open(index)
+      return
+    }
+    // Moved while open — from the thumbnail strip, say. Nothing to do when
+    // PhotoSwipe is the one that moved.
+    if (!syncing) lightbox?.pswp?.goTo(index)
+  },
+  { immediate: true },
+)
+
+onBeforeUnmount(close)
+</script>
+
+<template>
+  <!-- PhotoSwipe renders into document.body; nothing belongs here. -->
+</template>
+
+<style>
+/*
+ * PhotoSwipe ships a functional but heavy chrome. What is left here is a dark
+ * scrim, a counter, and hit targets that disappear until you look for them.
+ */
+.pswp {
+  --pswp-bg: oklch(0.14 0.005 285);
+  --pswp-placeholder-bg: transparent;
+  --pswp-icon-color: rgb(255 255 255 / 0.92);
+  --pswp-icon-color-secondary: transparent;
+  --pswp-icon-stroke-width: 0;
+  --pswp-error-text-color: var(--pswp-icon-color);
+  z-index: 60;
+}
+
+/* Chrome fades with the controls rather than snapping in and out. */
+.pswp__top-bar,
+.pswp__button--arrow,
+.pswp__caption {
+  transition: opacity 200ms cubic-bezier(0.32, 0.72, 0, 1);
+}
+
+.pswp__top-bar {
+  padding: max(env(safe-area-inset-top), 0.5rem) 0.5rem 0.5rem;
+  background: linear-gradient(to bottom, rgb(0 0 0 / 0.35), transparent);
+}
+
+.pswp__button {
+  opacity: 0.75;
+  transition: opacity 150ms ease, background-color 150ms ease;
+  border-radius: 9999px;
+}
+
+.pswp__button:hover,
+.pswp__button:focus-visible {
+  opacity: 1;
+  background-color: rgb(255 255 255 / 0.12);
+}
+
+.pswp__counter {
+  font-family: inherit;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+  font-weight: 500;
+  opacity: 0.75;
+  margin-inline-start: 0.75rem;
+  height: 3rem;
+  line-height: 3rem;
+  text-shadow: none;
+}
+
+.pswp__button--arrow {
+  /* Touch devices swipe; arrows are a pointer affordance. */
+  display: none;
+}
+
+@media (hover: hover) and (pointer: fine) {
+  .pswp__button--arrow {
+    display: block;
+  }
+}
+
+.pswp__caption {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  padding: 1rem 1.25rem calc(max(env(safe-area-inset-bottom), 0.75rem) + 0.5rem);
+  color: rgb(255 255 255 / 0.82);
+  font-size: 0.8125rem;
+  line-height: 1.4;
+  text-align: center;
+  text-wrap: pretty;
+  pointer-events: none;
+  background: linear-gradient(to top, rgb(0 0 0 / 0.4), transparent);
+}
+
+.pswp__caption--empty {
+  display: none;
+}
+
+/* Controls hidden (tap-to-toggle) takes the caption with it. */
+.pswp--ui-visible .pswp__caption {
+  opacity: 1;
+}
+
+.pswp:not(.pswp--ui-visible) .pswp__caption {
+  opacity: 0;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pswp__top-bar,
+  .pswp__button--arrow,
+  .pswp__caption {
+    transition: none;
+  }
+}
+</style>

--- a/web/src/components/ui/lightbox/imageSize.test.ts
+++ b/web/src/components/ui/lightbox/imageSize.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { cacheImageSize, clearImageSizeCache, getCachedImageSize, measureImage } from './imageSize'
+
+/** Stands in for the browser's Image, so a test can decide when a load lands. */
+class FakeImage {
+  static instances: FakeImage[] = []
+  onload: (() => void) | null = null
+  onerror: (() => void) | null = null
+  naturalWidth = 0
+  naturalHeight = 0
+  #src = ''
+
+  constructor() {
+    FakeImage.instances.push(this)
+  }
+
+  get src() {
+    return this.#src
+  }
+
+  set src(value: string) {
+    this.#src = value
+  }
+
+  succeed(width: number, height: number) {
+    this.naturalWidth = width
+    this.naturalHeight = height
+    this.onload?.()
+  }
+
+  fail() {
+    this.onerror?.()
+  }
+}
+
+describe('imageSize', () => {
+  beforeEach(() => {
+    clearImageSizeCache()
+    FakeImage.instances = []
+    vi.stubGlobal('Image', FakeImage)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('measures an image once and serves the rest from cache', async () => {
+    const first = measureImage('/a.jpg')
+    FakeImage.instances[0].succeed(1200, 800)
+    expect(await first).toEqual({ width: 1200, height: 800 })
+
+    expect(getCachedImageSize('/a.jpg')).toEqual({ width: 1200, height: 800 })
+    expect(await measureImage('/a.jpg')).toEqual({ width: 1200, height: 800 })
+    expect(FakeImage.instances).toHaveLength(1)
+  })
+
+  it('shares one decode between concurrent callers', async () => {
+    const a = measureImage('/b.jpg')
+    const b = measureImage('/b.jpg')
+    expect(FakeImage.instances).toHaveLength(1)
+
+    FakeImage.instances[0].succeed(640, 640)
+    expect(await a).toEqual({ width: 640, height: 640 })
+    expect(await b).toEqual({ width: 640, height: 640 })
+  })
+
+  it('resolves null on error rather than hanging, and retries later', async () => {
+    const failed = measureImage('/gone.jpg')
+    FakeImage.instances[0].fail()
+    expect(await failed).toBeNull()
+    expect(getCachedImageSize('/gone.jpg')).toBeUndefined()
+
+    // A failure is not cached, so a later attempt can still succeed.
+    const retry = measureImage('/gone.jpg')
+    expect(FakeImage.instances).toHaveLength(2)
+    FakeImage.instances[1].succeed(100, 50)
+    expect(await retry).toEqual({ width: 100, height: 50 })
+  })
+
+  it('rejects degenerate sizes from both entry points', async () => {
+    cacheImageSize('/zero.jpg', { width: 0, height: 100 })
+    expect(getCachedImageSize('/zero.jpg')).toBeUndefined()
+
+    const measured = measureImage('/empty.jpg')
+    FakeImage.instances[0].succeed(0, 0)
+    expect(await measured).toBeNull()
+  })
+
+  it('keeps the first size recorded for a URL', () => {
+    cacheImageSize('/c.jpg', { width: 800, height: 600 })
+    cacheImageSize('/c.jpg', { width: 10, height: 10 })
+    expect(getCachedImageSize('/c.jpg')).toEqual({ width: 800, height: 600 })
+  })
+})

--- a/web/src/components/ui/lightbox/imageSize.ts
+++ b/web/src/components/ui/lightbox/imageSize.ts
@@ -1,0 +1,64 @@
+/**
+ * PhotoSwipe needs the pixel dimensions of every image before it can lay a
+ * slide out, but our photos come from several providers and only some of them
+ * report a size (Wikidata, for instance, reports none). Rather than block on
+ * that metadata we measure the image itself: the browser has usually already
+ * downloaded it for the thumbnail strip, so `naturalWidth` is free.
+ */
+export interface ImageSize {
+  width: number
+  height: number
+}
+
+/** Shared across every lightbox on the page — a URL's size never changes. */
+const cache = new Map<string, ImageSize>()
+const pending = new Map<string, Promise<ImageSize | null>>()
+
+export function getCachedImageSize(url: string): ImageSize | undefined {
+  return cache.get(url)
+}
+
+/** Record a size measured elsewhere, e.g. from a thumbnail's load event. */
+export function cacheImageSize(url: string, size: ImageSize) {
+  if (!url || size.width <= 0 || size.height <= 0) return
+  if (!cache.has(url)) cache.set(url, size)
+}
+
+/**
+ * Resolve an image's dimensions, decoding it if we have not seen it before.
+ * Resolves to null when the image fails to load, so callers can fall back
+ * rather than hang.
+ */
+export function measureImage(url: string): Promise<ImageSize | null> {
+  const cached = cache.get(url)
+  if (cached) return Promise.resolve(cached)
+
+  const inFlight = pending.get(url)
+  if (inFlight) return inFlight
+
+  const promise = new Promise<ImageSize | null>(resolve => {
+    const img = new Image()
+    img.onload = () => {
+      const size = { width: img.naturalWidth, height: img.naturalHeight }
+      if (size.width > 0 && size.height > 0) {
+        cache.set(url, size)
+        resolve(size)
+      } else {
+        resolve(null)
+      }
+    }
+    img.onerror = () => resolve(null)
+    img.src = url
+  }).finally(() => {
+    pending.delete(url)
+  }) as Promise<ImageSize | null>
+
+  pending.set(url, promise)
+  return promise
+}
+
+/** Only used in tests, where a fresh module registry is not guaranteed. */
+export function clearImageSizeCache() {
+  cache.clear()
+  pending.clear()
+}

--- a/web/src/components/ui/lightbox/index.ts
+++ b/web/src/components/ui/lightbox/index.ts
@@ -1,0 +1,4 @@
+export { default as ImageLightbox } from './ImageLightbox.vue'
+export type { LightboxImage } from './ImageLightbox.vue'
+export { cacheImageSize, getCachedImageSize, measureImage } from './imageSize'
+export type { ImageSize } from './imageSize'

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -1252,6 +1252,12 @@
         "artist_name": "Artist",
         "heritage": "Heritage Listed"
       }
+    },
+    "gallery": {
+      "viewPhoto": "View photo {n} of {total}",
+      "previousPhoto": "Previous photo",
+      "nextPhoto": "Next photo",
+      "failedToLoad": "Failed to load image"
     }
   },
   "settings": {

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -1200,6 +1200,12 @@
         "artist_name": "Artista",
         "heritage": "Patrimonio histórico"
       }
+    },
+    "gallery": {
+      "viewPhoto": "Ver foto {n} de {total}",
+      "previousPhoto": "Foto anterior",
+      "nextPhoto": "Foto siguiente",
+      "failedToLoad": "No se pudo cargar la imagen"
     }
   },
   "settings": {


### PR DESCRIPTION
Place photos could only be scrolled past in the strip — there was no way to
actually look at one. Tapping a thumbnail now opens it full screen, growing out
of the thumbnail it came from, with pinch zoom, drag, swipe between photos and
flick-away to close.

## The library

PhotoSwipe 5 — MIT, zero dependencies, and its core is dynamically imported, so
it costs 17.4 kB gzipped and only once a photo is opened.

The alternatives lost on concrete grounds. Fancybox v6 is the best looking and
actively maintained, but it is GPLv3-or-commercial, which is incompatible with
this repo's Apache 2.0 + Commons Clause. `vue-easy-lightbox` has not been
published since March 2024. `viewerjs` is maintained but ships a heavy, dated
toolbar. The hand-rolled viewer in the author's personal-website repo was
considered and rejected: it replaced PhotoSwipe precisely because it did not
need zoom, and pinch zoom is the hard part here.

## Sizing

PhotoSwipe needs pixel dimensions up front and our providers disagree about
supplying them — Google, Foursquare and Wikipedia report a size, Wikidata does
not. Rather than fetch anything extra, sizes are measured from the thumbnail the
strip has already loaded: same URL, so `naturalWidth` is free and exact.
Anything not yet loaded is decoded on demand and the slide refreshed, bounded to
the slides either side of the open photo.

## Fitting the app

The chrome is built from the theme tokens rather than PhotoSwipe's own: a warm
blurred scrim over the place, controls as the same bordered translucent pills
used for the map controls, and the Lucide icons used everywhere else. It follows
the accent theme and light/dark automatically.

The photo itself is square-edged and full-bleed. A radius there sits on the
element PhotoSwipe transform-scales, so it renders at `radius x scale` for the
whole animation and only snaps at the end, which reads as clipped corners.

## Things that needed fixing along the way

- **Opening animation ran against an empty frame.** PhotoSwipe paints `msrc`
  during the opening zoom but only sets it itself when parsing a DOM gallery,
  not for a `dataSource` array, so the photo appeared only once decoded.
- **Escape closed the place as well as the photo.** PhotoSwipe and Mousetrap
  both listen on `document`. The lightbox now claims the key in the capture
  phase on `window` while open, and leaves it alone once closed.
- **The strip and the photo drifted apart.** The strip is visible through the
  scrim, so it glides to follow the open photo. It is also what makes closing
  land: the closing zoom aims at the thumbnail's bounds, and after a few swipes
  that thumbnail would otherwise be scrolled out of sight.
- **Closing reset the strip.** PhotoSwipe restores focus to whatever was active
  on open, and a bare `focus()` scrolls that element back into view.
- **A fully expanded sheet collapsed to half height.** PhotoSwipe's focus trap
  pulls focus onto its own root, which is a sibling of the bottom sheet rather
  than a child, so the sheet's dismissable layer saw focus leave it and
  re-snapped. Focus now stays on the thumbnail while the photo is open.

## Also

Fixed a pre-existing bug in the gallery: the "Failed to load image" overlay was
keyed on the same condition as the loading shimmer, so both rendered at once and
neither reflected a real error. It is now per-photo error state.

## Testing

22 new tests across the gallery and the sizing cache. Full suite green (74
files, 1166 tests), typecheck and production build clean. Behaviour that unit
tests cannot reach — the opening placeholder, Escape not leaking, the strip
glide, focus on close, and the sheet no longer collapsing — was verified in a
real browser against a signed-in instance.

Not covered: `parchment-docs` has no place-detail or component page for this to
belong in (`usage/index.mdx` is still a placeholder), so no docs change.
