### PR TITLE
Cache proxied portolan tiles in the server

### DIFF
--- a/server/src/controllers/proxy.controller.test.ts
+++ b/server/src/controllers/proxy.controller.test.ts
@@ -13,6 +13,7 @@
 import { describe, test, expect, mock, beforeEach, afterAll } from 'bun:test'
 import { authMockModule, setAuthUser, resetAuth } from '../test/auth-mock'
 import { createTestApp, req } from '../test/app'
+import { portolanTileCache } from '../lib/tile-cache'
 
 let configuredIntegrations: any[] = []
 
@@ -61,6 +62,7 @@ const barrelmanIntegration = {
 
 beforeEach(() => {
   resetAuth()
+  portolanTileCache.clear()
   fetchCalls.length = 0
   fetchResponses = []
   fetchError = null
@@ -264,5 +266,91 @@ describe('GET /proxy/barrelman/:source/:z/:x/:y', () => {
     const res = await req(app).get('/proxy/barrelman/geo_places/12/1170/1567')
 
     expect(res.status).toBe(404)
+  })
+})
+
+/**
+ * Portolan tiles are cached IN THE SERVER, not just in the browser.
+ *
+ * Parchment proxies them, so every user's map traffic reaches barrelman
+ * from one address — and barrelman's per-address limit is sized for API
+ * calls, not for a viewport's worth of tiles. Forwarding each request ran
+ * normal map viewing into a steady stream of 429s. These assert the proxy
+ * asks upstream once and answers from memory after that.
+ */
+describe('GET /proxy/portolan/* — server-side caching', () => {
+  test('the second request never reaches barrelman', async () => {
+    fetchResponses = [tileResponse()]
+
+    const first = await req(app).get('/proxy/portolan/nyc/14/4825/6168.mvt')
+    expect(first.status).toBe(200)
+    expect(first.headers.get('x-cache')).toBe('MISS')
+    expect(fetchCalls.length).toBe(1)
+
+    const second = await req(app).get('/proxy/portolan/nyc/14/4825/6168.mvt')
+    expect(second.status).toBe(200)
+    expect(second.headers.get('x-cache')).toBe('HIT')
+    expect(fetchCalls.length).toBe(1) // no second upstream call
+    // the harness decodes the body as text; the bytes survive the round trip
+    expect(String(second.body)).toBe(String(first.body))
+    expect(String(second.body).length).toBeGreaterThan(0)
+  })
+
+  test('an empty tile is cached, which is most of a viewport', async () => {
+    fetchResponses = [new Response(null, { status: 204 })]
+
+    const first = await req(app).get('/proxy/portolan/nyc/14/1/1.mvt')
+    expect(first.status).toBe(204)
+    expect(fetchCalls.length).toBe(1)
+
+    const second = await req(app).get('/proxy/portolan/nyc/14/1/1.mvt')
+    expect(second.status).toBe(204)
+    expect(second.headers.get('x-cache')).toBe('HIT')
+    expect(fetchCalls.length).toBe(1)
+  })
+
+  test('a 404 is cached — the client asks again on every load', async () => {
+    // the bus-only feeds have no routes.json at all, and that request
+    // repeats forever; barrelman boxes an address that keeps being refused
+    fetchResponses = [new Response('nope', { status: 404 })]
+
+    const first = await req(app).get('/proxy/portolan/mta-bus/routes.json')
+    expect(first.status).toBe(404)
+    expect(fetchCalls.length).toBe(1)
+
+    const second = await req(app).get('/proxy/portolan/mta-bus/routes.json')
+    expect(second.status).toBe(404)
+    expect(second.headers.get('x-cache')).toBe('HIT')
+    expect(fetchCalls.length).toBe(1)
+  })
+
+  test('an upstream fault is NOT cached', async () => {
+    // a 500 is a moment, not an answer — caching it would extend an
+    // outage past the end of the outage
+    fetchResponses = [new Response('boom', { status: 500 }), tileResponse()]
+
+    const first = await req(app).get('/proxy/portolan/nyc/14/9/9.mvt')
+    expect(first.status).toBe(500)
+
+    const second = await req(app).get('/proxy/portolan/nyc/14/9/9.mvt')
+    expect(second.status).toBe(200)
+    expect(fetchCalls.length).toBe(2) // it asked again
+  })
+
+  test('different tiles are different entries', async () => {
+    fetchResponses = [tileResponse(), tileResponse()]
+    await req(app).get('/proxy/portolan/nyc/14/1/2.mvt')
+    await req(app).get('/proxy/portolan/nyc/14/1/3.mvt')
+    expect(fetchCalls.length).toBe(2)
+    await req(app).get('/proxy/portolan/nyc/14/1/2.mvt')
+    expect(fetchCalls.length).toBe(2)
+  })
+
+  test('a cached tile keeps its content type and browser TTL', async () => {
+    fetchResponses = [tileResponse()]
+    await req(app).get('/proxy/portolan/nyc/14/5/5.mvt')
+    const hit = await req(app).get('/proxy/portolan/nyc/14/5/5.mvt')
+    expect(hit.headers.get('content-type')).toContain('protobuf')
+    expect(hit.headers.get('cache-control')).toContain('max-age=3600')
   })
 })

--- a/server/src/controllers/proxy.controller.ts
+++ b/server/src/controllers/proxy.controller.ts
@@ -14,6 +14,7 @@
 
 import { Elysia } from 'elysia'
 import { integrationManager } from '../services/integrations'
+import { portolanTileCache, type CachedResponse } from '../lib/tile-cache'
 import { IntegrationId } from '../types/integration.types'
 import { resolveBarrelmanConfig } from '../services/barrelman.service'
 import { logError } from '../lib/logger'
@@ -220,6 +221,50 @@ app.get(
   },
 )
 
