### PR TITLE
Give in-station transfers their own section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,13 @@
 
 ### Changed
 
+* Lines you can transfer to without leaving a station have their own Transfers section below the departures, instead of being mixed into the station's own bullets
 * The toolbox button has been removed from the map. Measure, radius and isochrone are still available from the map's right-click menu, and the setting for showing the toolbox is gone from Settings
 * The capability filters in integration settings are listed alphabetically
 
 ### Fixed
 
+* A station's line bullets no longer claim a transfer line isn't running. The row beside a station's name listed every line in its transfer complex and dimmed the ones with nothing on the board — but a transfer line never has anything on that board, so the 4, 5, 6 and 6X at Chambers St all read "isn't running now" while the trains were arriving one platform away. The row now shows only the lines that stop here
 * OSM tag groups with subfields are easier to read in place details, and each individual value can now be copied on its own instead of only as one combined block
 * Trees and street furniture on the map were being drawn inside-out, so they were lit by the side of themselves facing away from you and came out flat and too dark. They now catch the light on the surface you can actually see
 * The Brand Catalog, Transit Routing and Rideshare Estimate capability filters in integration settings show their names instead of raw translation keys, in English and Spanish

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -8,7 +8,7 @@
  *     Headsign     12, 25 min  📶
  */
 import { computed, markRaw, onBeforeUnmount, watch } from 'vue'
-import { setPlaceTransitLines } from '@/composables/usePlaceTransitLines'
+import { setPlaceTransitLines, usePlaceTransferLines, type StationLine } from '@/composables/usePlaceTransitLines'
 import { useI18n } from 'vue-i18n'
 import type { Place, TransitDeparture, TransitStopInfo } from '@/types/place.types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -25,6 +25,7 @@ import {
   type RouteGroup,
 } from '@/lib/transit-departures'
 import { formatDepartureTime, getMinutesUntil, getRouteBulletLabel } from '@/lib/transit'
+import StationTransfers from '@/components/transit/StationTransfers.vue'
 import PlaceTransitPage from '@/components/place/pages/PlaceTransitPage.vue'
 import { useRouter } from 'vue-router'
 import { AppRoute } from '@/router'
