### PR TITLE
Rework the desktop sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,15 @@
 
 ### Changed
 
+* The desktop sidebar has been rebuilt. Rows sit on an even grid at full contrast, the current one is marked by a single raised chip that slides between them, and collapsing or expanding the rail now glides instead of snapping — with the map resizing in step
+* The sidebar remembers whether it was collapsed, and the collapse toggle has moved to the top of the panel, next to the logo. Collapsed, the strip along the sidebar's edge lights up under the cursor and clicking it expands the panel again — `S` still works from anywhere
+* The expanded sidebar can be dragged to whatever width you want, by its outer edge, and it remembers that too. Drag it well past its narrowest and it collapses to the icon rail; drag back out and it returns
+* The account row at the bottom of the sidebar now lines up with the links above it, showing your name against a single line; your email is still in the menu it opens, which is wider and no longer clips a long address
+
 ### Fixed
+
+* The map keeps up with the sidebar as it is dragged or collapsed, resizing frame by frame rather than snapping once the panel has settled
+* Centring on a place, or fitting a route, no longer aims too far to the right when a panel is open over the map. The gutter the map was told to leave on the left included the sidebar's width a second time, even though the map never extended under it — worse the wider the sidebar
 
 ## [0.8.3] - 2026-09-02
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -12,6 +12,7 @@ import { useCategoryPaletteStore } from '@/stores/category-palette.store'
 import { useLayersStore } from '@/stores/layers.store'
 import { useBookmarksService } from '@/services/library/bookmarks.service'
 import { useCollectionsService } from '@/services/library/collections.service'
+import { useStorage } from '@vueuse/core'
 import { useResponsive } from '@/lib/utils'
 import { isTauri } from '@/lib/api'
 import { useExternalLink } from '@/composables/useExternalLink'
