### PR TITLE
Ship the chunk MapLibre's worker imports, or the map never starts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+* The map draws again on the MapLibre engine. A released build was missing one file the map's background worker loads, so the worker died the moment it started — silently, with nothing in the console and not a single tile ever requested. The map sat blank behind everything else, which carried on working: search found places, panels opened, the transit layer was there, all of it over empty space
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,12 +1,50 @@
 import path from 'path'
 import vue from '@vitejs/plugin-vue'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import svgLoader from 'vite-svg-loader'
 import { readFileSync } from 'fs'
+import { createRequire } from 'module'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 const host = process.env.TAURI_DEV_HOST
+
+/**
+ * Ship the chunk MapLibre's worker imports.
+ *
+ * `maplibre.strategy.ts` pulls the worker in with `?url`, which copies the file
+ * verbatim and hands back its URL. Verbatim means its own
+ * `import ... from './maplibre-gl-shared.mjs'` is left exactly as written, and
+ * Rollup never sees it, so that sibling is never emitted. The dev server gets
+ * away with it because `optimizeDeps.exclude` serves MapLibre straight from
+ * `node_modules`, where the two files already sit side by side — a production
+ * build has only the worker.
+ *
+ * The failure is silent and total: the import 404s (or, behind an SPA fallback,
+ * comes back as `index.html`), the worker dies before it can report anything,
+ * and every source stays pending forever. No tiles are ever requested, no error
+ * is raised, and the map renders blank.
+ *
+ * The worker's import is relative and unhashed, so the sibling has to keep that
+ * exact name — hence `fileName` rather than the usual hashed asset naming.
+ */
+function maplibreWorkerChunk(): Plugin {
+  return {
+    name: 'maplibre-worker-shared-chunk',
+    apply: 'build',
+    generateBundle() {
+      const require = createRequire(import.meta.url)
+      const shared = require.resolve(
+        'maplibre-gl/dist/maplibre-gl-shared.mjs',
+      )
+      this.emitFile({
+        type: 'asset',
+        fileName: 'assets/maplibre-gl-shared.mjs',
+        source: readFileSync(shared, 'utf-8'),
+      })
+    },
+  }
+}
 
 export default defineConfig({
   define: {
@@ -17,6 +55,7 @@ export default defineConfig({
     svgLoader({
       defaultImport: 'url', // Import as URL by default
     }),
+    maplibreWorkerChunk(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
0.8.0 renders a completely blank map on the MapLibre engine in production. Reproduced against `map.parchment.app` and from a clean local `bun run build`.

## What happens

`maplibre.strategy.ts` pulls the worker in with `?url`:

```ts
import maplibreWorkerUrl from 'maplibre-gl/dist/maplibre-gl-worker.mjs?url'
```

`?url` copies the file **verbatim** and hands back its URL. Verbatim means the worker's own `import ... from './maplibre-gl-shared.mjs'` is left exactly as written, and Rollup never sees it — so that sibling chunk is never emitted. The build produces only:

```
dist/assets/maplibre-gl-worker-B8Yt-scJ.mjs
```

The dev server gets away with it: `optimizeDeps.exclude: ['maplibre-gl']` serves MapLibre straight from `node_modules`, where the worker and its shared chunk already sit side by side. **The bug only exists in a production build**, which is why it reached users.

## Why it was invisible

In production the missing import doesn't even 404 — Netlify's SPA fallback answers `/assets/maplibre-gl-shared.mjs` with `index.html`, HTTP 200, `text/html`. The worker dies before it can report anything, so:

- no console error, no `map.on('error')` event
- every source stays `pending` forever
- **zero** tile requests — not the basemap, not glyphs, nothing
- the canvas is created at full size and stays blank

Everything else keeps working — search, panels, the transit layer — drawn over empty space, which makes it read as "the whole release is broken" rather than a map bug.

## The fix

Emit the shared chunk next to the worker. The worker's import is relative and unhashed, so it must keep that exact name — hence `fileName` rather than the usual hashed asset naming.

## Verification

Against the built output, serving `dist` locally:

| | worker | `maplibre-gl-shared.mjs` | worker event |
|---|---|---|---|
| before | 200 | 404 → `text/html` | `ERROR` |
| after | 200 | 200 (484 KB) | none, worker alive |

Removing the emitted chunk again reproduces the error exactly, so the link is causal. `vue-tsc` and the unit tests pass (both run as part of `bun run build`).

Note a branch preview will **not** demonstrate this — previews run the Vite dev server, where the bug does not reproduce. It needs a production build.