@@ -167,8 +168,15 @@ function openFullTransit() {
 }
 
 function openRouteDetail(group: RouteGroup) {
+  openRoute(group.route.id)
+}
+
+/** Lines reached by an in-station transfer — their own section below the
+ *  board, because they do not depart from here. */
+const transferLines = usePlaceTransferLines(computed(() => props.place?.id))
+
+function openRoute(routeId?: string) {
   const feedId = transitInfo.value?.feedId
-  const routeId = group.route.id
   if (!feedId || !routeId) return
 
   router.push({
@@ -248,6 +256,14 @@ function openRouteDetail(group: RouteGroup) {
       <div v-else class="py-4 text-center text-sm text-muted-foreground">
         {{ t('place.transit.noUpcomingDepartures') }}
       </div>
+
+      <StationTransfers
+        :lines="transferLines"
+        :lat="transitInfo?.lat"
+        :lng="transitInfo?.lng"
+        :feed-id="transitInfo?.feedId"
+        @open="(line: StationLine) => openRoute(line.id)"
+      />
 
       <!-- Agency attribution -->
       <div v-if="agencyName" class="mt-3 pt-2 border-t text-xs text-muted-foreground">

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -15,6 +15,8 @@ import { api } from '@/lib/api'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useTransitClock } from '@/composables/useTransitClock'
 import { groupDepartures, type BoardDeparture } from '@/lib/transit-departures'
+import { transferLinesOf, type StationLine } from '@/composables/usePlaceTransitLines'
+import StationTransfers from '@/components/transit/StationTransfers.vue'
 import {
   formatDepartureTime,
   getMinutesUntil,
@@ -66,6 +68,16 @@ watch(
 )
 const styleOfRoute = (route: { id: string; type?: number }) =>
   bulletFor(route.id, props.transitInfo?.lat, props.transitInfo?.lng, route.type)
+
+/** Lines an in-station transfer reaches — listed below the board, since they
+ *  do not depart from here. */
+const transferLines = computed(() => transferLinesOf(props.transitInfo?.routes))
+
+function openRoute(routeId?: string) {
+  const feedId = props.transitInfo?.feedId
+  if (!feedId || !routeId) return
+  router.push({ name: AppRoute.TRANSIT_ROUTE, params: { feedId, routeId } })
+}
 
 const routeGroups = computed(() =>
   groupDepartures(departures.value, currentTime.value, {
@@ -267,6 +279,15 @@ function openTransitlandLink() {
       <p class="text-sm">{{ t('place.transit.noUpcomingDepartures') }}</p>
       <p class="text-xs mt-1">{{ t('place.transit.checkBackLater') }}</p>
     </div>
+
+    <StationTransfers
+      :lines="transferLines"
+      :lat="transitInfo?.lat"
+      :lng="transitInfo?.lng"
+      :feed-id="transitInfo?.feedId"
+      class="mt-6"
+      @open="(line: StationLine) => openRoute(line.id)"
+    />
 
     <!-- Footer -->
     <div class="mt-6 pt-3 border-t space-y-2 text-xs text-muted-foreground">

--- a/web/src/components/transit/StationTransfers.vue
+++ b/web/src/components/transit/StationTransfers.vue
@@ -1,0 +1,70 @@
+<script setup lang="ts">
+/**
+ * Lines a rider reaches from this station without leaving the paid area.
+ *
+ * Its own section, below the departures, because it answers a different
+ * question from the board above it. These trains do not depart from here —
+ * the J and Z at Brooklyn Bridge–City Hall are one connection away at
+ * Chambers St — so they carry no times, and no "isn't running" state: what
+ * this section asserts is that the transfer exists, which is all the
+ * agency's transfers.txt tells us.
+ *
+ * Membership comes from Barrelman, which marks each line `station` or
+ * `transfer`. A free transfer bought by a fare rule rather than a walk
+ * between platforms is not published there, so it is not claimed here.
+ */
+import { useI18n } from 'vue-i18n'
+import RouteBullet from '@/components/transit/RouteBullet.vue'
+import { bulletFor } from '@/services/layers/features/portolan/portolan-bullets'
+import { getRouteBulletLabel } from '@/lib/transit'
+import type { StationLine } from '@/composables/usePlaceTransitLines'
+
+const props = defineProps<{
+  lines: StationLine[]
+  /** The station's coordinates — portolan's bullets are resolved against the
+   *  pyramid covering this point, so a Brooklyn 4 is not a Long Island one. */
+  lat?: number
+  lng?: number
+  /** Absent when the board never named its feed; a bullet is then inert. */
+  feedId?: string
+}>()
+
+const emit = defineEmits<{ (e: 'open', line: StationLine): void }>()
+
+const { t } = useI18n()
+
+const styleOf = (line: StationLine) => bulletFor(line.id, props.lat, props.lng, line.type)
+</script>
+
+<template>
+  <section v-if="lines.length" class="mt-3 pt-3 border-t">
+    <h3 class="text-sm font-medium mb-2">{{ t('place.transit.transfers') }}</h3>
+    <p class="text-xs text-muted-foreground mb-2">
+      {{ t('place.transit.transfersHint') }}
+    </p>
+
+    <ul class="space-y-1.5">
+      <li v-for="line in lines" :key="line.id">
+        <component
+          :is="feedId ? 'button' : 'div'"
+          class="flex items-center gap-2 w-full text-left"
+          :class="feedId && 'group/transfer cursor-pointer'"
+          @click="feedId && emit('open', line)"
+        >
+          <RouteBullet
+            :label="styleOf(line)?.label || getRouteBulletLabel(line, t)"
+            :color="styleOf(line)?.color || line.color"
+            :shape="styleOf(line)?.shape"
+            :text-color="styleOf(line)?.color ? null : line.textColor"
+            class="group-hover/transfer:ring-2 ring-offset-1 ring-foreground/20 transition-shadow"
+          />
+          <span
+            class="text-sm text-muted-foreground truncate group-hover/transfer:text-foreground transition-colors"
+          >
+            {{ line.longName || line.shortName }}
+          </span>
+        </component>
+      </li>
+    </ul>
+  </section>
+</template>

--- a/web/src/composables/usePlaceTransitLines.ts
+++ b/web/src/composables/usePlaceTransitLines.ts
@@ -33,6 +33,10 @@ export interface StationLinesContext {
  * 1 2 A B C D here while the map drew A C · B D · 1 2, which is the order
  * the MTA and Apple both use. Sorting on the way OUT rather than the way
  * in means every subscriber gets it, whatever published the lines.
+ *
+ * Read as two lists, because they answer different questions: the lines the
+ * station runs, and the lines a transfer reaches. Only the first belongs
+ * beside the title.
  */
 type Entry = { routes: StationRoute[]; running: Set<string>; ctx: StationLinesContext }
 
@@ -60,31 +64,57 @@ export function setPlaceTransitLines(
   }
 }
 
+/** Bullet-order input: the glyphs portolan sorts by are the bullet's own —
+ *  short name, long name if there is none. Not parchment's translated mode
+ *  fallback ("Tram"), which would sort by the UI language. */
+const bulletOf = (r: StationRoute) => ({
+  label: r.shortName || r.longName || '',
+  color: r.color,
+  id: r.id,
+})
+
+/**
+ * The lines this station runs.
+ *
+ * Only its own: a line reachable by transfer does not depart from here, and
+ * putting it in this row made the header lie twice over. The row dims a bullet
+ * whose line has no run on the board — which is honest for a line that stops
+ * here and simply isn't running — but a transfer line has no run on this
+ * board by construction, so every one of them rendered as "isn't running now"
+ * while the trains were in fact turning up one platform away.
+ */
 export function usePlaceTransitLines(placeId: Ref<string | undefined>) {
   return computed<StationLine[]>(() => {
     const entry = placeId.value ? byPlace[placeId.value] : undefined
     if (!entry) return []
-    const bullet = (r: StationRoute) => ({
-      // the label portolan sorts by is the bullet's own glyphs — short
-      // name, long name if there is none. Not parchment's translated
-      // mode fallback ("Tram"), which would sort by the UI language.
-      label: r.shortName || r.longName || '',
-      color: r.color,
-      id: r.id,
-    })
-    // Lines the station runs come before the ones a transfer reaches — the J
-    // and Z are how a rider leaves Brooklyn Bridge–City Hall without paying
-    // twice, and they still aren't its own. Bullet order applies inside each
-    // group; one sort across both would interleave them.
-    const ordered = [
-      ...orderBullets(entry.routes.filter(r => r.via !== 'transfer'), bullet),
-      ...orderBullets(entry.routes.filter(r => r.via === 'transfer'), bullet),
-    ]
-    return ordered.map(r => ({
+    const own = entry.routes.filter(r => r.via !== 'transfer')
+    return orderBullets(own, bulletOf).map(r => ({
       ...r,
       inService: !entry.ctx.known || entry.running.has(r.id),
     }))
   })
+}
+
+/**
+ * The lines a rider reaches from here without leaving the paid area — the J
+ * and Z at Chambers St, from Brooklyn Bridge–City Hall.
+ *
+ * Never marked out of service. The board that would answer that question is
+ * the connecting station's, not this one's, so the honest answer here is to
+ * say the transfer exists and stop there.
+ */
+export function usePlaceTransferLines(placeId: Ref<string | undefined>) {
+  return computed<StationLine[]>(() => {
+    const entry = placeId.value ? byPlace[placeId.value] : undefined
+    return entry ? transferLinesOf(entry.routes) : []
+  })
+}
+
+/** The same split off a raw route list, for a view holding the board's own
+ *  `transitInfo` rather than a place id. */
+export function transferLinesOf(routes: StationRoute[] | undefined): StationLine[] {
+  const reached = (routes ?? []).filter(r => r.via === 'transfer')
+  return orderBullets(reached, bulletOf).map(r => ({ ...r, inService: true }))
 }
 
 /** The board's own context — feed and window — for the same place. */

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -1060,7 +1060,9 @@
       },
       "notInService": "Not running now",
       "openRouteDetail": "Show {name}",
-      "notInServiceNamed": "{name} isn't running now"
+      "notInServiceNamed": "{name} isn't running now",
+      "transfers": "Transfers",
+      "transfersHint": "Reachable from this station without exiting"
     },
     "header": {
       "showMore": "Show more",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -1011,7 +1011,9 @@
       },
       "notInService": "No circula ahora",
       "openRouteDetail": "Ver {name}",
-      "notInServiceNamed": "{name} no circula ahora"
+      "notInServiceNamed": "{name} no circula ahora",
+      "transfers": "Transbordos",
+      "transfersHint": "Accesibles desde esta estación sin salir"
     },
     "header": {
       "showMore": "Ver más",


### PR DESCRIPTION
Fixes a bug I introduced in #430.

## The problem

`inService` is derived from the departure board — a bullet dims when its line has no run on it. #430 put transfer lines in that row, and barrelman#81 made the board carry only the station's own lines. So every transfer line had nothing on the board *by construction* and rendered "isn't running now", while those trains were arriving one platform away.

At Chambers Street that meant all six bullets — J, Z, 4, 5, 6, 6X — reading as not running.

## What changed

**Header** — only lines that stop here. Transfer lines are no longer in that row, so nothing can falsely dim them.

**New Transfers section**, below the departures in both the place card and the full transit page:

```
Transfers
Reachable from this station without exiting
 (J)  Nassau St Local
 (Z)  Nassau St Express
```

Never dimmed. The board that could answer "is the J running" is Chambers St's, not this station's, so the only honest claim here is that the transfer exists — which is exactly what `transfers.txt` tells us. Bullets link through to route detail like the departure headers do.

`usePlaceTransitLines` now returns the station's own lines; `usePlaceTransferLines` (and `transferLinesOf`, for the page that holds `transitInfo` rather than a place id) returns the reachable ones.

## Verified on a preview against production barrelman

Brooklyn Bridge–City Hall renders:

```
header:     4  5  6  6X
departures: 4 Lexington Avenue Express …
Transfers:  Reachable from this station without exiting
            (J) Nassau St Local   (Z) Nassau St Express
```

and the widget payload splits `station: [4,5,6,6X]` / `transfer: [J,Z]`. Chambers Street is the exact inverse (`station: [J,Z]`, `transfer: [4,5,6,6X]`).

`vue-tsc` clean, 213 web tests pass, strings added in en-US and es-ES.

## Not included

Apple groups its Connections card under the connecting station's name. `/transit/routes` marks a route as a transfer but doesn't say *which* station it calls at, so that needs a barrelman change first — happy to follow up.