### PR TITLE
Release: fix the blank MapLibre map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+* The map draws again on the MapLibre engine. A released build was missing one file the map's background worker loads, so the worker died the moment it started — silently, with nothing in the console and not a single tile ever requested. The map sat blank behind everything else, which carried on working: search found places, panels opened, the transit layer was there, all of it over empty space
+
 ## [0.8.0] - 2026-08-27
 
 ### Added

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,12 +1,50 @@
 import path from 'path'
 import vue from '@vitejs/plugin-vue'
-import { defineConfig } from 'vite'
+import { defineConfig, type Plugin } from 'vite'
 import svgLoader from 'vite-svg-loader'
 import { readFileSync } from 'fs'
+import { createRequire } from 'module'
 
 const pkg = JSON.parse(readFileSync('./package.json', 'utf-8'))
 
 const host = process.env.TAURI_DEV_HOST
+
+/**
+ * Ship the chunk MapLibre's worker imports.
+ *
+ * `maplibre.strategy.ts` pulls the worker in with `?url`, which copies the file
+ * verbatim and hands back its URL. Verbatim means its own
+ * `import ... from './maplibre-gl-shared.mjs'` is left exactly as written, and
+ * Rollup never sees it, so that sibling is never emitted. The dev server gets
+ * away with it because `optimizeDeps.exclude` serves MapLibre straight from
+ * `node_modules`, where the two files already sit side by side — a production
+ * build has only the worker.
+ *
+ * The failure is silent and total: the import 404s (or, behind an SPA fallback,
+ * comes back as `index.html`), the worker dies before it can report anything,
+ * and every source stays pending forever. No tiles are ever requested, no error
+ * is raised, and the map renders blank.
+ *
+ * The worker's import is relative and unhashed, so the sibling has to keep that
+ * exact name — hence `fileName` rather than the usual hashed asset naming.
+ */
+function maplibreWorkerChunk(): Plugin {
+  return {
+    name: 'maplibre-worker-shared-chunk',
+    apply: 'build',
+    generateBundle() {
+      const require = createRequire(import.meta.url)
+      const shared = require.resolve(
+        'maplibre-gl/dist/maplibre-gl-shared.mjs',
+      )
+      this.emitFile({
+        type: 'asset',
+        fileName: 'assets/maplibre-gl-shared.mjs',
+        source: readFileSync(shared, 'utf-8'),
+      })
+    },
+  }
+}
 
 export default defineConfig({
   define: {
@@ -17,6 +55,7 @@ export default defineConfig({
     svgLoader({
       defaultImport: 'url', // Import as URL by default
     }),
+    maplibreWorkerChunk(),
   ],
   resolve: {
     alias: {


### PR DESCRIPTION
Ships #419 — the MapLibre worker's shared chunk was never emitted by the production build, so the worker died on start, no tiles were ever requested, and the map rendered blank for every MapLibre user.

Dev-only bug in reverse: the dev server worked because `optimizeDeps.exclude` serves MapLibre from node_modules, where the chunk sits beside the worker. Only the production build was broken.

Netlify builds `main`, so merging this is the deploy.