@@ -30,6 +31,7 @@ import {
 // imports in one obvious place.
 import '@/lib/realtime-bootstrap'
 
+import { SIDEBAR_WIDTH } from '@/components/ui/sidebar'
 import DesktopNav from '@/components/navigation/DesktopNavigation.vue'
 import MobileNav from '@/components/navigation/MobileNavigation.vue'
 import DialogView from '@/views/DialogView.vue'
@@ -77,7 +79,11 @@ watch(
 const { openExternalLink } = useExternalLink()
 
 const { dialogs } = appStore
-const navMini = ref(true)
+// Collapsed by default, and remembered — the rail's width changes the map's
+// viewport, so relearning it on every load is a visible layout shift.
+const navCollapsed = useStorage('sidebar-collapsed', true)
+// Width the user dragged the rail to, kept for the same reason.
+const navWidth = useStorage('sidebar-width', SIDEBAR_WIDTH)
 const viewRef = ref()
 
 const hideUI = ref(true)
@@ -271,7 +277,12 @@ function beforeNavTransition(value: boolean) {
         @after-enter="() => afterNavTransition(true)"
         @before-leave="() => beforeNavTransition(false)"
       >
-        <DesktopNav v-if="!hideUI" v-model:mini="navMini" class="z-40 h-full" />
+        <DesktopNav
+          v-if="!hideUI"
+          v-model:collapsed="navCollapsed"
+          v-model:width="navWidth"
+          class="z-40 h-full"
+        />
       </transition-slide>
     </template>
 

--- a/web/src/components/map/map-providers/mapbox.strategy.ts
+++ b/web/src/components/map/map-providers/mapbox.strategy.ts
@@ -52,7 +52,7 @@ import { createVueMarkerElement } from '@/lib/vue-marker.utils'
 import WaypointMapIcon from '@/components/map/WaypointMapIcon.vue'
 import InstructionPointMarker from '@/components/map/InstructionPointMarker.vue'
 import { useAppStore } from '@/stores/app.store'
-import { calculateFitPadding } from '@/lib/map-padding'
+import { calculateFitPadding, toContainerRect } from '@/lib/map-padding'
 import { useThemeStore } from '@/stores/theme.store'
 import { useMapToolsStore } from '@/stores/map-tools.store'
 import { getPrimaryThemeHex, adjustLightness, cssHslToHex } from '@/lib/utils'
@@ -1004,7 +1004,10 @@ export class MapboxStrategy extends MapStrategy {
 
     const appStore = useAppStore()
     const padding = calculateFitPadding(
-      appStore.visibleMapArea,
+      toContainerRect(
+        appStore.visibleMapArea,
+        this.container.getBoundingClientRect(),
+      ),
       this.container.clientWidth,
       this.container.clientHeight,
     )

--- a/web/src/components/map/map-providers/maplibre.strategy.ts
+++ b/web/src/components/map/map-providers/maplibre.strategy.ts
@@ -61,7 +61,7 @@ import { createVueMarkerElement } from '@/lib/vue-marker.utils'
 import WaypointMapIcon from '@/components/map/WaypointMapIcon.vue'
 import InstructionPointMarker from '@/components/map/InstructionPointMarker.vue'
 import { useAppStore } from '@/stores/app.store'
-import { calculateFitPadding } from '@/lib/map-padding'
+import { calculateFitPadding, toContainerRect } from '@/lib/map-padding'
 import { useThemeStore } from '@/stores/theme.store'
 import { useCategoryPaletteStore } from '@/stores/category-palette.store'
 import {
@@ -1429,7 +1429,10 @@ export class MaplibreStrategy extends MapStrategy {
 
     const appStore = useAppStore()
     const padding = calculateFitPadding(
-      appStore.visibleMapArea,
+      toContainerRect(
+        appStore.visibleMapArea,
+        this.container.getBoundingClientRect(),
+      ),
       this.container.clientWidth,
       this.container.clientHeight,
     )

--- a/web/src/components/navigation/AccountDropdown.vue
+++ b/web/src/components/navigation/AccountDropdown.vue
@@ -26,6 +26,7 @@ import type { GitHubReleaseSummary } from '@/composables/useGitHubReleases'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
+import { Separator } from '@/components/ui/separator'
 import ResponsiveDropdown, {
   type MenuItemDefinition,
 } from '@/components/responsive/ResponsiveDropdown.vue'
@@ -36,7 +37,7 @@ import {
   LanguagesIcon,
   MessageSquareQuoteIcon,
   LogOutIcon,
-  ChevronUpIcon,
+  ChevronsUpDownIcon,
   CheckIcon,
   InfoIcon,
   KeyboardIcon,
@@ -229,14 +230,22 @@ const menuItems = computed((): MenuItemDefinition[] => {
     :side="mini ? 'right' : 'top'"
     :align="mini ? 'end' : 'start'"
     :side-offset="8"
-    content-class="w-56"
+    content-class="w-64"
   >
     <template #trigger="{ open }">
+      <!-- Sized to the sidebar's row rhythm on desktop, and to a comfortable
+           touch target on mobile, where this same trigger sits in the sheet.
+           The email is one click away in the menu header, so the row stays a
+           single line and lines up with the links above it. -->
       <Button
         variant="ghost"
         :class="
           cn(
-            'w-full h-auto px-1 py-2 rounded-lg flex flex-row justify-center gap-2 hover:bg-foreground/5',
+            'w-full h-11 md:h-10 gap-2.5 rounded-md flex flex-row justify-start',
+            'text-foreground hover:bg-foreground/5',
+            // The avatar is wider than a row icon, so the padding — not its
+            // left edge — is what puts it on the collapsed rail's centre line.
+            mini ? 'px-0.5' : 'px-2',
           )
         "
         @click.stop="open"
@@ -252,24 +261,24 @@ const menuItems = computed((): MenuItemDefinition[] => {
           </AvatarFallback>
         </Avatar>
 
-        <div class="flex flex-col text-nowrap flex-1 text-left" v-if="!mini">
-          <span class="text-sm font-semibold leading-4">
-            {{ me.firstName }} {{ me.lastName }}
-          </span>
-          <span class="text-xs text-muted-foreground leading-4">{{ me.email }}</span>
-        </div>
-
-        <ChevronUpIcon
+        <span
           v-if="!mini"
-          class="size-4 text-muted-foreground self-center"
+          class="flex-1 min-w-0 text-left text-sm font-medium truncate"
+        >
+          {{ me.firstName }} {{ me.lastName }}
+        </span>
+
+        <ChevronsUpDownIcon
+          v-if="!mini"
+          class="size-4 shrink-0 text-muted-foreground"
         />
       </Button>
     </template>
 
     <!-- Custom header with avatar -->
     <template #header>
-      <div class="px-2 py-1.5">
-        <div class="flex items-center gap-2">
+      <div class="px-2 py-2">
+        <div class="flex items-center gap-2.5 min-w-0">
           <Avatar size="sm">
             <AvatarImage
               v-if="me.picture"
@@ -280,11 +289,11 @@ const menuItems = computed((): MenuItemDefinition[] => {
               {{ me.firstName?.charAt(0) }}{{ me.lastName?.charAt(0) }}
             </AvatarFallback>
           </Avatar>
-          <div class="flex flex-col">
-            <span class="text-sm font-semibold leading-tight">
+          <div class="flex flex-col min-w-0">
+            <span class="text-sm font-semibold leading-tight truncate">
               {{ me.firstName }} {{ me.lastName }}
             </span>
-            <span class="text-xs text-muted-foreground leading-tight">{{
+            <span class="text-xs text-muted-foreground leading-tight truncate">{{
               me.email
             }}</span>
             <a
@@ -307,14 +316,13 @@ const menuItems = computed((): MenuItemDefinition[] => {
           </div>
         </div>
       </div>
-      <div class="h-px bg-border my-1" />
-      <!-- TODO: Replace with separator component -->
+      <Separator class="my-1 bg-border" />
     </template>
 
     <!-- Version footer -->
     <template #footer>
-      <div class="h-px bg-border my-1" />
-      <div class="flex items-center justify-between gap-2 px-2 pb-2 py-1">
+      <Separator class="my-1 bg-border" />
+      <div class="flex items-center justify-between gap-2 px-2 pb-1 py-1">
         <span class="ml-1 text-xs text-muted-foreground">
           v{{ APP_VERSION }}
         </span>

--- a/web/src/components/navigation/DesktopNavigation.vue
+++ b/web/src/components/navigation/DesktopNavigation.vue
@@ -4,7 +4,6 @@ import { useRouter, useRoute } from 'vue-router'
 import { AppRoute } from '@/router'
 import { useI18n } from 'vue-i18n'
 import { toast } from 'vue-sonner'
-import { cn } from '@/lib/utils'
 import { useCommandStore } from '@/stores/command.store'
 import { useAppStore } from '@/stores/app.store'
 import { capitalize } from '@/filters/text.filters'
@@ -16,14 +15,17 @@ import { useUpdater } from '@/composables/useUpdater'
 import { appEventBus } from '@/lib/eventBus'
 
 import { Button } from '@/components/ui/button'
-import { Separator } from '@/components/ui/separator'
 import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
-import Kbd from '@/components/ui/kbd/Kbd.vue'
+  Sidebar,
+  SidebarContent,
+  SidebarFooter,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarRail,
+  SidebarSeparator,
+  SIDEBAR_WIDTH,
+} from '@/components/ui/sidebar'
 import ParchmentLogo from '@/assets/parchment.svg?component'
 import AccountDropdown from '@/components/navigation/AccountDropdown.vue'
 import {
@@ -51,22 +53,28 @@ import { useCommandService } from '@/services/command.service'
 import ResponsiveHoverCard from '@/components/responsive/ResponsiveHoverCard.vue'
 
 const router = useRouter()
+const route = useRoute()
 const { t } = useI18n()
 const { openExternalLink } = useExternalLink()
 const mapService = useMapService()
 const { isFullscreen } = useFullscreen()
 const commandService = useCommandService()
 const commandStore = useCommandStore()
-
-const route = useRoute()
-const mini = defineModel('mini', { type: Boolean, default: true })
-const navRef = ref<HTMLElement | null>(null)
 const appStore = useAppStore()
+
+const collapsed = defineModel<boolean>('collapsed', { default: true })
+const width = defineModel<number>('width', { default: SIDEBAR_WIDTH })
+const sidebarRef = ref<InstanceType<typeof Sidebar> | null>(null)
 const { width: windowWidth, height: windowHeight } = useWindowSize()
 const paletteDialogOpen = ref(false)
 const paletteDialogRef = ref<InstanceType<typeof Palette> | null>(null)
 
 const isDashboard = computed(() => route.name === AppRoute.DASHBOARD)
+
+// Shared by the binding below and the hint on the Settings row. Rows take the
+// literal combo rather than a hotkey id because ids resolve from a registry
+// that is only populated once the owning component has mounted.
+const SETTINGS_HOTKEY: Hotkey = ['mod', ',']
 
 const isTauriDesktop = ref(false)
 const updateDismissed = ref(false)
@@ -81,7 +89,7 @@ useHotkeys([
     key: ['s'],
     name: t('navigation.toggle'),
     description: t('navigation.toggleDescription'),
-    handler: () => (mini.value = !mini.value),
+    handler: () => (collapsed.value = !collapsed.value),
   },
   {
     id: HotkeyId.COMMAND_PALETTE,
@@ -92,7 +100,7 @@ useHotkeys([
   },
   {
     id: HotkeyId.OPEN_SETTINGS,
-    key: ['mod', ','],
+    key: SETTINGS_HOTKEY,
     name: t('settings.title'),
     description: t('settings.openHotkeyDescription'),
     handler: () => {
@@ -103,9 +111,44 @@ useHotkeys([
   },
 ])
 
-// Track navbar bounds manually for map UI area calculation
-// We need to register it in the obstructing components map first
+// ==================== MAP GEOMETRY ====================
+//
+// The map is a flex sibling of this rail, so every pixel the rail gives up
+// belongs to the canvas. `Sidebar` reports its animated width on each frame
+// of a collapse or expand; republishing bounds and resizing there keeps the
+// map in lockstep with the animation instead of snapping at the end of it.
+
+function publishBounds() {
+  const el = sidebarRef.value?.$el as HTMLElement | undefined
+  if (!el) return
+  const rect = el.getBoundingClientRect()
+  appStore.updateManualBounds('desktopNav', {
+    x: rect.left,
+    y: rect.top,
+    width: rect.width,
+    height: rect.height,
+  })
+}
+
+function handleSidebarResize() {
+  publishBounds()
+  mapService.resize()
+}
+
+watch([windowWidth, windowHeight], () => nextTick(publishBounds), {
+  flush: 'post',
+})
+
 onMounted(async () => {
+  // The obstructing-components map is keyed by name; we publish bounds
+  // manually rather than letting it track the component, so the entry only
+  // needs to exist.
+  if (!appStore.getObstructingComponent('desktopNav')) {
+    appStore.trackObstructingComponentWithKey('desktopNav', {} as any)
+  }
+  await nextTick()
+  publishBounds()
+
   isTauriDesktop.value = await getIsTauri()
   if (isTauriDesktop.value) {
     void checkForUpdates()
@@ -116,23 +159,6 @@ onMounted(async () => {
         __parchmentForceShowUpdateBanner?: typeof forceShowUpdateBanner
       }
     ).__parchmentForceShowUpdateBanner = forceShowUpdateBanner
-  }
-
-  // Register desktopNav in the obstructing components map
-  // We use a dummy object since we're using manual bounds instead of component tracking
-  if (!appStore.getObstructingComponent('desktopNav')) {
-    appStore.trackObstructingComponentWithKey('desktopNav', {} as any)
-  }
-
-  // Update bounds when navRef is available
-  if (navRef.value) {
-    const rect = navRef.value.getBoundingClientRect()
-    appStore.updateManualBounds('desktopNav', {
-      x: rect.left,
-      y: rect.top,
-      width: rect.width,
-      height: rect.height,
-    })
   }
 })
 
@@ -146,57 +172,41 @@ async function handleRestartToUpdate() {
   }
 }
 
-// Watch for changes to navbar position/size
-watch(
-  [navRef, mini, windowWidth, windowHeight],
-  () => {
-    if (!navRef.value) return
+// ==================== NAVIGATION ====================
 
-    nextTick(() => {
-      const rect = navRef.value!.getBoundingClientRect()
-      appStore.updateManualBounds('desktopNav', {
-        x: rect.left,
-        y: rect.top,
-        width: rect.width,
-        height: rect.height,
-      })
-    })
-  },
-  { immediate: true, flush: 'post' },
-)
-
-watch(mini, () => {
-  nextTick(() => {
-    mapService.resize()
-  })
-})
-
-interface MenuItemDefinition {
-  separator?: boolean
-  items?: {
-    label: string
-    icon: Icon
-    hotkey?: Hotkey
-    hotkeyId?: string
-    commandId?: CommandName
-    to?: string
-    onClick?: () => void | Promise<void>
-  }[]
-  spacer?: boolean
+interface NavItem {
+  label: string
+  icon: Icon
+  /** A destination. Omitted for the rows that just run an action. */
+  to?: string
+  commandId?: CommandName
+  onClick?: () => void
 }
 
-function handleNavClick(to: string) {
-  const isCurrentRoute = router.currentRoute.value.path.startsWith(to)
-  if (appStore.leftSheetHidden) {
-    // Always reopen the drawer
-    appStore.leftSheetHidden = false
-    // Only navigate if it's a different route
-    if (!isCurrentRoute) {
-      router.push(to)
-    }
-  } else {
-    router.push(to)
-  }
+const items = computed<NavItem[]>(() => [
+  {
+    label: t('palette.commands.search.name'),
+    icon: SearchIcon,
+    commandId: CommandName.SEARCH,
+    onClick: () => openPalette(true),
+  },
+  { label: t('dashboard.title'), icon: LayoutDashboardIcon, to: '/dashboard' },
+  { label: t('directions.title'), icon: CornerUpRightIcon, to: '/directions' },
+  { label: capitalize(t('library.title')), icon: LibraryIcon, to: '/library' },
+  { label: 'Lookout', icon: TelescopeIcon, to: '/lookout' },
+  { label: t('timeline.title'), icon: HistoryIcon, to: '/timeline' },
+])
+
+/**
+ * Rows are real links, so the default is to let the browser navigate. The one
+ * exception is a collapsed left drawer: then the click's job is to reopen the
+ * drawer, and re-navigating to the route you are already on would do nothing
+ * but discard the drawer's state.
+ */
+function handleNavClick(event: MouseEvent, to: string) {
+  if (!appStore.leftSheetHidden) return
+  appStore.leftSheetHidden = false
+  if (router.currentRoute.value.path.startsWith(to)) event.preventDefault()
 }
 
 function openPalette(withSearch = false) {
@@ -226,309 +236,167 @@ defineExpose({
   /** Set to true to force-show the update banner (e.g. in console: $refs.desktopNav.forceShowUpdateBanner = true). */
   forceShowUpdateBanner,
 })
-
-const items = computed<MenuItemDefinition[]>(() => [
-  {
-    items: [
-      {
-        label: t('palette.commands.search.name'),
-        icon: SearchIcon,
-        onClick: () => openPalette(true),
-        commandId: CommandName.SEARCH,
-      },
-      {
-        label: t('dashboard.title'),
-        icon: LayoutDashboardIcon,
-        to: '/dashboard',
-      },
-      {
-        label: t('directions.title'),
-        icon: CornerUpRightIcon,
-        // hotkey: ['d'],
-        to: '/directions',
-      },
-      {
-        label: capitalize(t('library.title')),
-        icon: LibraryIcon,
-        // hotkey: ['l'],
-        to: '/library',
-      },
-      {
-        label: 'Lookout',
-        icon: TelescopeIcon,
-        to: '/lookout',
-      },
-      {
-        label: t('timeline.title'),
-        icon: HistoryIcon,
-        to: '/timeline',
-      },
-    ],
-  },
-  {
-    spacer: true,
-  },
-  {
-    items: [
-      {
-        label: mini.value ? t('navigation.maximize') : t('navigation.minimize'),
-        icon: PanelLeftIcon,
-        onClick: () => {
-          mini.value = !mini.value
-        },
-        hotkeyId: HotkeyId.TOGGLE_NAV_MINI,
-      },
-      {
-        label: t('feedback.title'),
-        icon: MessageSquareQuoteIcon,
-        onClick: () => {
-          openExternalLink(
-            'https://github.com/alexwohlbruck/parchment/issues',
-            '_blank',
-          )
-        },
-      },
-      {
-        label: t('settings.title'),
-        icon: SettingsIcon,
-        to: '/settings',
-      },
-    ],
-  },
-])
 </script>
 
 <template>
-  <div class="flex flex-col justify-center">
+  <Sidebar
+    ref="sidebarRef"
+    v-model:collapsed="collapsed"
+    v-model:width="width"
+    :label="t('navigation.title')"
+    :class="isTauri ? 'tauri-translucent' : 'bg-muted/50'"
+    data-tauri-drag-region
+    @resize="handleSidebarResize"
+  >
+    <!-- Spacer for the macOS traffic lights, which are hidden in fullscreen -->
     <div
-      ref="navRef"
-      :class="
-        cn(
-          'overflow-y-auto py-1 border-r flex flex-col gap-2 items-stretch relative',
-          isTauri ? 'tauri-translucent' : 'bg-background',
-          $attrs.class ?? '',
-        )
-      "
+      v-if="isTauri && !isFullscreen"
+      class="h-6 shrink-0"
       data-tauri-drag-region
-    >
-      <!-- Spacer for traffic lights on macOS - draggable -->
-      <!-- Hide spacer in fullscreen mode since traffic lights are hidden -->
-      <div
-        v-if="isTauri && !isFullscreen"
-        class="h-4 w-16"
-        data-tauri-drag-region
-      ></div>
+    ></div>
 
-      <h2 v-if="!isTauri" class="px-[.95rem] text-lg font-bold">
+    <SidebarHeader data-tauri-drag-region>
+      <div class="flex items-center gap-1 h-10">
         <router-link
+          v-if="!isTauri"
           to="/"
-          class="flex items-center gap-3 hover:opacity-85 dark:hover:opacity-90 transition-opacity cursor-pointer"
+          class="flex-1 min-w-0 h-10 flex items-center gap-2.5 rounded-md no-underline hover:bg-foreground/5 transition-all duration-200"
+          :class="collapsed ? 'px-1' : 'px-2'"
         >
           <ParchmentLogo
-            class="w-5 h-11 scale-150 text-primary shrink-0"
+            class="size-7 shrink-0 text-primary"
             aria-label="Parchment"
           />
           <span
-            v-if="!mini"
-            class="text-nowrap text-base text-primary-950 dark:text-primary-100"
+            class="text-base font-display text-foreground whitespace-nowrap transition-opacity duration-150"
+            :class="collapsed ? 'opacity-0' : 'opacity-100'"
           >
             Parchment
           </span>
         </router-link>
-      </h2>
+        <div v-else class="flex-1" data-tauri-drag-region></div>
 
-      <CommandDialog
-        v-model:open="paletteDialogOpen"
-        modal
-        class="top-[20%] bottom-auto"
-      >
-        <Palette
-          ref="paletteDialogRef"
-          v-model:open="paletteDialogOpen"
-          :show-hints="true"
-        />
-      </CommandDialog>
-
-      <template v-for="(item, i) in items" :key="i">
-        <Separator
-          v-if="item.separator"
-          class="bg-foreground/10"
-          data-tauri-drag-region
-        />
-        <template v-else-if="item.spacer">
-          <div class="flex-1" data-tauri-drag-region></div>
-          <!-- Slot for custom banner alerts (above Minimize row). Default: Tauri update banner. -->
-          <div class="px-1 py-0.5">
-            <slot name="banner">
-              <template
-                v-if="
-                  forceShowUpdateBanner ||
-                  (isTauriDesktop && updateAvailable && !updateDismissed)
-                "
-              >
-                <UpdateBanner
-                  v-if="!mini"
-                  :update-available="updateAvailable"
-                  :force-show-update-banner="forceShowUpdateBanner"
-                  :install-in-progress="installInProgress"
-                  :embedded="false"
-                  @restart="handleRestartToUpdate"
-                  @dismiss="updateDismissed = true"
-                />
-                <ResponsiveHoverCard
-                  v-else
-                  side="right"
-                  :side-offset="8"
-                  align="start"
-                  :open-delay="200"
-                  desktop-content-class="p-0 w-fit overflow-hidden rounded-md"
-                >
-                  <template #trigger>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      class="w-full flex px-3 justify-center hover:bg-foreground/5 hover:text-foreground relative"
-                      :aria-label="t('profileMenu.updateBanner')"
-                    >
-                      <span class="relative inline-flex">
-                        <MegaphoneIcon class="size-5" />
-                        <span
-                          class="absolute -top-0.5 -right-0.5 size-2 rounded-full bg-primary ring-2 ring-background"
-                          aria-hidden
-                        />
-                      </span>
-                    </Button>
-                  </template>
-                  <template #content>
-                    <UpdateBanner
-                      :update-available="updateAvailable"
-                      :force-show-update-banner="forceShowUpdateBanner"
-                      :install-in-progress="installInProgress"
-                      :embedded="true"
-                      @restart="handleRestartToUpdate"
-                      @dismiss="updateDismissed = true"
-                    />
-                  </template>
-                </ResponsiveHoverCard>
-              </template>
-            </slot>
-          </div>
-        </template>
-        <div v-else>
-          <div class="flex flex-col px-1">
-            <template v-for="subitem in item.items">
-              <!-- v-if="subitem.to && (subitem.condition ?? true)" -->
-              <TooltipProvider v-if="subitem.onClick" :disabled="!mini">
-                <Tooltip>
-                  <TooltipTrigger as-child>
-                    <Button
-                      variant="ghost"
-                      :class="cn('w-full flex px-3 gap-3 hover:bg-primary/5 hover:text-primary', mini ? 'justify-center' : 'justify-start')"
-                      @click="subitem.onClick()"
-                    >
-                      <component :is="subitem.icon" class="size-5 shrink-0" />
-                      <div v-if="!mini" class="flex flex-1 gap-1 text-nowrap">
-                        <div class="flex-1 text-left">
-                          {{ subitem.label }}
-                        </div>
-
-                        <Kbd
-                          v-if="
-                            !mini &&
-                            ((subitem as any).hotkey ||
-                              (subitem as any).hotkeyId ||
-                              (subitem as any).commandId)
-                          "
-                          :hotkey-id="(subitem as any).hotkeyId"
-                          :hotkey="
-                            (subitem as any).hotkeyId ||
-                            (subitem as any).commandId
-                              ? undefined
-                              : (subitem as any).hotkey
-                          "
-                          :command-id="(subitem as any).commandId"
-                        ></Kbd>
-                      </div>
-                    </Button>
-                  </TooltipTrigger>
-
-                  <TooltipContent
-                    side="right"
-                    v-if="mini"
-                    class="flex items-center gap-2"
-                  >
-                    <span class="leading-none">{{ subitem.label }}</span>
-                    <Kbd
-                      v-if="
-                        (subitem as any).hotkey ||
-                        (subitem as any).hotkeyId ||
-                        (subitem as any).commandId
-                      "
-                      :hotkey-id="(subitem as any).hotkeyId"
-                      :hotkey="
-                        (subitem as any).hotkeyId || (subitem as any).commandId
-                          ? undefined
-                          : (subitem as any).hotkey
-                      "
-                      :command-id="(subitem as any).commandId"
-                    />
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-
-              <TooltipProvider v-if="subitem.to" :disabled="!mini">
-                <Tooltip>
-                  <TooltipTrigger as-child>
-                    <Button
-                      variant="ghost"
-                      :class="cn('w-full flex px-3 gap-3 hover:bg-primary/5 hover:text-primary', mini ? 'justify-center' : 'justify-start', router.currentRoute.value.path.startsWith(subitem.to) ? 'bg-primary/10 text-primary' : '')"
-                      @click="handleNavClick(subitem.to)"
-                    >
-                      <component :is="subitem.icon" class="size-5 shrink-0" />
-
-                      <div v-if="!mini" class="flex flex-1 gap-1 text-nowrap">
-                        <div class="flex-1 text-left">
-                          {{ subitem.label }}
-                        </div>
-
-                        <Kbd
-                          v-if="
-                            (subitem as any).hotkey ||
-                            (subitem as any).commandId
-                          "
-                          :hotkey="(subitem as any).hotkey"
-                          :command-id="(subitem as any).commandId"
-                        ></Kbd>
-                      </div>
-                    </Button>
-                  </TooltipTrigger>
-
-                  <TooltipContent
-                    side="right"
-                    v-if="mini"
-                    class="flex items-center gap-2"
-                  >
-                    <span class="leading-none -translate-y-px">{{
-                      subitem.label
-                    }}</span>
-                    <Kbd
-                      v-if="
-                        (subitem as any).hotkey || (subitem as any).commandId
-                      "
-                      :hotkey="(subitem as any).hotkey"
-                      :command-id="(subitem as any).commandId"
-                    />
-                  </TooltipContent>
-                </Tooltip>
-              </TooltipProvider>
-            </template>
-          </div>
-        </div>
-      </template>
-
-      <div class="px-1">
-        <AccountDropdown :mini="mini" />
+        <Button
+          v-if="!collapsed"
+          variant="ghost"
+          size="icon"
+          class="shrink-0 text-foreground hover:bg-foreground/5"
+          :aria-label="t('navigation.minimize')"
+          @click="collapsed = true"
+        >
+          <PanelLeftIcon class="size-5" />
+        </Button>
       </div>
+    </SidebarHeader>
+
+    <CommandDialog
+      v-model:open="paletteDialogOpen"
+      modal
+      class="top-[20%] bottom-auto"
+    >
+      <Palette
+        ref="paletteDialogRef"
+        v-model:open="paletteDialogOpen"
+        :show-hints="true"
+      />
+    </CommandDialog>
+
+    <SidebarContent>
+      <SidebarMenu>
+        <SidebarMenuItem
+          v-for="item in items"
+          :key="item.to ?? item.label"
+          :label="item.label"
+          :icon="item.icon"
+          :to="item.to"
+          :command-id="item.commandId"
+          @click="item.to ? handleNavClick($event, item.to) : item.onClick?.()"
+        />
+      </SidebarMenu>
+    </SidebarContent>
+
+    <!-- Slot for custom banner alerts. Default: the Tauri update banner. -->
+    <div class="px-2">
+      <slot name="banner">
+        <template
+          v-if="
+            forceShowUpdateBanner ||
+            (isTauriDesktop && updateAvailable && !updateDismissed)
+          "
+        >
+          <UpdateBanner
+            v-if="!collapsed"
+            :update-available="updateAvailable"
+            :force-show-update-banner="forceShowUpdateBanner"
+            :install-in-progress="installInProgress"
+            :embedded="false"
+            @restart="handleRestartToUpdate"
+            @dismiss="updateDismissed = true"
+          />
+          <ResponsiveHoverCard
+            v-else
+            side="right"
+            :side-offset="10"
+            align="start"
+            :open-delay="200"
+            desktop-content-class="p-0 w-fit overflow-hidden rounded-md"
+          >
+            <template #trigger>
+              <button
+                type="button"
+                class="w-full h-10 px-2 flex items-center rounded-md cursor-pointer text-foreground hover:bg-foreground/5 transition-colors"
+                :aria-label="t('profileMenu.updateBanner')"
+              >
+                <span class="relative inline-flex">
+                  <MegaphoneIcon class="size-5" />
+                  <span
+                    class="absolute -top-0.5 -right-0.5 size-1.5 rounded-full bg-primary ring-2 ring-muted"
+                    aria-hidden
+                  />
+                </span>
+              </button>
+            </template>
+            <template #content>
+              <UpdateBanner
+                :update-available="updateAvailable"
+                :force-show-update-banner="forceShowUpdateBanner"
+                :install-in-progress="installInProgress"
+                :embedded="true"
+                @restart="handleRestartToUpdate"
+                @dismiss="updateDismissed = true"
+              />
+            </template>
+          </ResponsiveHoverCard>
+        </template>
+      </slot>
     </div>
-  </div>
+
+    <SidebarFooter>
+      <SidebarMenu>
+        <SidebarMenuItem
+          :label="t('feedback.title')"
+          :icon="MessageSquareQuoteIcon"
+          @click="
+            openExternalLink(
+              'https://github.com/alexwohlbruck/parchment/issues',
+              '_blank',
+            )
+          "
+        />
+        <SidebarMenuItem
+          :label="t('settings.title')"
+          :icon="SettingsIcon"
+          to="/settings"
+          :hotkey="SETTINGS_HOTKEY"
+          @click="handleNavClick($event, '/settings')"
+        />
+      </SidebarMenu>
+
+      <SidebarSeparator />
+
+      <AccountDropdown :mini="collapsed" />
+    </SidebarFooter>
+
+    <SidebarRail :label="t('navigation.toggle')" />
+  </Sidebar>
 </template>

--- a/web/src/components/ui/kbd/Kbd.vue
+++ b/web/src/components/ui/kbd/Kbd.vue
@@ -74,7 +74,8 @@ const displayString = computed(() => {
 </script>
 
 <template>
-  <component :is="props.as" :class="kbdClass">
+  <!-- An id that resolves to nothing would otherwise render an empty keycap. -->
+  <component v-if="displayString" :is="props.as" :class="kbdClass">
     {{ displayString }}
   </component>
 </template>

--- a/web/src/components/ui/sidebar/Sidebar.vue
+++ b/web/src/components/ui/sidebar/Sidebar.vue
@@ -1,0 +1,148 @@
+<script setup lang="ts">
+import { computed, nextTick, ref, watch } from 'vue'
+import { useMediaQuery, useTransition } from '@vueuse/core'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { provideSidebarContext } from './context'
+import {
+  SIDEBAR_COLLAPSE_SLACK,
+  SIDEBAR_DRAG_THRESHOLD,
+  SIDEBAR_DURATION_MS,
+  SIDEBAR_EASING,
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_ICON,
+} from './scale'
+
+/**
+ * A collapsible, drag-resizable side rail.
+ *
+ * Width is animated as a real number rather than a CSS transition so hosts
+ * can stay in lockstep with it frame by frame — the map next door has to
+ * resize and re-publish its padding as the rail moves, and a CSS transition
+ * gives it nothing to listen to. Same reason `LeftSheet` drives its slide
+ * off a `useTransition` value.
+ */
+const props = withDefaults(
+  defineProps<{
+    /** Icon-rail width, px. */
+    collapsedWidth?: number
+    /** Drag-resize bounds for the expanded panel, px. */
+    minWidth?: number
+    maxWidth?: number
+    /** Labels the landmark for screen readers. */
+    label?: string
+    /** Landmark element. A sidebar that isn't navigation should say so. */
+    as?: string
+  }>(),
+  {
+    collapsedWidth: SIDEBAR_WIDTH_ICON,
+    minWidth: SIDEBAR_MIN_WIDTH,
+    maxWidth: SIDEBAR_MAX_WIDTH,
+    as: 'nav',
+  },
+)
+
+const collapsed = defineModel<boolean>('collapsed', { default: false })
+/** Expanded width, px. Owned by the host so it can be persisted. */
+const width = defineModel<number>('width', { default: SIDEBAR_WIDTH })
+
+const emit = defineEmits<{
+  /** Fires on every frame of a collapse, expand or drag. */
+  (e: 'resize', width: number): void
+}>()
+
+const resizing = ref(false)
+const reducedMotion = useMediaQuery('(prefers-reduced-motion: reduce)')
+
+const targetWidth = computed(() =>
+  collapsed.value ? props.collapsedWidth : width.value,
+)
+// A drag has to track the pointer exactly, and a reduced-motion preference
+// wants no travel at all. Both are a zero-length transition rather than
+// `disabled`, which skips the source watcher and would leave the output
+// holding a stale width the moment the drag ended.
+const duration = computed(() =>
+  resizing.value || reducedMotion.value ? 0 : SIDEBAR_DURATION_MS,
+)
+const animatedWidth = useTransition(targetWidth, {
+  duration,
+  transition: SIDEBAR_EASING,
+})
+
+// After the DOM update, not before it: hosts react to this by measuring the
+// panel and resizing a neighbour, and a pre-flush watcher would hand them the
+// width from the previous frame.
+watch(animatedWidth, w => emit('resize', w), { flush: 'post' })
+
+function toggle() {
+  collapsed.value = !collapsed.value
+}
+
+/**
+ * Dragging the rail sizes the panel; dragging it well inside the minimum
+ * collapses it, and dragging back out brings it straight back — the offset is
+ * always measured from where the press started, so the panel never jumps.
+ */
+function startResize(event: PointerEvent): Promise<boolean> {
+  const startX = event.clientX
+  const startWidth = collapsed.value ? props.collapsedWidth : width.value
+  let dragged = false
+
+  return new Promise(resolve => {
+    function onMove(e: PointerEvent) {
+      const dx = e.clientX - startX
+      if (!dragged && Math.abs(dx) < SIDEBAR_DRAG_THRESHOLD) return
+      if (!dragged) {
+        dragged = true
+        resizing.value = true
+        document.body.style.cursor = 'col-resize'
+        document.body.style.userSelect = 'none'
+      }
+      const next = startWidth + dx
+      if (next < props.minWidth - SIDEBAR_COLLAPSE_SLACK) {
+        collapsed.value = true
+      } else {
+        collapsed.value = false
+        width.value = Math.min(props.maxWidth, Math.max(props.minWidth, next))
+      }
+    }
+
+    function onEnd() {
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onEnd)
+      window.removeEventListener('pointercancel', onEnd)
+      if (dragged) {
+        document.body.style.cursor = ''
+        document.body.style.userSelect = ''
+      }
+      // Released a frame after the last move, the panel would animate the
+      // final few pixels instead of landing on them. Hold the drag open for
+      // one flush so that last width is applied instantly, like the rest.
+      void nextTick(() => (resizing.value = false))
+      resolve(dragged)
+    }
+
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onEnd)
+    window.addEventListener('pointercancel', onEnd)
+  })
+}
+
+provideSidebarContext({ collapsed, toggle, resizing, startResize })
+</script>
+
+<template>
+  <component
+    :is="as"
+    :aria-label="label"
+    :data-collapsed="collapsed"
+    :data-resizing="resizing"
+    class="relative shrink-0 h-full flex flex-col overflow-hidden border-r border-border/60"
+    :style="{ width: `${animatedWidth}px` }"
+  >
+    <TooltipProvider :delay-duration="collapsed ? 200 : 500">
+      <slot />
+    </TooltipProvider>
+  </component>
+</template>

--- a/web/src/components/ui/sidebar/SidebarContent.vue
+++ b/web/src/components/ui/sidebar/SidebarContent.vue
@@ -1,0 +1,18 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ class?: string }>()
+</script>
+
+<template>
+  <div
+    :class="
+      cn(
+        'flex-1 min-h-0 flex flex-col gap-3 overflow-y-auto overflow-x-hidden px-2 py-1',
+        props.class,
+      )
+    "
+  >
+    <slot />
+  </div>
+</template>

--- a/web/src/components/ui/sidebar/SidebarFooter.vue
+++ b/web/src/components/ui/sidebar/SidebarFooter.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ class?: string }>()
+</script>
+
+<template>
+  <div :class="cn('flex flex-col gap-1 p-2', props.class)">
+    <slot />
+  </div>
+</template>

--- a/web/src/components/ui/sidebar/SidebarHeader.vue
+++ b/web/src/components/ui/sidebar/SidebarHeader.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ class?: string }>()
+</script>
+
+<template>
+  <div :class="cn('flex flex-col gap-1 p-2', props.class)">
+    <slot />
+  </div>
+</template>

--- a/web/src/components/ui/sidebar/SidebarMenu.vue
+++ b/web/src/components/ui/sidebar/SidebarMenu.vue
@@ -1,0 +1,57 @@
+<script setup lang="ts">
+import { nextTick, onMounted, ref } from 'vue'
+import { useMutationObserver, useResizeObserver } from '@vueuse/core'
+import { cn } from '@/lib/utils'
+
+/**
+ * A menu list, plus the one raised chip that marks the current row.
+ *
+ * The chip is a single element that slides between rows rather than a
+ * background on each row, so moving between destinations reads as one
+ * object travelling instead of two independent fades. Rows only announce
+ * themselves with `data-active`; the list finds the active one by query, so
+ * an item can decide it's active for any reason without wiring state back up.
+ */
+const props = defineProps<{ class?: string }>()
+
+const listRef = ref<HTMLElement | null>(null)
+const chip = ref<{ top: number; height: number } | null>(null)
+// Suppresses the slide on the very first measure, so the chip fades in where
+// it belongs instead of flying down from the top of the list on load.
+const settled = ref(false)
+
+function measure() {
+  const list = listRef.value
+  if (!list) return
+  const active = list.querySelector<HTMLElement>('[data-active="true"]')
+  chip.value = active
+    ? { top: active.offsetTop, height: active.offsetHeight }
+    : null
+  if (!settled.value) nextTick(() => (settled.value = true))
+}
+
+onMounted(() => nextTick(measure))
+useResizeObserver(listRef, measure)
+useMutationObserver(listRef, measure, {
+  subtree: true,
+  childList: true,
+  attributes: true,
+  attributeFilter: ['data-active'],
+})
+</script>
+
+<template>
+  <ul
+    ref="listRef"
+    :class="cn('relative flex flex-col gap-0.5', props.class)"
+  >
+    <li
+      v-if="chip"
+      aria-hidden="true"
+      class="absolute inset-x-0 rounded-md bg-card dark:bg-foreground/[0.07] depth pointer-events-none"
+      :class="settled && 'motion-safe:transition-[top,height] duration-200 ease-out'"
+      :style="{ top: `${chip.top}px`, height: `${chip.height}px` }"
+    />
+    <slot />
+  </ul>
+</template>

--- a/web/src/components/ui/sidebar/SidebarMenuItem.test.ts
+++ b/web/src/components/ui/sidebar/SidebarMenuItem.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect } from 'vitest'
+import { defineComponent, h, nextTick } from 'vue'
+import { mount } from '@vue/test-utils'
+import { createMemoryHistory, createRouter } from 'vue-router'
+import Sidebar from './Sidebar.vue'
+import SidebarMenu from './SidebarMenu.vue'
+import SidebarMenuItem from './SidebarMenuItem.vue'
+
+const Blank = defineComponent({ render: () => h('div') })
+
+/** The chip is measured after mount, so it lands a couple of ticks later. */
+const flush = async () => {
+  await nextTick()
+  await nextTick()
+  await nextTick()
+}
+
+function makeRouter() {
+  return createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: '/', component: Blank },
+      { path: '/library', component: Blank },
+      { path: '/library/collections', component: Blank },
+      { path: '/timeline', component: Blank },
+    ],
+  })
+}
+
+/**
+ * Rows carry the active state the travelling chip is positioned from, so the
+ * cheap-looking `data-active` attribute is load-bearing.
+ */
+function mountMenu(
+  items: { label: string; to?: string; active?: boolean }[],
+  router: ReturnType<typeof makeRouter>,
+  collapsed = false,
+) {
+  const Harness = defineComponent({
+    render: () =>
+      h(Sidebar, { collapsed }, () => [
+        h(SidebarMenu, null, () =>
+          items.map(item => h(SidebarMenuItem, { key: item.label, ...item })),
+        ),
+      ]),
+  })
+  return mount(Harness, { global: { plugins: [router] } })
+}
+
+describe('SidebarMenuItem', () => {
+  it('marks the row whose route prefix the current path matches', async () => {
+    const router = makeRouter()
+    await router.push('/library/collections')
+    await router.isReady()
+
+    const w = mountMenu(
+      [
+        { label: 'Library', to: '/library' },
+        { label: 'Timeline', to: '/timeline' },
+      ],
+      router,
+    )
+    await nextTick()
+
+    const rows = w.findAll('li[data-active]')
+    expect(rows.map(r => r.attributes('data-active'))).toEqual(['true', 'false'])
+    expect(w.get('a[aria-current="page"]').text()).toBe('Library')
+  })
+
+  it('follows navigation, so the chip can travel', async () => {
+    const router = makeRouter()
+    await router.push('/library')
+    await router.isReady()
+
+    const w = mountMenu(
+      [
+        { label: 'Library', to: '/library' },
+        { label: 'Timeline', to: '/timeline' },
+      ],
+      router,
+    )
+    await nextTick()
+    expect(w.findAll('li[data-active]').map(r => r.attributes('data-active')))
+      .toEqual(['true', 'false'])
+
+    await router.push('/timeline')
+    await nextTick()
+    expect(w.findAll('li[data-active]').map(r => r.attributes('data-active')))
+      .toEqual(['false', 'true'])
+  })
+
+  it('falls back to the route when no active prop is passed', async () => {
+    // Vue casts an absent boolean prop to `false`; if that value reached the
+    // active check it would silently beat the route and nothing would ever
+    // look selected.
+    const router = makeRouter()
+    await router.push('/timeline')
+    await router.isReady()
+
+    const w = mountMenu([{ label: 'Timeline', to: '/timeline' }], router)
+    await nextTick()
+
+    expect(w.get('li[data-active]').attributes('data-active')).toBe('true')
+  })
+
+  it('lets an explicit active prop win over the route', async () => {
+    const router = makeRouter()
+    await router.push('/timeline')
+    await router.isReady()
+
+    const w = mountMenu(
+      [
+        { label: 'Timeline', to: '/timeline', active: false },
+        { label: 'Library', to: '/library', active: true },
+      ],
+      router,
+    )
+    await nextTick()
+
+    expect(w.findAll('li[data-active]').map(r => r.attributes('data-active')))
+      .toEqual(['false', 'true'])
+  })
+
+  it('renders an action row as a button and emits its click', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const w = mountMenu([{ label: 'Search' }], router)
+    await nextTick()
+
+    const button = w.get('li button')
+    expect(button.attributes('type')).toBe('button')
+    expect(w.find('li a').exists()).toBe(false)
+
+    await button.trigger('click')
+    expect(
+      w.findComponent(SidebarMenuItem).emitted('click'),
+    ).toHaveLength(1)
+  })
+})
+
+describe('SidebarMenu', () => {
+  it('only draws the chip when something is active', async () => {
+    const router = makeRouter()
+    await router.push('/')
+    await router.isReady()
+
+    const inactive = mountMenu([{ label: 'Timeline', to: '/timeline' }], router)
+    await flush()
+    expect(inactive.find('li[aria-hidden="true"]').exists()).toBe(false)
+
+    await router.push('/timeline')
+    const active = mountMenu([{ label: 'Timeline', to: '/timeline' }], router)
+    await flush()
+    expect(active.find('li[aria-hidden="true"]').exists()).toBe(true)
+  })
+})

--- a/web/src/components/ui/sidebar/SidebarMenuItem.vue
+++ b/web/src/components/ui/sidebar/SidebarMenuItem.vue
@@ -1,0 +1,112 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { RouterLink, useRoute } from 'vue-router'
+import { cn } from '@/lib/utils'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import Kbd from '@/components/ui/kbd/Kbd.vue'
+import type { Icon } from '@/types/app.types'
+import type { Hotkey } from '@/types/command.types'
+import { useSidebar } from './context'
+import { SIDEBAR_ROW } from './scale'
+
+/**
+ * One row: icon, label, and — when there is one — the shortcut that fires it.
+ *
+ * A row with `to` renders a real link so middle-click and copy-link behave;
+ * callers that need to do something extra on click can still listen, and
+ * `preventDefault` to suppress the navigation.
+ *
+ * The row paints no background of its own when active — `SidebarMenu`'s
+ * travelling chip does that. Collapsed, the label is clipped by the sidebar
+ * rather than unmounted, so expanding reveals text that is already in place,
+ * and the tooltip takes over as the row's name.
+ */
+const props = withDefaults(
+  defineProps<{
+    label: string
+    icon?: Icon
+    /** Makes the row a link. */
+    to?: string
+    /** Overrides the route-derived active state. */
+    active?: boolean
+    hotkey?: Hotkey
+    hotkeyId?: string
+    commandId?: string
+  }>(),
+  // Absent boolean props are cast to `false` unless a default is declared, and
+  // `false` would beat the route check every time.
+  { active: undefined },
+)
+
+defineEmits<{ (e: 'click', event: MouseEvent): void }>()
+
+const route = useRoute()
+const { collapsed } = useSidebar()
+
+const isActive = computed(() =>
+  props.active ?? (props.to ? route.path.startsWith(props.to) : false),
+)
+
+const hasShortcut = computed(
+  () => !!(props.hotkey || props.hotkeyId || props.commandId),
+)
+
+// `hotkey` is a literal key combo; the other two resolve one from a store, and
+// passing both leaves Kbd's union prop ambiguous.
+const shortcutProps = computed(() =>
+  props.hotkeyId
+    ? { hotkeyId: props.hotkeyId }
+    : props.commandId
+      ? { commandId: props.commandId }
+      : { hotkey: props.hotkey! },
+)
+</script>
+
+<template>
+  <li :data-active="isActive">
+    <Tooltip :disabled="!collapsed">
+      <TooltipTrigger as-child>
+        <component
+          :is="to ? RouterLink : 'button'"
+          :to="to"
+          :type="to ? undefined : 'button'"
+          :aria-current="to && isActive ? 'page' : undefined"
+          :class="
+            cn(
+              SIDEBAR_ROW,
+              'relative w-full flex items-center cursor-pointer no-underline',
+              'focus-visible:outline-hidden focus-visible:ring-1 focus-visible:ring-ring focus-visible:ring-inset',
+              'text-foreground',
+              !isActive && 'hover:bg-foreground/5',
+            )
+          "
+          @click="$emit('click', $event)"
+        >
+          <component
+            :is="icon"
+            v-if="icon"
+            class="size-5 shrink-0 transition-colors"
+            :class="isActive ? 'text-primary' : 'text-current'"
+          />
+          <span
+            class="flex-1 text-left whitespace-nowrap transition-opacity duration-150"
+            :class="collapsed ? 'opacity-0' : 'opacity-100'"
+          >
+            {{ label }}
+          </span>
+          <Kbd
+            v-if="hasShortcut"
+            v-bind="shortcutProps"
+            class="transition-opacity duration-150"
+            :class="collapsed ? 'opacity-0' : 'opacity-100'"
+          />
+        </component>
+      </TooltipTrigger>
+
+      <TooltipContent side="right" :side-offset="10" class="flex items-center gap-2">
+        <span class="leading-none">{{ label }}</span>
+        <Kbd v-if="hasShortcut" v-bind="shortcutProps" />
+      </TooltipContent>
+    </Tooltip>
+  </li>
+</template>

--- a/web/src/components/ui/sidebar/SidebarRail.test.ts
+++ b/web/src/components/ui/sidebar/SidebarRail.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect } from 'vitest'
+import { defineComponent, h, nextTick, ref } from 'vue'
+import { mount } from '@vue/test-utils'
+import Sidebar from './Sidebar.vue'
+import SidebarRail from './SidebarRail.vue'
+import {
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_ICON,
+} from './scale'
+
+/**
+ * The rail is one control doing two jobs — drag to size, click to collapse —
+ * so what separates them (a few pixels of pointer travel) is worth pinning.
+ */
+function mountRail(collapsed = false, width = SIDEBAR_WIDTH) {
+  const state = { collapsed: ref(collapsed), width: ref(width) }
+  const Harness = defineComponent({
+    setup: () => () =>
+      h(
+        Sidebar,
+        {
+          collapsed: state.collapsed.value,
+          'onUpdate:collapsed': (v: boolean) => (state.collapsed.value = v),
+          width: state.width.value,
+          'onUpdate:width': (v: number) => (state.width.value = v),
+        },
+        () => [h(SidebarRail, { label: 'Toggle navigation' })],
+      ),
+  })
+  return { state, wrapper: mount(Harness) }
+}
+
+// Real pointer events arrive in separate task-queue turns, so Vue flushes
+// between them. Ticking here matters: the panel only skips its collapse
+// animation while a drag is actually in flight.
+async function drag(wrapper: ReturnType<typeof mount>, from: number, to: number) {
+  await wrapper.get('button').trigger('pointerdown', { button: 0, clientX: from })
+  window.dispatchEvent(new MouseEvent('pointermove', { clientX: to }))
+  await nextTick()
+  window.dispatchEvent(new MouseEvent('pointerup'))
+  await nextTick()
+}
+
+describe('SidebarRail', () => {
+  it('sizes the panel to the pointer, and stays there on release', async () => {
+    const { state, wrapper } = mountRail()
+    await drag(wrapper, 240, 300)
+    expect(state.width.value).toBe(300)
+    expect(state.collapsed.value).toBe(false)
+    // Letting go must not hand the panel back to a stale animated width.
+    expect(wrapper.get('nav').attributes('style')).toContain('width: 300px')
+  })
+
+  it('clamps to the resize bounds', async () => {
+    const wide = mountRail()
+    await drag(wide.wrapper, 240, 1000)
+    expect(wide.state.width.value).toBe(SIDEBAR_MAX_WIDTH)
+
+    const narrow = mountRail()
+    await drag(narrow.wrapper, 240, SIDEBAR_MIN_WIDTH - 10)
+    expect(narrow.state.width.value).toBe(SIDEBAR_MIN_WIDTH)
+    expect(narrow.state.collapsed.value).toBe(false)
+  })
+
+  it('collapses when dragged well inside the minimum', async () => {
+    const { state, wrapper } = mountRail()
+    await drag(wrapper, 240, 100)
+    expect(state.collapsed.value).toBe(true)
+  })
+
+  it('expands again when dragged back out from collapsed', async () => {
+    const { state, wrapper } = mountRail(true, SIDEBAR_WIDTH)
+    await drag(wrapper, SIDEBAR_WIDTH_ICON, SIDEBAR_WIDTH_ICON + 200)
+    expect(state.collapsed.value).toBe(false)
+    expect(state.width.value).toBe(SIDEBAR_WIDTH_ICON + 200)
+  })
+
+  it('toggles when the press does not move', async () => {
+    const { state, wrapper } = mountRail()
+    await drag(wrapper, 240, 240)
+    expect(state.collapsed.value).toBe(true)
+    expect(state.width.value).toBe(SIDEBAR_WIDTH)
+  })
+
+  it('does not toggle after a drag', async () => {
+    const { state, wrapper } = mountRail()
+    await drag(wrapper, 240, 320)
+    expect(state.collapsed.value).toBe(false)
+  })
+
+  it('lands on the final width even when release shares the last frame', async () => {
+    const { state, wrapper } = mountRail()
+    await wrapper.get('button').trigger('pointerdown', { button: 0, clientX: 240 })
+    window.dispatchEvent(new MouseEvent('pointermove', { clientX: 300 }))
+    window.dispatchEvent(new MouseEvent('pointerup'))
+    await nextTick()
+    await nextTick()
+
+    expect(state.width.value).toBe(300)
+    expect(wrapper.get('nav').attributes('style')).toContain('width: 300px')
+  })
+})

--- a/web/src/components/ui/sidebar/SidebarRail.vue
+++ b/web/src/components/ui/sidebar/SidebarRail.vue
@@ -1,0 +1,58 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { cn } from '@/lib/utils'
+import { useSidebar } from './context'
+
+/**
+ * The hit strip along the sidebar's outer edge: drag it to size the panel,
+ * click it to collapse or expand. Collapsed, it is the main way back — it
+ * lights up under the cursor where the panel ends, which is where people
+ * already reach to drag a sidebar open.
+ */
+const props = defineProps<{ label: string; class?: string }>()
+
+const { collapsed, resizing, toggle, startResize } = useSidebar()
+
+// A press that turns into a drag must not also toggle. The pointer path
+// decides for itself; `click` is left to handle keyboard activation, which
+// never goes through pointerdown.
+const fromPointer = ref(false)
+
+async function onPointerDown(event: PointerEvent) {
+  if (event.button !== 0) return
+  event.preventDefault()
+  fromPointer.value = true
+  const dragged = await startResize(event)
+  if (!dragged) toggle()
+  setTimeout(() => (fromPointer.value = false))
+}
+
+function onClick() {
+  if (fromPointer.value) return
+  toggle()
+}
+</script>
+
+<template>
+  <button
+    type="button"
+    :aria-label="props.label"
+    :title="props.label"
+    :aria-expanded="!collapsed"
+    :class="
+      cn(
+        'group absolute inset-y-0 right-0 z-20 w-2.5 cursor-col-resize touch-none',
+        'focus-visible:outline-hidden',
+        props.class,
+      )
+    "
+    @pointerdown="onPointerDown"
+    @click="onClick"
+  >
+    <span
+      aria-hidden="true"
+      class="absolute inset-y-0 right-0 w-0.5 bg-primary/60 transition-opacity duration-150 group-hover:opacity-100 group-focus-visible:opacity-100"
+      :class="resizing ? 'opacity-100' : 'opacity-0'"
+    />
+  </button>
+</template>

--- a/web/src/components/ui/sidebar/SidebarSeparator.vue
+++ b/web/src/components/ui/sidebar/SidebarSeparator.vue
@@ -1,0 +1,9 @@
+<script setup lang="ts">
+import { cn } from '@/lib/utils'
+
+const props = defineProps<{ class?: string }>()
+</script>
+
+<template>
+  <div :class="cn('h-px shrink-0 bg-border/70 mx-2 my-1', props.class)" />
+</template>

--- a/web/src/components/ui/sidebar/context.ts
+++ b/web/src/components/ui/sidebar/context.ts
@@ -1,0 +1,28 @@
+import { inject, provide, type InjectionKey, type Ref } from 'vue'
+
+export interface SidebarContext {
+  /** Icon-rail mode: labels are hidden, rows centre, tooltips take over. */
+  collapsed: Ref<boolean>
+  toggle: () => void
+  /** True while a rail drag is in flight. */
+  resizing: Ref<boolean>
+  /**
+   * Begin a rail drag. Resolves with whether the pointer actually moved, so
+   * the caller can treat a press that went nowhere as a plain click.
+   */
+  startResize: (event: PointerEvent) => Promise<boolean>
+}
+
+const SIDEBAR_CONTEXT = Symbol('sidebar') as InjectionKey<SidebarContext>
+
+export function provideSidebarContext(context: SidebarContext) {
+  provide(SIDEBAR_CONTEXT, context)
+}
+
+export function useSidebar(): SidebarContext {
+  const context = inject(SIDEBAR_CONTEXT, null)
+  if (!context) {
+    throw new Error('Sidebar parts must be rendered inside a <Sidebar>.')
+  }
+  return context
+}

--- a/web/src/components/ui/sidebar/index.ts
+++ b/web/src/components/ui/sidebar/index.ts
@@ -1,0 +1,16 @@
+export { default as Sidebar } from './Sidebar.vue'
+export { default as SidebarContent } from './SidebarContent.vue'
+export { default as SidebarFooter } from './SidebarFooter.vue'
+export { default as SidebarHeader } from './SidebarHeader.vue'
+export { default as SidebarMenu } from './SidebarMenu.vue'
+export { default as SidebarMenuItem } from './SidebarMenuItem.vue'
+export { default as SidebarRail } from './SidebarRail.vue'
+export { default as SidebarSeparator } from './SidebarSeparator.vue'
+
+export { useSidebar, type SidebarContext } from './context'
+export {
+  SIDEBAR_MAX_WIDTH,
+  SIDEBAR_MIN_WIDTH,
+  SIDEBAR_WIDTH,
+  SIDEBAR_WIDTH_ICON,
+} from './scale'

--- a/web/src/components/ui/sidebar/scale.ts
+++ b/web/src/components/ui/sidebar/scale.ts
@@ -1,0 +1,32 @@
+/**
+ * One rhythm for the whole sidebar, header to footer: a 40px row holding a
+ * 20px icon, on a 4px grid. Every part of the kit reads its sizing from here
+ * so a row, the logo and the account footer never drift apart.
+ */
+
+/** Expanded width, px, before the user has dragged it anywhere. */
+export const SIDEBAR_WIDTH = 240
+/** Drag-resize bounds for the expanded panel, px. */
+export const SIDEBAR_MIN_WIDTH = 200
+export const SIDEBAR_MAX_WIDTH = 400
+/** Drag this far inside the minimum and the panel collapses instead. */
+export const SIDEBAR_COLLAPSE_SLACK = 44
+/** Pointer travel before a press on the rail counts as a drag, not a click. */
+export const SIDEBAR_DRAG_THRESHOLD = 3
+/**
+ * Icon-rail width, px. Deliberately `8px gutter + 8px row padding + 20px icon`
+ * doubled: at this width a left-aligned row icon lands dead centre of the
+ * rail, so rows never have to re-centre themselves as the sidebar collapses.
+ */
+export const SIDEBAR_WIDTH_ICON = 52
+
+/**
+ * Collapse/expand timing. The same deceleration curve `LeftSheet` uses, so
+ * the two panels that flank the map feel like one mechanism.
+ */
+export const SIDEBAR_DURATION_MS = 220
+export const SIDEBAR_EASING: [number, number, number, number] = [0.32, 0.72, 0, 1]
+
+/** Row chrome, shared by menu rows and anything that has to line up with them. */
+export const SIDEBAR_ROW =
+  'h-10 rounded-md px-2 gap-2.5 text-sm font-medium transition-colors duration-150'

--- a/web/src/lib/map-padding.test.ts
+++ b/web/src/lib/map-padding.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect } from 'vitest'
+import { calculateFitPadding, toContainerRect } from './map-padding'
+
+/**
+ * The desktop sidebar is a flex sibling of the map canvas, so the canvas
+ * origin is already inset by its width — and that width is now whatever the
+ * user dragged the rail to.
+ */
+describe('toContainerRect', () => {
+  it('is a no-op when the container fills the viewport', () => {
+    const visible = { x: 0, y: 240, width: 390, height: 600 }
+    expect(toContainerRect(visible, { left: 0, top: 0 })).toEqual(visible)
+  })
+
+  it('drops the container offset out of the visible rect', () => {
+    // 1280px viewport, 320px sidebar, a 400px drawer over the canvas.
+    const visible = { x: 720, y: 0, width: 560, height: 800 }
+    expect(toContainerRect(visible, { left: 320, top: 0 })).toEqual({
+      x: 400,
+      y: 0,
+      width: 560,
+      height: 800,
+    })
+  })
+})
+
+describe('calculateFitPadding', () => {
+  it('measures the gutters from the container, not the viewport', () => {
+    const viewportSpace = { x: 720, y: 0, width: 560, height: 800 }
+    const containerSpace = toContainerRect(viewportSpace, { left: 320, top: 0 })
+
+    // 960 x 800 canvas: 5% of 960 = 48 side margin, 8% of 800 = 64 top/bottom.
+    const padding = calculateFitPadding(containerSpace, 960, 800)
+    expect(padding.left).toBe(400 + 48)
+    expect(padding.right).toBe(48)
+    expect(padding.top).toBe(64)
+    expect(padding.bottom).toBe(64)
+
+    // Uncorrected, the drawer gutter would carry the sidebar's width too.
+    expect(calculateFitPadding(viewportSpace, 960, 800).left).toBe(720 + 48)
+  })
+
+  it('never returns a negative gutter', () => {
+    const padding = calculateFitPadding(
+      { x: -20, y: -10, width: 1000, height: 900 },
+      960,
+      800,
+    )
+    expect(padding.left).toBe(48)
+    expect(padding.top).toBe(64)
+  })
+})

--- a/web/src/lib/map-padding.ts
+++ b/web/src/lib/map-padding.ts
@@ -27,6 +27,30 @@ export interface Padding {
   left: number
 }
 
+/**
+ * Re-express a viewport-space visible rect in a container's own coordinates.
+ *
+ * Obstruction bounds are collected with `getBoundingClientRect`, so they are
+ * relative to the viewport. The map canvas, though, is a flex sibling of the
+ * desktop sidebar: its origin is already inset by the sidebar's width. Handing
+ * viewport coordinates to a container-sized padding calculation therefore
+ * counts the sidebar twice, pushing the vanishing point right by its width —
+ * and the sidebar is drag-resizable, so the error is not a fixed one.
+ *
+ * On mobile, where the map container fills the viewport, this is a no-op.
+ */
+export function toContainerRect(
+  visibleArea: Rect,
+  containerOrigin: { left: number; top: number },
+): Rect {
+  return {
+    x: visibleArea.x - containerOrigin.left,
+    y: visibleArea.y - containerOrigin.top,
+    width: visibleArea.width,
+    height: visibleArea.height,
+  }
+}
+
 const MARGIN_X_FRACTION = 0.05 // 5% of viewport width per side
 const MARGIN_Y_FRACTION = 0.08 // 8% of viewport height per side
 const MIN_MARGIN = 16

--- a/web/src/services/map.service.ts
+++ b/web/src/services/map.service.ts
@@ -31,7 +31,11 @@ import { useTimelineLayerService } from '@/services/layers/features/timeline-lay
 import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
 import { usePortolanTransitStore } from '@/stores/portolan.store'
 import { useAppStore } from '../stores/app.store'
-import { calculateFitPadding, type Padding } from '@/lib/map-padding'
+import {
+  calculateFitPadding,
+  toContainerRect,
+  type Padding,
+} from '@/lib/map-padding'
 import {
   findGriddedCity,
   gridOrientations,
@@ -617,7 +621,12 @@ function mapService() {
       return null
     }
 
-    const visibleArea = appStore.visibleMapArea
+    // Obstruction bounds are viewport-space; everything below is relative to
+    // the canvas, which the sidebar has already pushed off the viewport edge.
+    const visibleArea = toContainerRect(
+      appStore.visibleMapArea,
+      mapContainer.getBoundingClientRect(),
+    )
     const mapWidth = mapContainer.clientWidth
     const mapHeight = mapContainer.clientHeight
 
@@ -723,7 +732,10 @@ function mapService() {
     // on top of the computed one — useful for cases that want an extra
     // buffer around the fitted content beyond the default breathing room.
     const basePadding = calculateFitPadding(
-      appStore.visibleMapArea,
+      toContainerRect(
+        appStore.visibleMapArea,
+        mapContainer.getBoundingClientRect(),
+      ),
       mapContainer.clientWidth,
       mapContainer.clientHeight,
     )
@@ -1470,10 +1482,17 @@ function mapService() {
       const map = mapStrategy?.mapInstance
       if (!map?.unproject) return mapStrategy?.getBounds() || null
 
-      const visibleArea = appStore.visibleMapArea
-      if (!visibleArea || !visibleArea.width || !visibleArea.height) {
+      const viewportArea = appStore.visibleMapArea
+      if (!viewportArea || !viewportArea.width || !viewportArea.height) {
         return mapStrategy?.getBounds() || null
       }
+
+      // `unproject` reads container-relative pixels, and the obstruction
+      // bounds are viewport-relative — on desktop the sidebar sits between
+      // the two origins.
+      const visibleArea = mapContainer
+        ? toContainerRect(viewportArea, mapContainer.getBoundingClientRect())
+        : viewportArea
 
       // Unproject the four corners of the visible area rect (pixel → lng/lat)
       const nw = map.unproject([visibleArea.x, visibleArea.y])


### PR DESCRIPTION
Reworks the desktop sidebar on a new `ui/sidebar` primitive kit, in the shape of
[shadcn-vue's sidebar](https://shadcn-vue.com/docs/components/sidebar) with ideas from
[fluidfunctionalism](https://www.fluidfunctionalism.com/docs/sidebar). Every function of the old
navigation is retained.

## The kit — `web/src/components/ui/sidebar/`

`Sidebar` (owns collapse, width and the drag), `SidebarHeader/Content/Footer`, `SidebarMenu`,
`SidebarMenuItem`, `SidebarRail`, `SidebarSeparator`, plus `useSidebar()` and a `scale.ts` that is
the single source of truth for sizing.

## Design

Rows are 40px holding a 20px icon on a recessed rail (`bg-muted/50`), at full contrast. The current
row is a single raised chip — `bg-card` plus the repo's own `depth` utility — that **slides between
rows** rather than two backgrounds cross-fading. The rail is 52px wide, chosen so a left-aligned row
icon lands dead centre of it; logo, icons and avatar therefore share one vertical line collapsed and
one left edge expanded, and nothing shifts as the panel moves.

## Interaction

* **Drag the outer edge** to size the panel between 200–400px. Drag 44px inside the minimum and it
  collapses to the icon rail; drag back out and it returns. A press that doesn't move still toggles.
* Collapse toggle moved to the header, next to the logo. `S` still works from anywhere.
* Collapsed state and dragged width both persist.
* Width animates as a real number via `useTransition` on `LeftSheet`'s easing curve, and is emitted
  every frame so the map resizes and re-pads in lockstep — a CSS transition would give it nothing to
  listen to.

## Structure and a11y

Real `<nav>` landmark, `<ul>/<li>`, `aria-current="page"`, `aria-expanded` on the rail. Rows are real
`RouterLink`s, so middle-click and copy-link work now. Honours `prefers-reduced-motion`.

## Account row

Now a real sidebar row — same height, padding and hover as the links above it, 32px avatar, single
line. The email moved into the menu header, which is wider and truncates instead of clipping. 44px
tall on mobile, where the same trigger sits in the bottom sheet. Replaced two hand-rolled divider
divs (one carrying a `TODO: Replace with separator component`).

## Bugs fixed along the way

* **No row was ever active.** `active?: boolean` silently defaults to `false` — Vue casts absent
  boolean props — so the override always beat the route check.
* **Empty keycaps.** Hotkey ids resolve from a non-reactive registry populated in the parent's
  `onMounted`, i.e. after children render, so `Kbd` rendered an empty pill on first paint.
* **The map read stale layout.** The resize emit was on a pre-flush watcher, firing before Vue
  applied the new width.
* **Map padding counted the sidebar twice.** Obstruction bounds are viewport-relative, but the map
  canvas is a flex sibling of the sidebar — its origin is already inset. Four places treated one as
  the other: the `setPadding` vanishing point, `_fitBoundsNow`, both strategies' `fitBounds`, and
  `getVisibleBounds()`, whose `unproject` takes container pixels. With only the sidebar this
  short-circuits to zero padding, but with a drawer open over the map the left gutter carried the
  sidebar's width a second time — and `calculateMapPadding` caps each side at 50%, so a wide sidebar
  plus a drawer pegged the vanishing point at the viewport midpoint. Fixed with one shared helper,
  `toContainerRect`. No-op on mobile.

## Testing

`vue-tsc` clean; full suite green at **1685 tests / 92 files**, 17 of them new:

* `SidebarMenuItem.test.ts` — active resolution, route following, the boolean-prop trap
* `SidebarRail.test.ts` — drag sizing, clamping, collapse threshold, click-vs-drag, release
* `map-padding.test.ts` — the container conversion, with the uncorrected value asserted

Layout was verified by measuring the running app at both widths and after a dragged reload: rail
52px, everything centred on x=26 collapsed and starting at x=16 expanded, uniform 42px row pitch. The
canvas CSS width, its backing buffer and `<main>` agree at every step of a drag (400→880, 300→980,
200→1080 at a 1280px viewport).

## Worth a look before merging

* **No screenshot.** Screenshot capture was unavailable in this environment — the automation tab runs
  backgrounded, which freezes `requestAnimationFrame` and fails the capture. Verification was by DOM
  and geometry measurement instead.
* The map-padding fix reaches beyond the sidebar into shared camera code. It only makes existing
  behaviour correct, but it does change where `flyTo`/`fitBounds` land on desktop whenever a drawer
  is open — worth trying on a real route.
