### PR TITLE
Draw a station's own lines, not a neighbouring agency's

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
 * OSM tag groups with subfields are easier to read in place details, and each individual value can now be copied on its own instead of only as one combined block
 * Trees and street furniture on the map were being drawn inside-out, so they were lit by the side of themselves facing away from you and came out flat and too dark. They now catch the light on the surface you can actually see
 * The Brand Catalog, Transit Routing and Rideshare Estimate capability filters in integration settings show their names instead of raw translation keys, in English and Spanish
+* A subway station's departure board shows that station's own lines. Opening Brooklyn Bridge–City Hall listed trains from the Chambers St platforms 14 m nearer and buried its own 4, 5 and 6 at the bottom, each departure printed twice
+* Line bullets in a station header show the right line. New York's subway 4, 5, 6 and 7 share their route ids with Long Island Rail Road branches, and every one of them was drawn as a Ronkonkoma, Montauk, Long Beach or Far Rockaway pill
+* A station's line-up now lists the lines it runs before the ones an in-station transfer reaches, instead of mixing them together
 
 ## [0.8.2] - 2026-09-01
 

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -130,6 +130,7 @@ export function resolveWidgetDescriptors(
       // The mode the place's own tags claim, so the stop search prefers a stop
       // of that mode over whatever happens to be closest.
       const routeTypes = getGTFSRouteTypesFromTags(getPlaceOsmTags(place))
+      const stationName = transitInfo?.name || place.name?.value
 
       descriptors.push({
         type: WidgetType.TRANSIT,
@@ -142,6 +143,10 @@ export function resolveWidgetDescriptors(
           ...(transitInfo?.feedId ? { feedId: transitInfo.feedId } : {}),
           ...(transitInfo?.stopId ? { stopId: transitInfo.stopId } : {}),
           ...(routeTypes.length ? { routeTypes: routeTypes.join(',') } : {}),
+          // The station's own name settles which GTFS stop these coordinates
+          // belong to. Nearest-wins gets it wrong wherever a neighbouring
+          // station's platforms sit closer to the node than the station's own.
+          ...(stationName ? { name: stationName } : {}),
           // Keep onestopIds for backwards compatibility with cached data
           ...(transitInfo?.onestopId ? { onestopIds: (transitInfo.onestopIds || [transitInfo.onestopId]).join(',') } : {}),
         },
@@ -404,7 +409,10 @@ function adaptDeparture(dep: BarrelmanDeparture, timezone: string): TransitDepar
  * enriches with route colors from the GTFS database.
  */
 async function fetchTransitDepartures(
-  params: { lat: number; lng: number; feedId?: string; stopId?: string; routeTypes?: string },
+  params: {
+    lat: number; lng: number; feedId?: string; stopId?: string
+    routeTypes?: string; name?: string
+  },
   options?: { limit?: number; windowMinutes?: number },
 ): Promise<{
   departures: TransitDeparture[]
@@ -435,6 +443,7 @@ async function fetchTransitDepartures(
     if (params.feedId) queryParams.set('feedId', params.feedId)
     if (params.stopId) queryParams.set('stopId', params.stopId)
     if (params.routeTypes) queryParams.set('routeTypes', params.routeTypes)
+    if (params.name) queryParams.set('name', params.name)
     if (windowMinutes) queryParams.set('windowMinutes', String(windowMinutes))
 
     const response = await fetch(`${config!.host}/transit/departures?${queryParams}`, { headers })
@@ -491,6 +500,7 @@ async function fetchTransitDepartures(
           const rows = await routesRes.json() as Array<{
             routeId: string; routeShortName?: string; routeLongName?: string
             routeType?: number; routeColor?: string; routeTextColor?: string
+            via?: 'station' | 'transfer'
           }>
           routes = rows.map((r) => ({
             id: r.routeId,
@@ -499,6 +509,10 @@ async function fetchTransitDepartures(
             color: r.routeColor,
             textColor: r.routeTextColor,
             type: r.routeType,
+            // Whether the line calls here or is reached by an in-station
+            // transfer. Both belong in a station's line-up and they do not
+            // mean the same thing; older instances send neither.
+            via: r.via ?? 'station',
           }))
         }
       } catch {
@@ -626,6 +640,7 @@ export async function fetchWidgetData(
           feedId: params.feedId || undefined,
           stopId: params.stopId || undefined,
           routeTypes: params.routeTypes || undefined,
+          name: params.name || undefined,
         },
         { limit, windowMinutes },
       )

--- a/server/src/types/place.types.ts
+++ b/server/src/types/place.types.ts
@@ -177,6 +177,9 @@ export interface TransitStopInfo {
     color?: string
     textColor?: string
     type?: number
+    /** `station` — the line calls here. `transfer` — it calls at a station
+     *  connected to this one, reachable without leaving the paid area. */
+    via?: 'station' | 'transfer'
   }>
 }
 

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -96,8 +96,8 @@ watch(
   () => void ensureBulletsAt(transitInfo.value?.lat, transitInfo.value?.lng),
   { immediate: true },
 )
-const styleOfRoute = (route: { id: string }) =>
-  bulletFor(route.id, transitInfo.value?.lat, transitInfo.value?.lng)
+const styleOfRoute = (route: { id: string; type?: number }) =>
+  bulletFor(route.id, transitInfo.value?.lat, transitInfo.value?.lng, route.type)
 
 const routeGroups = computed(() =>
   groupDepartures(departures.value, currentTime.value, {

--- a/web/src/components/place/header/PlaceHeader.vue
+++ b/web/src/components/place/header/PlaceHeader.vue
@@ -74,7 +74,9 @@ watch(
 
 function styleOf(line: StationLine) {
   const center = props.place?.geometry?.value?.center
-  return bulletFor(line.id, center?.lat, center?.lng)
+  // The route type goes with the id: a bare "4" is the Lexington Avenue
+  // express here and the Ronkonkoma Branch in the commuter-rail pyramid.
+  return bulletFor(line.id, center?.lat, center?.lng, line.type)
 }
 
 /** Why a bullet is dimmed, in words — a dimmed chip with no explanation

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -64,8 +64,8 @@ watch(
   () => void ensureBulletsAt(props.transitInfo?.lat, props.transitInfo?.lng),
   { immediate: true },
 )
-const styleOfRoute = (route: { id: string }) =>
-  bulletFor(route.id, props.transitInfo?.lat, props.transitInfo?.lng)
+const styleOfRoute = (route: { id: string; type?: number }) =>
+  bulletFor(route.id, props.transitInfo?.lat, props.transitInfo?.lng, route.type)
 
 const routeGroups = computed(() =>
   groupDepartures(departures.value, currentTime.value, {

--- a/web/src/composables/usePlaceTransitLines.ts
+++ b/web/src/composables/usePlaceTransitLines.ts
@@ -64,14 +64,22 @@ export function usePlaceTransitLines(placeId: Ref<string | undefined>) {
   return computed<StationLine[]>(() => {
     const entry = placeId.value ? byPlace[placeId.value] : undefined
     if (!entry) return []
-    const ordered = orderBullets(entry.routes, r => ({
+    const bullet = (r: StationRoute) => ({
       // the label portolan sorts by is the bullet's own glyphs — short
       // name, long name if there is none. Not parchment's translated
       // mode fallback ("Tram"), which would sort by the UI language.
       label: r.shortName || r.longName || '',
       color: r.color,
       id: r.id,
-    }))
+    })
+    // Lines the station runs come before the ones a transfer reaches — the J
+    // and Z are how a rider leaves Brooklyn Bridge–City Hall without paying
+    // twice, and they still aren't its own. Bullet order applies inside each
+    // group; one sort across both would interleave them.
+    const ordered = [
+      ...orderBullets(entry.routes.filter(r => r.via !== 'transfer'), bullet),
+      ...orderBullets(entry.routes.filter(r => r.via === 'transfer'), bullet),
+    ]
     return ordered.map(r => ({
       ...r,
       inService: !entry.ctx.known || entry.running.has(r.id),

--- a/web/src/services/layers/features/portolan/portolan-bullets.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-bullets.test.ts
@@ -85,3 +85,41 @@ describe('the curated bullet', () => {
     expect(bulletFor('2', BROOKLYN.lat, BROOKLYN.lng)?.color).toBe('D82233')
   })
 })
+
+describe('telling two agencies apart by mode', () => {
+  /**
+   * The reported bug. New York publishes no subway pyramid, so a station
+   * header's "4" fell through to northeast-corridor — where `f1:4` is the Long
+   * Island Rail Road's Ronkonkoma Branch, and the suffix match took it. Every
+   * Lexington Avenue bullet came out a magenta commuter-rail pill, and so did
+   * the 5, 6 and 7 as Montauk, Long Beach and Far Rockaway.
+   */
+  beforeEach(() => {
+    resetPortolanBullets([NYC])
+    setPortolanRouteIndex('northeast-corridor', {
+      'f1:4': { label: 'Ronkonkoma Branch', color: 'A626AA', mode: 'regional' },
+      'f1:6': { label: 'Long Beach Branch', color: 'FF6319', mode: 'regional' },
+    })
+  })
+
+  test('refuses a commuter-rail bullet for a subway route', () => {
+    expect(bulletFor('4', BROOKLYN.lat, BROOKLYN.lng, 1)).toBeNull()
+    expect(bulletFor('6', BROOKLYN.lat, BROOKLYN.lng, 1)).toBeNull()
+  })
+
+  test('still takes it for a route of that mode', () => {
+    expect(bulletFor('4', BROOKLYN.lat, BROOKLYN.lng, 2)?.label).toBe('Ronkonkoma Branch')
+    // 109 is an extended rail type, and portolan files it as regional too.
+    expect(bulletFor('6', BROOKLYN.lat, BROOKLYN.lng, 109)?.label).toBe('Long Beach Branch')
+  })
+
+  test('matches as loosely as before when no mode is given', () => {
+    expect(bulletFor('4', BROOKLYN.lat, BROOKLYN.lng)?.label).toBe('Ronkonkoma Branch')
+  })
+
+  test('takes a bullet that never declared a mode', () => {
+    // An older pyramid predates the mode field; it cannot contradict anything.
+    setPortolanRouteIndex('northeast-corridor', { '4': { label: '4', color: '00933C' } })
+    expect(bulletFor('4', BROOKLYN.lat, BROOKLYN.lng, 1)?.label).toBe('4')
+  })
+})

--- a/web/src/services/layers/features/portolan/portolan-bullets.ts
+++ b/web/src/services/layers/features/portolan/portolan-bullets.ts
@@ -23,7 +23,7 @@
  */
 import { reactive } from 'vue'
 import { api } from '@/lib/api'
-import type { PortolanIndexEntry } from '@/types/portolan.types'
+import { portolanClassOf, type PortolanIndexEntry } from '@/types/portolan.types'
 
 export interface PortolanBullet {
   label: string
@@ -115,21 +115,40 @@ export async function ensureBulletsAt(lat?: number, lng?: number): Promise<void>
  * own id first, then a `:id` suffix, because a group pyramid prefixes
  * every feed after the first — the 2 is `f3:2` in northeast-corridor and
  * plain `2` in mta-subway, and the panel only ever has the bare one.
+ *
+ * A bare id is not unique across agencies, though, and the suffix match
+ * happily crosses one. The New York subway's 4, 5, 6 and 7 are also the
+ * Long Island Rail Road's route ids, stored as `f1:4`…`f1:7` in the
+ * northeast-corridor pyramid, and no NYC subway pyramid is published — so
+ * every Lexington Avenue bullet in a station header came back as a
+ * Ronkonkoma, Montauk or Long Beach Branch pill. Passing the route's GTFS
+ * `route_type` narrows the match to bullets of the same mode class, which
+ * is what separates a metro 4 from a regional one. Omit it and the match
+ * is as loose as it ever was.
  */
-export function bulletFor(routeId: string, lat?: number, lng?: number): PortolanBullet | null {
+export function bulletFor(
+  routeId: string,
+  lat?: number,
+  lng?: number,
+  routeType?: number | null,
+): PortolanBullet | null {
   // touch the generation so Vue re-evaluates when a fetch lands
   void state.generation
   if (!routeId) return null
   const feeds =
     lat !== undefined && lng !== undefined ? feedsAt(lat, lng) : Object.keys(indexes)
+  const wanted = portolanClassOf(routeType)
+  // A bullet that never declared a mode can't contradict one — take it.
+  const usable = (b?: PortolanBullet) =>
+    !!b && (!wanted || !b.mode || b.mode === wanted)
   const suffix = `:${routeId}`
   for (const feed of feeds) {
     const idx = indexes[feed]
     if (!idx) continue
     const exact = idx[routeId]
-    if (exact) return exact
+    if (usable(exact)) return exact
     for (const id of Object.keys(idx)) {
-      if (id.endsWith(suffix)) return idx[id]
+      if (id.endsWith(suffix) && usable(idx[id])) return idx[id]
     }
   }
   return null

--- a/web/src/types/portolan.types.ts
+++ b/web/src/types/portolan.types.ts
@@ -70,6 +70,44 @@ export const PORTOLAN_CLASSES = [
 ] as const
 export type PortolanClass = (typeof PORTOLAN_CLASSES)[number]
 
+/**
+ * The class portolan files a GTFS `route_type` under — the port of
+ * `mode.Of` (internal/mode/mode.go), basic types then the extended HVT
+ * ranges. Portolan keys everything off the class and never the raw
+ * number, so anything matching parchment's routes against portolan's has
+ * to ask the same question the same way.
+ *
+ * Returns null for a type portolan calls unknown, which matches nothing
+ * rather than matching the first thing tried.
+ */
+export function portolanClassOf(routeType?: number | null): PortolanClass | null {
+  if (routeType == null) return null
+
+  switch (routeType) {
+    case 0: return 'tram'
+    case 1: return 'metro'
+    case 2: return 'regional'
+    case 3: case 11: return 'bus' // bus, trolleybus
+    case 4: return 'ferry'
+    case 5: return 'cable'
+    case 6: return 'aerial'
+    case 7: return 'funicular'
+    case 12: return 'monorail'
+  }
+
+  if (routeType >= 100 && routeType < 300) return 'regional' // rail + coach
+  if (routeType === 405) return 'monorail'
+  if (routeType >= 400 && routeType < 500) return 'metro'
+  if (routeType >= 700 && routeType < 900) return 'bus'
+  if (routeType >= 900 && routeType < 1000) return 'tram'
+  if (routeType >= 1000 && routeType < 1300) return 'ferry' // water, air, taxi
+  if (routeType >= 1300 && routeType < 1400) return 'aerial'
+  if (routeType >= 1400 && routeType < 1500) return 'funicular'
+  if (routeType >= 1700 && routeType < 1800) return 'cable'
+
+  return null
+}
+
 /** Ribbon feature properties (vector layer `ribbons`, z0..max). */
 export interface PortolanRibbonProps {
   seg: string


### PR DESCRIPTION
The second half of the Brooklyn Bridge–City Hall departure board report. Pairs with barrelman#81, which fixes the board itself; this fixes the bullets above it and sends barrelman what it needs.

## The wrong badges

Grand Central–42nd Street's header read *S, Ronkonkoma Branch, Montauk Branch, Long Beach Branch, 6X, Far Rockaway Branch, 7X*. The LIRR names line up exactly with the missing subway numbers:

| subway route_id | LIRR route_id | badge drawn | colour |
|---|---|---|---|
| 4 | 4 Ronkonkoma | Ronkonkoma Branch | `A626AA` |
| 5 | 5 Montauk | Montauk Branch | `00B2A9` |
| 6 | 6 Long Beach | Long Beach Branch | `FF6319` |
| 7 | 7 Far Rockaway | Far Rockaway Branch | `6E3219` |

Those four colours are the ones in the screenshots.

`bulletFor` matches a bare route id, then falls back to any id ending `:<id>` — the prefix a group pyramid gives every feed after its first. No NYC subway pyramid is published, so a subway "4" fell through the feeds covering the point to `northeast-corridor`, where `f1:4` is LIRR's Ronkonkoma Branch, and the suffix match took it. 6X, 7X, S, J and Z survived only because their ids don't collide.

## What changed

* `bulletFor` takes the route's GTFS `route_type` and will only accept a bullet of the same mode class. `portolanClassOf` is a port of `mode.Of` (portolan `internal/mode/mode.go`) so both sides ask the same question the same way — a metro 4 can no longer take a regional bullet. A bullet with no declared mode still matches, and omitting the type leaves the match as loose as it was.
* The transit widget sends the station's name to `/transit/departures`, which is what lets barrelman tell Brooklyn Bridge–City Hall from the Chambers St platforms 14 m nearer.
* `via` is read off `/transit/routes` and threaded to the header, which lists the station's own lines before the ones an in-station transfer reaches. Instances that don't send it yet read as `station`, so nothing regresses.

## Verified

Verified against the deployed portolan index: the pyramids covering that point are `mta-nyct-bus`, `mta-bus`, `nyc-ferry`, `nywaterway`, `seastreak`, `northeast-corridor`, `amtrak` — no subway among them — and `northeast-corridor`'s `f1:4`…`f1:7` carry the four branch labels and colours above.

3927 server tests and 213 web tests pass; `vue-tsc` is clean.

One thing deliberately left out: transfer lines now sort after the station's own but get no distinct visual treatment. That's a design call rather than a bug.