### PR TITLE
Seed a fresh Unreleased with its headings, as merge anchors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Added
+
+### Changed
+
+### Fixed
+
 ## [0.8.3] - 2026-09-02
 
 ### Changed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@
 
 `CHANGELOG.md` is cumulative ([Keep a Changelog](https://keepachangelog.com/en/1.1.0/)). When a user-facing feature or fix is complete, append an entry under `## [Unreleased]` at the top — do not wait for release time.
 
-- Group entries under `### Added`, `### Changed`, or `### Fixed` within `[Unreleased]`. Create the heading if it isn't there; otherwise append to the existing one.
+- Group entries under `### Added`, `### Changed`, or `### Fixed` within `[Unreleased]`. All three headings are always present, even when empty — append under the right one rather than adding or removing a heading. They exist as merge anchors: two branches that each have to invent a heading conflict, two branches filling in different existing headings do not. Empty headings are stripped back out at release time, so they never ship.
 - One `*` bullet per change, written for users rather than developers: what it does for them, not which files moved.
 - Keep each bullet short: usually one sentence, with a second only when it adds necessary user-facing context.
 - Prefer plain, direct language over scene-setting or long explanations. If a bullet needs more than about 30 words, tighten it.

--- a/scripts/changelog.sh
+++ b/scripts/changelog.sh
@@ -4,6 +4,14 @@
 # file with an `## [Unreleased]` section on top that accumulates entries as work
 # lands, followed by `## [X.Y.Z] - DATE` sections newest-first.
 #
+# A fresh `[Unreleased]` is opened with its `### Added` / `### Changed` /
+# `### Fixed` headings already in place, even though they are empty. They are
+# there to be merge anchors: two branches appending under headings they both
+# had to invent land on the same line with the same context and always
+# conflict, whereas two branches filling in headings that already exist merge
+# cleanly as long as they are different headings. Empty headings are stripped
+# back out on the way to any consumer, so nothing downstream ever sees one.
+#
 # Every consumer of the changelog goes through here so the format is known in
 # exactly one place: deploy.sh (PR body, release cut) and release.yml (GitHub
 # Release body, Google Play "what's new").
@@ -18,6 +26,9 @@ set -euo pipefail
 
 CHANGELOG="${CHANGELOG_FILE:-CHANGELOG.md}"
 
+# Seeded into every fresh [Unreleased], in Keep a Changelog order.
+SECTIONS="Added Changed Fixed"
+
 # Print the body of one `## [...]` section, without its header.
 # want=unreleased -> the [Unreleased] section; want=latest -> the first released one.
 section() {
@@ -31,6 +42,24 @@ section() {
         }
         capturing { print }
     ' "$CHANGELOG" | trim
+}
+
+# Drop any `### X` heading with no `* ` bullet under it. The seeded headings
+# exist for git's benefit, not the reader's — callers asking "is there anything
+# to release?" must not see three empty headings and answer yes.
+drop_empty_sections() {
+    awk '
+        function flush() {
+            if (heading != "" && has) {
+                print heading
+                for (i = 1; i <= n; i++) print buf[i]
+            }
+        }
+        /^### / { flush(); heading = $0; n = 0; has = 0; next }
+        heading == "" { print; next }
+        { buf[++n] = $0; if ($0 ~ /^\* /) has = 1 }
+        END { flush() }
+    '
 }
 
 # Strip leading and trailing blank lines.
@@ -52,14 +81,14 @@ plain() {
 
 case "${1:-}" in
     unreleased)
-        section unreleased
+        section unreleased | drop_empty_sections | trim
         ;;
 
     latest)
         if [ "${2:-}" = "--plain" ]; then
-            section latest | plain
+            section latest | drop_empty_sections | trim | plain
         else
-            section latest
+            section latest | drop_empty_sections | trim
         fi
         ;;
 
@@ -69,24 +98,30 @@ case "${1:-}" in
             echo "Usage: $0 release X.Y.Z" >&2
             exit 1
         fi
-        if [ -z "$(section unreleased)" ]; then
+        body=$(section unreleased | drop_empty_sections | trim)
+        if [ -z "$body" ]; then
             echo "Nothing under [Unreleased] in $CHANGELOG — nothing to release." >&2
             exit 1
         fi
 
-        # Retitle [Unreleased] as the new version and open an empty one above it.
-        # The accumulated entries stay put and fall under the new version header.
+        # Retitle [Unreleased] as the new version and open a freshly seeded one
+        # above it. The accumulated entries are rewritten rather than left in
+        # place so the headings nobody filled in don't ship with the release.
         tmp=$(mktemp)
-        awk -v v="$version" -v d="$(date +%Y-%m-%d)" '
-            !stamped && /^## \[Unreleased\]/ {
-                print "## [Unreleased]"
-                print ""
-                print "## [" v "] - " d
-                stamped = 1
-                next
-            }
-            { print }
-        ' "$CHANGELOG" > "$tmp"
+        {
+            echo "## [Unreleased]"
+            for s in $SECTIONS; do
+                echo ""
+                echo "### $s"
+            done
+            echo ""
+            echo "## [$version] - $(date +%Y-%m-%d)"
+            echo ""
+            echo "$body"
+            echo ""
+            # Everything from the previous release header down, untouched.
+            awk 'seen { print } !seen && /^## \[/ && !/^## \[Unreleased\]/ { seen = 1; print }' "$CHANGELOG"
+        } > "$tmp"
         mv "$tmp" "$CHANGELOG"
         ;;
 


### PR DESCRIPTION
Every branch appends to the top of the same two headings inside `## [Unreleased]`, so any two
concurrent branches insert different lines at the same offset with identical surrounding context.
Git has no basis to pick an order, and conflicts. 121 commits have touched this file.

Opening a fresh `[Unreleased]` with its headings already in place turns those headings into merge
anchors. Two branches that each have to *invent* `### Fixed` land on the same line; two branches
filling in a `### Fixed` that already exists are separated by unchanged context and merge cleanly.

Measured on scratch repos:

| | today | with seeded headings |
|---|---|---|
| Two branches, different sections | conflict | **clean** |
| Two branches, same section | conflict | conflict |

It is a partial fix, and worth being clear about that: it removes every cross-section conflict and
confines the rest to one section's bullet list, instead of one hunk that swallows the whole
`[Unreleased]` block including its headings.

## What changed

`scripts/changelog.sh` only, so the file still has exactly one writer:

* `release X.Y.Z` opens the new `[Unreleased]` with `### Added` / `### Changed` / `### Fixed`, and
  rewrites the section it stamps so headings nobody filled in don't ship with the release.
* New `drop_empty_sections` filter on `unreleased` and `latest`.

That filter is load-bearing rather than cosmetic. `deploy.sh` decides "is there anything to release?"
with `changelog.sh unreleased | grep -q .`, and `changelog.sh release` guards on the same body.
Seeding headings without it would make a seeded-but-empty `[Unreleased]` read as *having entries*,
which would break the hotfix path that deliberately expects an empty one, and would push empty
`### Added` headings into the GitHub Release body and the Google Play "what's new" text.

## Verified

Against the real `CHANGELOG.md` and a fixture:

* a seeded-but-empty `[Unreleased]` still reads as nothing to release, so `deploy.sh`'s hotfix branch
  is unchanged and `changelog.sh release` still refuses
* a release cut stamps only the sections that have bullets, and opens a freshly seeded `[Unreleased]`
* `latest` and `latest --plain` render 0.8.3 with no stray headings
* older released sections are untouched

`CLAUDE.md`'s changelog rule is updated: the headings are always there, so append under one rather
than adding or removing headings.