+/** The body a cached 404 replays. Matching what the live path returns
+ *  keeps a hit and a miss indistinguishable to the client. */
+const MISSING_BODY = new TextEncoder().encode('Upstream error').buffer as ArrayBuffer
+
+/**
+ * Turn a cached answer back into a response.
+ *
+ * The headers are rebuilt rather than stored: they are a pure function of
+ * the path and the status, and a stored header set would be one more thing
+ * that can go stale. `X-Cache` is there so a HIT is visible in a browser's
+ * network panel without instrumenting anything.
+ */
+function cachedResponse(rest: string, hit: CachedResponse, state: 'HIT' | 'MISS'): Response {
+  if (hit.status === 204) {
+    return new Response(null, { status: 204, headers: { 'X-Cache': state } })
+  }
+  if (hit.status !== 200) {
+    // BodyInit rejects a nullable Uint8Array; a non-200 always has a body
+    return new Response(hit.body ?? null, {
+      status: hit.status,
+      headers: { 'X-Cache': state },
+    })
+  }
+  const isJson = rest.endsWith('.json')
+  return new Response(hit.body ?? null, {
+    headers: {
+      'Content-Type': isJson
+        ? 'application/json'
+        : hit.contentType || 'application/x-protobuf',
+      // pyramids rebuild on Barrelman's import cadence, so tiles get a
+      // moderate TTL while the JSON manifests stay revalidated
+      'Cache-Control': isJson ? 'no-cache' : 'public, max-age=3600',
+      'X-Cache': state,
+    },
+  })
+}
+
+/** Remember an answer, then serve it. Every exit from the portolan route
+ *  goes through here, so what is cached and what is sent cannot drift. */
+function store(rest: string, value: CachedResponse): Response {
+  portolanTileCache.set(rest, value)
+  return cachedResponse(rest, value, 'MISS')
+}
+
 // Proxy portolan transit tiles from the Barrelman host.
 //
 // Barrelman serves portolan's MVT pyramids at /tiles/portolan/*:
