### PR TITLE
Refine OSM subtag details and fix map object lighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Fixed
 
 * OSM tag groups with subfields are easier to read in place details, and each individual value can now be copied on its own instead of only as one combined block
+* Trees and street furniture on the map were being drawn inside-out, so they were lit by the side of themselves facing away from you and came out flat and too dark. They now catch the light on the surface you can actually see
 
 ## [0.8.2] - 2026-09-01
 

--- a/web/src/lib/map-objects/map-objects.test.ts
+++ b/web/src/lib/map-objects/map-objects.test.ts
@@ -13,7 +13,7 @@ import { parseGlb } from './glb.mjs'
 import { treeFamily, treeInstance, walkLine, TREE_FAMILIES, TREE_MODELS, TREE_OBJECTS } from './trees'
 import { bearingOf, headingToBearing, furnitureInstance, FURNITURE_MODELS } from './furniture'
 import { CATALOGUE_MODELS, OBJECT_MODELS, OBJECT_PALETTE, OBJECT_SOLID } from './index'
-import { FAR_SUFFIX, project } from './object-layer'
+import { FAR_SUFFIX, FRONT_FACE, project } from './object-layer'
 import { MercatorCoordinate } from 'maplibre-gl'
 
 const MODELS = resolve(__dirname, '../../../public/models')
@@ -156,6 +156,50 @@ describe('models', () => {
     expect(solid, `${name}: paired=${paired} consistent=${consistent} volume=${volume.toFixed(4)}`)
       .toBe(OBJECT_SOLID[name])
   })