@@ -242,6 +287,12 @@ app.get(
     if (rest.includes('..') || !/\.(json|mvt)$/.test(rest)) {
       return new Response('Not found', { status: 404 })
     }
+
+    // Served from memory when we have it. The cache holds the answer the
+    // client would have got, misses included — see lib/tile-cache.ts for
+    // why the empties matter more than the hits.
+    const cached = portolanTileCache.get(rest)
+    if (cached) return cachedResponse(rest, cached, 'HIT')
 
     try {
       const config = resolveBarrelmanConfig()
@@ -268,7 +319,9 @@ app.get(
 
       // an empty tile is a valid answer inside a pyramid: the cutter only
       // writes tiles a feature touches
-      if (response.status === 204) return new Response(null, { status: 204 })
+      if (response.status === 204) {
+        return store(rest, { status: 204, body: null, contentType: null })
+      }
 
       if (!response.ok) {
         // a missing index.json means portolan isn't deployed on this
@@ -277,6 +330,13 @@ app.get(
           logError(
             `Portolan tile proxy: ${response.status} ${response.statusText}`,
           )
+        }
+        // A 404 is a stable answer — this pyramid has no such file, and the
+        // client asks again on every load (the bus-only feeds have no
+        // routes.json at all). Anything else is a fault upstream and must
+        // not be remembered.
+        if (response.status === 404) {
+          return store(rest, { status: 404, body: MISSING_BODY, contentType: 'text/plain' })
         }
         return new Response('Upstream error', { status: response.status })
       }
@@ -290,25 +350,18 @@ app.get(
             t.replace(/^https?:\/\/[^/]+\/tiles\/portolan\/[^/]+\//, ''),
           )
         }
-        return new Response(JSON.stringify(body), {
-          headers: {
-            'Content-Type': 'application/json',
-            'Cache-Control': 'no-cache',
-          },
+        return store(rest, {
+          status: 200,
+          body: new TextEncoder().encode(JSON.stringify(body)).buffer as ArrayBuffer,
+          contentType: 'application/json',
         })
       }
 
       const data = await response.arrayBuffer()
-      const isJson = rest.endsWith('.json')
-      return new Response(data, {
-        headers: {
-          'Content-Type': isJson
-            ? 'application/json'
-            : response.headers.get('content-type') || 'application/x-protobuf',
-          // pyramids rebuild on Barrelman's import cadence, so tiles get a
-          // moderate TTL while the JSON manifests stay revalidated
-          'Cache-Control': isJson ? 'no-cache' : 'public, max-age=3600',
-        },
+      return store(rest, {
+        status: 200,
+        body: data,
+        contentType: response.headers.get('content-type'),
       })
     } catch (error) {
       logError('Portolan tile proxy error', error, { rest })

--- a/server/src/lib/tile-cache.test.ts
+++ b/server/src/lib/tile-cache.test.ts
@@ -1,0 +1,110 @@
+/**
+ * The cache exists because forwarding every tile ran the map into
+ * barrelman's rate limit. What matters is that it holds the right things,
+ * forgets them at the right time, and never grows past its budget — a
+ * cache that quietly keeps everything is a memory leak with good manners.
+ */
+import { describe, test, expect } from 'bun:test'
+import { TileCache } from './tile-cache'
+
+const body = (n: number) => new ArrayBuffer(n)
+const KB = 1024
+
+describe('serving from memory', () => {
+  test('a stored answer comes back', () => {
+    const c = new TileCache(1024 * KB, 60_000)
+    c.set('a/1/2/3.mvt', { status: 200, body: body(100), contentType: 'application/x-protobuf' })
+    const hit = c.get('a/1/2/3.mvt')
+    expect(hit?.status).toBe(200)
+    expect(hit?.body?.byteLength).toBe(100)
+    expect(c.stats().hits).toBe(1)
+  })
+
+  test('an empty tile is remembered too', () => {
+    // the majority of a viewport: the cutter only writes tiles a feature
+    // touches, so most answers are 204 and each one cost a round trip
+    const c = new TileCache(1024 * KB, 60_000)
+    c.set('a/1/2/3.mvt', { status: 204, body: null, contentType: null })
+    expect(c.get('a/1/2/3.mvt')?.status).toBe(204)
+  })
+
+  test('a miss is a miss, not an empty answer', () => {
+    const c = new TileCache(1024 * KB, 60_000)
+    expect(c.get('never/seen.mvt')).toBe(null)
+    expect(c.stats().misses).toBe(1)
+  })
+})
+
+describe('forgetting', () => {
+  test('an entry stops being served once its time is up', () => {
+    let now = 1_000
+    const c = new TileCache(1024 * KB, 5_000, () => now)
+    c.set('a.mvt', { status: 200, body: body(10), contentType: null })
+    now += 4_999
+    expect(c.get('a.mvt')).not.toBe(null)
+    now += 2
+    expect(c.get('a.mvt')).toBe(null)
+  })
+
+  test('an expired entry is dropped, not just hidden', () => {
+    let now = 0
+    const c = new TileCache(1024 * KB, 1_000, () => now)
+    c.set('a.mvt', { status: 200, body: body(500), contentType: null })
+    expect(c.byteSize).toBeGreaterThan(500)
+    now += 2_000
+    c.get('a.mvt')
+    expect(c.size).toBe(0)
+    expect(c.byteSize).toBe(0)
+  })
+})
+
+describe('staying inside the budget', () => {
+  test('bytes, not entries, bound it', () => {
+    const c = new TileCache(10 * KB, 60_000)
+    for (let i = 0; i < 50; i++) {
+      c.set(`t${i}.mvt`, { status: 200, body: body(KB), contentType: null })
+    }
+    expect(c.byteSize).toBeLessThanOrEqual(10 * KB)
+    expect(c.stats().evictions).toBeGreaterThan(0)
+  })
+
+  test('the least recently USED goes, not the oldest stored', () => {
+    const c = new TileCache(3 * KB + 3 * 256, 60_000)
+    c.set('a', { status: 200, body: body(KB), contentType: null })
+    c.set('b', { status: 200, body: body(KB), contentType: null })
+    c.set('c', { status: 200, body: body(KB), contentType: null })
+    c.get('a') // a is now the youngest
+    c.set('d', { status: 200, body: body(KB), contentType: null })
+    expect(c.get('a')).not.toBe(null)
+    expect(c.get('b')).toBe(null) // b was the coldest
+  })
+
+  test('re-storing a key replaces it rather than double-counting', () => {
+    const c = new TileCache(100 * KB, 60_000)
+    c.set('a', { status: 200, body: body(KB), contentType: null })
+    const once = c.byteSize
+    c.set('a', { status: 200, body: body(KB), contentType: null })
+    expect(c.byteSize).toBe(once)
+    expect(c.size).toBe(1)
+  })
+
+  test('an entry bigger than the whole budget is refused, not obeyed', () => {
+    // storing it would evict everything else to hold one tile
+    const c = new TileCache(2 * KB, 60_000)
+    c.set('small', { status: 200, body: body(100), contentType: null })
+    c.set('huge', { status: 200, body: body(10 * KB), contentType: null })
+    expect(c.get('huge')).toBe(null)
+    expect(c.get('small')).not.toBe(null)
+  })
+
+  test('thousands of empty answers are not free', () => {
+    // an empty body is 0 bytes; without per-entry overhead the budget
+    // would never bind and the map could hold every miss it ever made
+    const c = new TileCache(10 * KB, 60_000)
+    for (let i = 0; i < 500; i++) {
+      c.set(`e${i}.mvt`, { status: 204, body: null, contentType: null })
+    }
+    expect(c.size).toBeLessThan(500)
+    expect(c.byteSize).toBeLessThanOrEqual(10 * KB)
+  })
+})

--- a/server/src/lib/tile-cache.ts
+++ b/server/src/lib/tile-cache.ts
@@ -1,0 +1,149 @@
+/**
+ * A bounded, in-process cache for proxied tiles.
+ *
+ * Tiles are the ideal thing to cache and the worst thing to forward: a
+ * single pan of the transit map asks for tiles from every mounted feed,
+ * the same tiles come back on the next pan, and nothing about them
+ * changes between rebuilds. Forwarding each one to barrelman cost a round
+ * trip per tile and — because parchment proxies, so every user's traffic
+ * arrives there from one address — ran the whole map into barrelman's
+ * per-address rate limit. Normal viewing produced a steady stream of 429s.
+ *
+ * MISSES ARE CACHED TOO, and matter more than hits. The cutter only writes
+ * tiles a feature touches, so most of a viewport is empty: a 60-tile burst
+ * over New York returned 13 tiles and 47 empties. An empty answer that
+ * costs a round trip is the expensive kind of nothing.
+ *
+ * Bounded by BYTES, not entries, because tiles differ by two orders of
+ * magnitude (an empty answer is 0; a dense downtown tile is tens of KB) and
+ * a count-based bound would either waste the budget or blow it. Eviction is
+ * least-recently-used: a Map keeps insertion order, and re-inserting on
+ * read moves an entry to the young end.
+ *
+ * In-process on purpose. Parchment runs one server container, so a shared
+ * cache would add a network hop and a dependency to buy nothing. If it ever
+ * runs horizontally — the same condition under which the rate limiter has
+ * to become Redis-backed — this interface is what a shared implementation
+ * replaces: get, set, and a byte budget.
+ */
+
+export interface CachedResponse {
+  status: number
+  /** null for a bodyless answer (204). ArrayBuffer rather than a view:
+   *  it is what `new Response()` accepts without a cast. */
+  body: ArrayBuffer | null
+  contentType: string | null
+}
+
+interface Entry extends CachedResponse {
+  /** Wall-clock ms when this stops being served. */
+  expiresAt: number
+  bytes: number
+}
+
+/** What an entry costs beyond its body: key, headers, object overhead. A
+ *  rough constant is enough — it stops thousands of empty answers from
+ *  looking free and overrunning the budget. */
+const ENTRY_OVERHEAD_BYTES = 256
+
+function envNumber(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (!raw) return fallback
+  const n = Number(raw)
+  return Number.isFinite(n) && n > 0 ? n : fallback
+}
+
+export class TileCache {
+  private readonly entries = new Map<string, Entry>()
+  private bytes = 0
+  private hits = 0
+  private misses = 0
+  private evictions = 0
+
+  constructor(
+    private readonly maxBytes: number,
+    private readonly ttlMs: number,
+    private readonly now: () => number = Date.now,
+  ) {}
+
+  get size(): number {
+    return this.entries.size
+  }
+
+  get byteSize(): number {
+    return this.bytes
+  }
+
+  stats() {
+    return {
+      entries: this.entries.size,
+      bytes: this.bytes,
+      hits: this.hits,
+      misses: this.misses,
+      evictions: this.evictions,
+    }
+  }
+
+  get(key: string): CachedResponse | null {
+    const hit = this.entries.get(key)
+    if (!hit) {
+      this.misses++
+      return null
+    }
+    if (hit.expiresAt <= this.now()) {
+      // expired entries are dropped on sight rather than swept: the only
+      // thing that can surface one is a read, and a read can pay for it
+      this.entries.delete(key)
+      this.bytes -= hit.bytes
+      this.misses++
+      return null
+    }
+    // re-insert to move it to the young end of the LRU order
+    this.entries.delete(key)
+    this.entries.set(key, hit)
+    this.hits++
+    return { status: hit.status, body: hit.body, contentType: hit.contentType }
+  }
+
+  set(key: string, value: CachedResponse): void {
+    const bytes = (value.body?.byteLength ?? 0) + ENTRY_OVERHEAD_BYTES
+    // A single entry larger than the whole budget is not cacheable; storing
+    // it would evict everything else to hold one tile.
+    if (bytes > this.maxBytes) return
+
+    const existing = this.entries.get(key)
+    if (existing) {
+      this.entries.delete(key)
+      this.bytes -= existing.bytes
+    }
+    this.entries.set(key, { ...value, bytes, expiresAt: this.now() + this.ttlMs })
+    this.bytes += bytes
+
+    while (this.bytes > this.maxBytes) {
+      const oldest = this.entries.keys().next()
+      if (oldest.done) break
+      const victim = this.entries.get(oldest.value)!
+      this.entries.delete(oldest.value)
+      this.bytes -= victim.bytes
+      this.evictions++
+    }
+  }
+
+  clear(): void {
+    this.entries.clear()
+    this.bytes = 0
+  }
+}
+
+/**
+ * The proxy's cache.
+ *
+ * The TTL matches the `max-age` tiles already carry, so the server holds
+ * them exactly as long as it tells browsers to — a retile is visible to a
+ * cold client and a warm one at the same time, rather than the server
+ * being the staler of the two.
+ */
+export const portolanTileCache = new TileCache(
+  envNumber('PORTOLAN_TILE_CACHE_MB', 256) * 1024 * 1024,
+  envNumber('PORTOLAN_TILE_CACHE_TTL_S', 3600) * 1000,
+)


### PR DESCRIPTION
## The problem

Parchment proxies portolan's tiles, so **every user's map traffic reaches
barrelman from one address**, on a service credential with no account
attached. That lands on barrelman's *anonymous* per-address limit — **120
requests a minute**, a number sized to stop a scraper hammering the
database.

One pan of the transit map asks for more than that on its own: the layer
mounts up to a dozen feeds and requests the tiles under the viewport from
each. Production logged **1,066 rejections in two hours** of normal
viewing.

Raising the limit on the barrelman side stopped the bleeding (`ANON_RPM`
120 → 6000). This is the actual fix: nothing about a tile changes between
rebuilds, and the same tiles come back on the next pan, so the proxy
should not be asking twice.

## What it does

A bounded in-process LRU in front of the `/proxy/portolan/*` route. Every
exit from that route goes through one `store()` helper, so what gets
cached and what gets sent cannot drift.

**Misses are cached too, and they matter more than the hits.** The cutter
only writes tiles a feature touches, so most of a viewport is empty — a
60-tile burst over New York returned 13 tiles and **47 empties**. An empty
answer that costs a round trip is the expensive kind of nothing.

**404s are cached** for the same reason: the three bus-only feeds have no
`routes.json` at all, the client asks on every load, and a stream of
refused requests is exactly what trips barrelman's penalty box.

**500s are not cached** — a fault is a moment, not an answer, and holding
it would extend an outage past the end of the outage.

Bounded by **bytes**, not entries: tiles differ by two orders of magnitude,
so a count-based bound would either waste the budget or blow it. A
per-entry overhead constant stops thousands of empty answers looking free.
Defaults: 256 MB, 3600s TTL matching the `max-age` tiles already carry, both
env-tunable.

`X-Cache: HIT|MISS` on every response, so a hit is visible in a browser's
network panel without instrumenting anything.

## Why not Redis

Parchment runs one server container, so a shared cache adds a network hop
and an operational dependency to buy nothing. The `TileCache` interface —
get, set, a byte budget — is what a shared implementation would replace if
it ever runs horizontally. Worth noting that condition already exists
elsewhere: `rate-limit.middleware.ts` says in its own header that it is
"not distributed... if Parchment ever runs horizontally, replace with a
Redis-backed limiter". That is the stronger argument for Redis than tiles
are.

## Tests

16 new: 10 on the cache (TTL expiry, byte-bounded eviction, LRU ordering,
oversized entries refused, empty answers not free) and 6 driving the real
route through a mocked upstream — asserting the second request never
reaches barrelman, that 204s and 404s are held, that a 500 is not, and that
a cached tile keeps its content type and browser TTL.

Note: the server suite has **575 pre-existing failures** on `dev` without a
database — identical count with and without this branch. The DB-backed job
in CI covers those.