+
+  /**
+   * A solid's outward faces reach the screen wound the way `FRONT_FACE` says.
+   *
+   * The test above settles which way a model is wound in its own space, and
+   * that is the half everyone checks. This is the other half, and it is the
+   * one that decides whether culling keeps the near surface or the far one:
+   * the map's frame runs y south while the framebuffer's runs y up, so the
+   * projection mirrors the plane and a model wound outwards arrives wound the
+   * other way. Match `frontFace` to the model rather than to the map and every
+   * solid is drawn from the inside — it keeps its silhouette and loses its
+   * lighting, which reads as normals pointing the wrong way.
+   */
+  test.each(Object.keys(OBJECT_SOLID).filter(name => OBJECT_SOLID[name]))(
+    '%s presents its outward faces as FRONT_FACE claims',
+    name => {
+      let tested = 0
+      for (const primitive of load(name).primitives) {
+        for (let i = 0; i < primitive.index.length; i += 3) {
+          const triangle = [primitive.index[i], primitive.index[i + 1], primitive.index[i + 2]]
+          // Only the faces a plan view can see. Those are the ones that have to
+          // survive the cull, so they are the ones worth asking about.
+          const up = triangle.reduce((sum, v) => sum + primitive.normal[v * 3 + 1], 0) / 3
+          if (up < 0.9) continue
+          const screen = triangle.map(v => {
+            const [x, y, z] = [0, 1, 2].map(c => primitive.position[v * 3 + c])
+            // Model space to the map's, mirroring the swap in `VS`, and then to
+            // the screen of a camera looking straight down: x east is x to the
+            // right, and y south is y down, which the framebuffer's y up flips.
+            const [east, south] = [x, -z]
+            return [east, -south]
+          })
+          const area =
+            (screen[1][0] - screen[0][0]) * (screen[2][1] - screen[0][1]) -
+            (screen[1][1] - screen[0][1]) * (screen[2][0] - screen[0][0])
+          if (Math.abs(area) < 1e-9) continue
+          expect(area > 0 ? 'ccw' : 'cw', `${name} triangle ${i / 3}`).toBe(FRONT_FACE)
+          tested++
+        }
+      }
+      // Otherwise a model with nothing facing upwards passes by testing nothing.
+      expect(tested, `${name} has no upward face to check`).toBeGreaterThan(0)
+    },
+  )
 
   /** Most of them should be, or the plan view is still shattering. */
   test('the great majority of models are solid', () => {

--- a/web/src/lib/map-objects/object-layer.ts
+++ b/web/src/lib/map-objects/object-layer.ts
@@ -101,6 +101,8 @@ const VS = `
 
     // glTF is Y-up and the map is Z-up. The asset keeps the standard
     // orientation so it opens correctly in any viewer; the swap happens here.
+    // It is a rotation, so it leaves the models' winding alone — which is not
+    // the same as leaving them facing the right way. See \`FRONT_FACE\`.
     vec3 p = vec3(a_position.x, -a_position.z, a_position.y);
     vec3 n = vec3(a_normal.x, -a_normal.z, a_normal.y);
 
@@ -135,6 +137,29 @@ const FS = `
   void main() { gl_FragColor = vec4(v_color, 1.0); }`
 
 const LOC = { a_position: 0, a_normal: 1, a_offset: 2, a_shape: 3, a_shade: 4 }
+
+/**
+ * Which way round an outward-facing triangle lands on screen.
+ *
+ * Clockwise, and that is not the usual answer. The map's frame is mirrored
+ * against the screen's: mercator x runs east but y runs *south*, while the
+ * framebuffer's y runs up, so the projection reflects the plane on the way to
+ * the viewport. The glTF-to-map swap in `VS` is a rotation and so preserves
+ * winding, which means a model authored counter-clockwise — every one of ours
+ * is, and `map-objects.test.ts` holds them to it — arrives clockwise here.
+ *
+ * MapLibre's own 3D geometry meets the same rule from the other side: its
+ * `fixWindingOrder` flips every fill-extrusion triangle to the winding that
+ * comes out counter-clockwise on screen, and only then draws with
+ * `frontFace(CCW)`. Nothing about `CCW` is inherent to the map; it is the
+ * convention their geometry is normalised into, and ours is not.
+ *
+ * Getting it backwards is not a subtle defect: culling then keeps the far side
+ * of every solid and throws away the surface facing the camera. The far side
+ * carries normals pointing away, so the object is shaded by the wrong half of
+ * itself and reads as inside-out — dark where the light is.
+ */
+export const FRONT_FACE: 'cw' | 'ccw' = 'cw'
 
 /** What a primitive is made of, which is how it gets its colour. */
 export type ObjectRole = 'bark' | 'foliage' | 'metal' | 'wood' | 'paint'
@@ -564,11 +589,11 @@ export class ObjectLayer {
     // removes the losing half of the argument outright rather than relying on
     // there being enough depth to settle it.
     //
-    // Winding survives the trip: the glTF-to-map frame swap in the shader is a
-    // rotation, and both instance scales are positive, so a model authored
-    // counter-clockwise still faces out.
+    // Both instance scales are positive, so nothing between the model and here
+    // flips a face; which way round its outward faces land is fixed by the
+    // frame it is drawn in, and `FRONT_FACE` is where that is worked out.
     gl.cullFace(gl.BACK)
-    gl.frontFace(gl.CCW)
+    gl.frontFace(FRONT_FACE === 'cw' ? gl.CW : gl.CCW)
 
     this.drawObjects(gl, shifted)
 
@@ -580,8 +605,12 @@ export class ObjectLayer {
     // MapLibre's painter caches GL state; invalidate what we touched.
     const context = this.map.painter?.context
     if (context)
+      // `frontFace` and `cullFaceSide` matter as much as the rest: MapLibre
+      // only re-issues a state call when its cached value differs, so a layer
+      // that leaves the winding on `CW` without saying so has every extrusion
+      // drawn after it inside-out.
       for (const key of ['program', 'bindVertexBuffer', 'bindElementBuffer', 'bindVertexArray',
-        'depthMask', 'depthFunc', 'depthRange', 'blend', 'cullFace'])
+        'depthMask', 'depthFunc', 'depthRange', 'blend', 'cullFace', 'cullFaceSide', 'frontFace'])
         if (context[key]) context[key].dirty = true
   }
 


### PR DESCRIPTION
## Summary

- Display OSM subfields with clearer labels and individual copy controls
- Add Wi-Fi password and board games tag labels
- Fix inside-out culling and lighting for map objects
- Add regression coverage for model face winding

## Testing

- Added map object winding-order tests
- Not run: full test suite