### PR TITLE
Globe view on MapLibre

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@
 
 * The map keeps up with the sidebar as it is dragged or collapsed, resizing frame by frame rather than snapping once the panel has settled
 * Centring on a place, or fitting a route, no longer aims too far to the right when a panel is open over the map. The gutter the map was told to leave on the left included the sidebar's width a second time, even though the map never extended under it — worse the wider the sidebar
+* The globe sits in the middle of the map when a panel is open. That same gutter moves the point the map is centred on off the middle of the screen, which a flat map hides and a globe cannot, so it is dropped while the globe is on screen
 
 ## [0.8.3] - 2026-09-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+* The MapLibre engine can now draw the map on a globe. The map projection setting applies to both engines, offering flat and globe on MapLibre and the full list on Mapbox
+
 ### Changed
 
 * The desktop sidebar has been rebuilt. Rows sit on an even grid at full contrast, the current one is marked by a single raised chip that slides between them, and collapsing or expanding the rail now glides instead of snapping — with the map resizing in step

--- a/web/src/components/map/Map.vue
+++ b/web/src/components/map/Map.vue
@@ -170,6 +170,24 @@ watch(
   outline: none;
 }
 
+/*
+ * What sits behind the globe.
+ *
+ * MapLibre's atmosphere leaves everything past its own glow transparent, so
+ * the page shows through around the sphere. A flat map covers the canvas edge
+ * to edge, which is why this is only ever visible under the globe projection.
+ * The colours are the basemap's own land and night sky rather than a
+ * photographic space, so the globe reads as sitting on the map's paper by day
+ * and in its own dark by night.
+ */
+.maplibregl-canvas-container {
+  background: hsl(44, 52%, 95%);
+}
+
+.dark .maplibregl-canvas-container {
+  background: hsl(217, 45%, 10%);
+}
+
 .mapboxgl-ctrl-scale,
 .maplibregl-ctrl-scale {
   font-weight: 700;

--- a/web/src/components/map/Map.vue
+++ b/web/src/components/map/Map.vue
@@ -173,12 +173,13 @@ watch(
 /*
  * What sits behind the globe.
  *
- * MapLibre's atmosphere leaves everything past its own glow transparent, so
- * the page shows through around the sphere. A flat map covers the canvas edge
- * to edge, which is why this is only ever visible under the globe projection.
- * The colours are the basemap's own land and night sky rather than a
- * photographic space, so the globe reads as sitting on the map's paper by day
- * and in its own dark by night.
+ * MapLibre draws nothing outside the sphere — the atmosphere that would
+ * otherwise halo it is off, because it doubles the day/night layer's
+ * terminator (see `SKY` in `map-style/build`) — so the page shows through
+ * around it. A flat map covers the canvas edge to edge, which is why this is
+ * only ever visible under the globe projection. The colours are the basemap's
+ * own land and night sky rather than a photographic space, so the globe reads
+ * as sitting on the map's paper by day and in its own dark by night.
  */
 .maplibregl-canvas-container {
   background: hsl(44, 52%, 95%);

--- a/web/src/components/map/map-providers/map.strategy.ts
+++ b/web/src/components/map/map-providers/map.strategy.ts
@@ -138,6 +138,19 @@ export class MapStrategy {
   setPlaceLabels(value: boolean) {}
   setLandmarkIcons(value: boolean) {}
   setMapProjection(projection: MapProjection) {}
+
+  /**
+   * Whether a sphere is on screen — not the same question as whether the globe
+   * projection is selected. Both engines ease the globe into Mercator as you
+   * zoom in, at zooms of their own, so a globe map is a flat map everywhere a
+   * street is legible.
+   *
+   * Anything that only makes sense against a flat map asks this. False here
+   * because a strategy with no globe never draws one.
+   */
+  isGlobeRendering(): boolean {
+    return false
+  }
   /**
    * Draw the top-down view orthographically rather than in perspective, so a
    * flat-on view has no vanishing point: building walls stop splaying outward

--- a/web/src/components/map/map-providers/mapbox.strategy.ts
+++ b/web/src/components/map/map-providers/mapbox.strategy.ts
@@ -57,6 +57,18 @@ import { useThemeStore } from '@/stores/theme.store'
 import { useMapToolsStore } from '@/stores/map-tools.store'
 import { getPrimaryThemeHex, adjustLightness, cssHslToHex } from '@/lib/utils'
 
+/**
+ * The zoom at which the globe has finished becoming a flat map.
+ *
+ * Mapbox interpolates the two across `globeToMercatorTransition`, a smoothstep
+ * from zoom 5 to zoom 6, rather than drawing a sphere at every zoom. Past this
+ * point a globe map and a Mercator map are the same map.
+ *
+ * MapLibre holds its sphere a good deal longer — see `GLOBE_FLATTENS_AT` in
+ * its strategy — so each engine keeps its own number rather than sharing one.
+ */
+const GLOBE_FLATTENS_AT = 6
+
 const basemapUrls: {
   [key in Basemap]: string
 } = {
@@ -569,7 +581,20 @@ export class MapboxStrategy extends MapStrategy {
   }
 
   setMapProjection(projection: MapProjection) {
+    this.options.projection = projection
     this.mapInstance.setProjection(projection)
+  }
+
+  /**
+   * Mapbox eases the globe into Mercator across `GLOBE_FLATTENS_AT`, so past
+   * that zoom a globe map is a flat map and the sphere is only on screen
+   * below it.
+   */
+  override isGlobeRendering(): boolean {
+    return (
+      this.options.projection === MapProjection.GLOBE &&
+      this.mapInstance.getZoom() < GLOBE_FLATTENS_AT
+    )
   }
 
   /**

--- a/web/src/components/map/map-providers/maplibre.strategy.ts
+++ b/web/src/components/map/map-providers/maplibre.strategy.ts
@@ -13,6 +13,7 @@ import {
   CameraOptions,
   setWorkerUrl,
 } from 'maplibre-gl'
+import type { StyleSpecification } from 'maplibre-gl'
 import 'maplibre-gl/dist/maplibre-gl.css'
 // MapLibre 6 is ESM-only and loads its worker from a URL it computes at
 // runtime, relative to its own `import.meta.url`. A bundler cannot see that as
@@ -68,6 +69,7 @@ import {
   buildMapStyle,
   buildSatelliteStyle,
   layerGroups,
+  maplibreProjection,
   MAX_PITCH,
   BUILDING_HEIGHT_EXPRESSION,
   BUILDING_BASE_EXPRESSION,
@@ -185,11 +187,13 @@ const ORTHO_FOV = 0.5
 const ORTHO_NEAR = 0.5
 const ORTHO_FAR = 2
 
-/** The internal transform surface `updateClipPlanes` needs. */
-interface OverridableTransform {
+/** The internal transform surface the camera work needs. */
+interface InternalTransform {
   cameraToCenterDistance: number
   autoCalculateNearFarZ: boolean
   nearZ: number
+  /** Set on the globe transform only; see `isGlobeRendering`. */
+  isGlobeRendering?: boolean
   overrideNearFarZ?: (near: number, far: number) => void
   clearNearFarZOverride?: () => void
 }
@@ -375,6 +379,11 @@ export class MaplibreStrategy extends MapStrategy {
     // The plan view's clip planes are scaled by a camera distance that moves
     // with the viewport height, so a resize has to recompute them.
     this.mapInstance.on('resize', () => this.updateCameraProjection())
+    // Under the globe, zoom is what decides whether a sphere or a flat map is
+    // being drawn — and so whether the plan view gets its camera. The setters
+    // inside are all guarded on the answer changing, so the frames where it
+    // does not cost a couple of reads.
+    this.mapInstance.on('zoom', () => this.updateCameraProjection())
     // A quarter of a degree a minute: five is far finer than the eye needs and
     // costs one trig evaluation.
     this.sunTimer = setInterval(() => this.updateSunShadow(), 5 * 60 * 1000)
@@ -963,6 +972,19 @@ export class MaplibreStrategy extends MapStrategy {
   }
 
   /**
+   * Flat or round. MapLibre animates between the two in place, so unlike a
+   * theme or basemap change this needs no style rebuild — `buildCurrentStyle`
+   * carries the setting only so a later rebuild does not undo it.
+   */
+  override setMapProjection(projection: MapProjection) {
+    this.options.projection = projection
+    this.mapInstance.setProjection({ type: maplibreProjection(projection) })
+    // The plan-view camera depends on which of the two is being drawn, and
+    // this switch goes through neither pitch nor style load.
+    this.updateCameraProjection()
+  }
+
+  /**
    * Swap the map style and fire style.load so downstream services can
    * re-register their custom layers.
    *
@@ -997,6 +1019,37 @@ export class MaplibreStrategy extends MapStrategy {
   }
 
   /**
+   * The live transform, which is where everything the camera API does not
+   * reach lives.
+   *
+   * The transit fork keeps it on `_camera` rather than having Map extend the
+   * camera; plain MapLibre exposes it on the map itself. Try both, so the
+   * reach survives either layout.
+   */
+  private transform(): InternalTransform | undefined {
+    const instance = this.mapInstance as unknown as {
+      _camera?: { transform?: InternalTransform }
+      transform?: InternalTransform
+    }
+    return instance._camera?.transform ?? instance.transform
+  }
+
+  /**
+   * Whether a sphere is on screen right now — which is not the same question
+   * as whether the globe projection is selected. MapLibre eases the globe into
+   * Mercator between zoom 11 and 12, so a globe map is flat by the time a
+   * building is drawn, and the plan view's flattening should come back with
+   * it. Reading the transform rather than the setting is what makes that
+   * happen at the same moment the map does it.
+   *
+   * The flag is internal to the globe transform; every other transform lacks
+   * it, and reads as not-a-globe, which is exactly what it is.
+   */
+  private isGlobeRendering(): boolean {
+    return this.transform()?.isGlobeRendering === true
+  }
+
+  /**
    * MapLibre has no orthographic camera — `setVerticalFieldOfView` is the same
    * trick behind a nicer name — so this narrows the field of view instead. A
    * perspective frustum approaches an orthographic box as the FOV approaches
@@ -1009,10 +1062,12 @@ export class MaplibreStrategy extends MapStrategy {
    * far plane out with it while MapLibre holds the near plane where it is, so
    * the clip planes have to be closed back in by hand. See `ORTHO_NEAR`.
    *
-   * Applied only when the map is perfectly flat on. Any pitch at all, however
-   * slight, gets the real perspective camera back — the flattening is meant
-   * for the plan view, and a near-zero FOV on a tilted map would rob it of the
-   * depth that makes the tilt worth having.
+   * Applied only when the map is perfectly flat on, and only when it is flat
+   * at all. Any pitch, however slight, gets the real perspective camera back —
+   * the flattening is meant for the plan view, and a near-zero FOV on a tilted
+   * map would rob it of the depth that makes the tilt worth having. The globe
+   * gets it back for a blunter reason: retreating the camera a hundred screen
+   * heights from a sphere leaves the sphere a speck.
    */
   override updateCameraProjection() {
     const current = this.mapInstance.getVerticalFieldOfView()
@@ -1020,7 +1075,9 @@ export class MaplibreStrategy extends MapStrategy {
 
     // Not `=== 0`: an eased pitch animation can settle a hair off zero, and
     // the view is still flat on at a thousandth of a degree.
-    const topDown = Math.abs(this.mapInstance.getPitch()) < TOP_DOWN_EPSILON
+    const topDown =
+      !this.isGlobeRendering() &&
+      Math.abs(this.mapInstance.getPitch()) < TOP_DOWN_EPSILON
     this.updateRoofEdge()
     const wanted = topDown ? ORTHO_FOV : this.defaultFov
     // `pitch` fires continuously through a gesture; setting the field of view
@@ -1042,14 +1099,7 @@ export class MaplibreStrategy extends MapStrategy {
    * z-fighting rather than throwing on every pitch event.
    */
   private updateClipPlanes(topDown: boolean) {
-    // The transit fork keeps the camera on `_camera` rather than having Map
-    // extend it; plain MapLibre exposes `transform` on the map itself. Try
-    // both, so the reach survives either layout.
-    const instance = this.mapInstance as unknown as {
-      _camera?: { transform?: OverridableTransform }
-      transform?: OverridableTransform
-    }
-    const transform = instance._camera?.transform ?? instance.transform
+    const transform = this.transform()
     if (!transform?.overrideNearFarZ || !transform.clearNearFarZOverride) return
 
     if (!topDown) {
@@ -1092,9 +1142,9 @@ export class MaplibreStrategy extends MapStrategy {
     this.mapInstance.setStyle(this.buildCurrentStyle(), { diff: false })
   }
 
-  private buildCurrentStyle() {
+  private buildCurrentStyle(): StyleSpecification {
     if (!this.tileServerUrl) {
-      return { version: 8 as const, sources: {}, layers: [] }
+      return { version: 8, sources: {}, layers: [] } as StyleSpecification
     }
     const theme = this.options.theme === 'dark' ? 'dark' : 'light'
     const styleOpts = {
@@ -1106,14 +1156,22 @@ export class MaplibreStrategy extends MapStrategy {
       categoryColors: this.categoryColors(theme),
     }
 
-    switch (this.currentBasemap) {
-      case 'satellite':
-        return buildSatelliteStyle({ ...styleOpts, hybrid: false })
-      case 'hybrid':
-        return buildSatelliteStyle({ ...styleOpts, hybrid: true })
-      default:
-        return buildMapStyle(styleOpts)
-    }
+    const style = (() => {
+      switch (this.currentBasemap) {
+        case 'satellite':
+          return buildSatelliteStyle({ ...styleOpts, hybrid: false })
+        case 'hybrid':
+          return buildSatelliteStyle({ ...styleOpts, hybrid: true })
+        default:
+          return buildMapStyle(styleOpts)
+      }
+    })()
+
+    // MapLibre reads the projection off the style, so it has to be carried on
+    // every rebuild — a theme or basemap switch would otherwise drop a globe
+    // back to Mercator, and the initial style is where the setting first
+    // reaches the map at all.
+    return { ...style, projection: { type: maplibreProjection(this.options.projection) } }
   }
 
   setMapLanguage(locale: string): boolean {

--- a/web/src/components/map/map-providers/maplibre.strategy.ts
+++ b/web/src/components/map/map-providers/maplibre.strategy.ts
@@ -192,11 +192,19 @@ interface InternalTransform {
   cameraToCenterDistance: number
   autoCalculateNearFarZ: boolean
   nearZ: number
-  /** Set on the globe transform only; see `isGlobeRendering`. */
-  isGlobeRendering?: boolean
   overrideNearFarZ?: (near: number, far: number) => void
   clearNearFarZOverride?: () => void
 }
+
+/**
+ * The zoom at which the globe has finished becoming a flat map.
+ *
+ * MapLibre's `globe` is shorthand for an interpolation — vertical perspective
+ * at zoom 11, Mercator at 12 — rather than a sphere at every zoom. Past this
+ * point a globe map and a Mercator map are the same map, and everything
+ * written for the flat one applies again.
+ */
+const GLOBE_FLATTENS_AT = 12
 
 /** Degrees of pitch over which the plan-view roof outline fades out. */
 const ROOF_EDGE_FADE_PITCH = 8
@@ -1035,18 +1043,24 @@ export class MaplibreStrategy extends MapStrategy {
   }
 
   /**
-   * Whether a sphere is on screen right now — which is not the same question
-   * as whether the globe projection is selected. MapLibre eases the globe into
-   * Mercator between zoom 11 and 12, so a globe map is flat by the time a
-   * building is drawn, and the plan view's flattening should come back with
-   * it. Reading the transform rather than the setting is what makes that
-   * happen at the same moment the map does it.
+   * Whether a sphere is on screen — which is not the same question as whether
+   * the globe projection is selected. MapLibre eases the globe into Mercator
+   * as you zoom in, so a globe map is flat by the time a building is drawn,
+   * and the plan view's flattening has to come back with it.
    *
-   * The flag is internal to the globe transform; every other transform lacks
-   * it, and reads as not-a-globe, which is exactly what it is.
+   * Derived from zoom rather than read off the transform, which holds the same
+   * answer in `isGlobeRendering`: the transform's copy is written during
+   * render, from a zoom-dependent style property evaluated for the frame about
+   * to be drawn. Every caller here runs from an event handler — before that
+   * frame — so it would read the previous answer, and a zoom that ended on the
+   * far side of the boundary would never be reconsidered, because the events
+   * stop with the gesture. See `GLOBE_FLATTENS_AT`.
    */
   private isGlobeRendering(): boolean {
-    return this.transform()?.isGlobeRendering === true
+    return (
+      this.options.projection === MapProjection.GLOBE &&
+      this.mapInstance.getZoom() < GLOBE_FLATTENS_AT
+    )
   }
 
   /**

--- a/web/src/components/map/map-providers/maplibre.strategy.ts
+++ b/web/src/components/map/map-providers/maplibre.strategy.ts
@@ -1056,7 +1056,7 @@ export class MaplibreStrategy extends MapStrategy {
    * far side of the boundary would never be reconsidered, because the events
    * stop with the gesture. See `GLOBE_FLATTENS_AT`.
    */
-  private isGlobeRendering(): boolean {
+  override isGlobeRendering(): boolean {
     return (
       this.options.projection === MapProjection.GLOBE &&
       this.mapInstance.getZoom() < GLOBE_FLATTENS_AT

--- a/web/src/lib/map-style/build.ts
+++ b/web/src/lib/map-style/build.ts
@@ -116,6 +116,16 @@ export const MAX_PITCH = 85
  * They are not tokens — the sky is ours, not MapTiler's — so a change to the
  * ground has to be made here too, and a mismatch shows as a band of the old
  * colour along the horizon where the land runs out.
+ *
+ * `atmosphere-blend` is the globe's halo, and it is off. MapLibre scatters it
+ * from the sun, which the strategy keeps at the real one so buildings cast
+ * their shadows the right way (see `updateSunShadow`) — so switching the globe
+ * on would light one limb and darken the other, drawing a second, cruder
+ * terminator underneath the day/night layer's own. One is the map's, tuned
+ * through twilight; the other is a side effect of the shadow light. The
+ * property is scaled by the globe transition, so this changes nothing on a
+ * flat map, and the shadows themselves are untouched — buildings are drawn far
+ * past the zoom where the sphere has already flattened.
  */
 const SKY: Record<FlavorId, Record<string, string | number>> = {
   light: {
@@ -125,6 +135,7 @@ const SKY: Record<FlavorId, Record<string, string | number>> = {
     'fog-ground-blend': 0.72,
     'horizon-fog-blend': 0.6,
     'sky-horizon-blend': 0.85,
+    'atmosphere-blend': 0,
   },
   dark: {
     'sky-color': 'hsl(217, 45%, 10%)',
@@ -133,6 +144,7 @@ const SKY: Record<FlavorId, Record<string, string | number>> = {
     'fog-ground-blend': 0.72,
     'horizon-fog-blend': 0.6,
     'sky-horizon-blend': 0.85,
+    'atmosphere-blend': 0,
   },
 }
 

--- a/web/src/lib/map-style/build.ts
+++ b/web/src/lib/map-style/build.ts
@@ -1,5 +1,6 @@
 import type { LayerSpecification, StyleSpecification } from 'maplibre-gl'
 import type { MapStyleId } from '@/types/map.types'
+import { MapProjection } from '@/types/map.types'
 import { getCustomColorTint } from '@/lib/color-tint'
 import spec from './spec.json'
 import {
@@ -133,6 +134,27 @@ const SKY: Record<FlavorId, Record<string, string | number>> = {
     'horizon-fog-blend': 0.6,
     'sky-horizon-blend': 0.85,
   },
+}
+
+/**
+ * The projection setting, in the two shapes MapLibre can draw.
+ *
+ * MapLibre projects onto a flat Mercator plane or onto a sphere, and nothing
+ * else — the rest of the setting's list is Mapbox's. `globe` is not a fixed
+ * sphere either: MapLibre eases it into Mercator between zoom 11 and 12, so a
+ * globe map is the same flat map as a Mercator one everywhere a street is
+ * legible, and the sphere is what you get on the way out.
+ *
+ * `ENGINE_PROJECTIONS` keeps the Mapbox-only projections out of MapLibre's
+ * picker, so they should never arrive here — but a setting carried over from
+ * the other engine can, and Mercator is the honest answer for those. Handing
+ * MapLibre the name itself would only get a console warning and the same
+ * fallback, one frame later.
+ */
+export function maplibreProjection(
+  projection?: MapProjection,
+): 'globe' | 'mercator' {
+  return projection === MapProjection.GLOBE ? 'globe' : 'mercator'
 }
 
 /** Self-hosted; see `scripts/build-glyphs.mjs` and `scripts/build-sprite.mjs`. */

--- a/web/src/lib/map-style/index.ts
+++ b/web/src/lib/map-style/index.ts
@@ -11,6 +11,7 @@ export {
   buildMapStyle,
   buildSatelliteStyle,
   buildLayers,
+  maplibreProjection,
   layerGroups,
   SOURCE,
   MAX_PITCH,

--- a/web/src/lib/map-style/map-style.test.ts
+++ b/web/src/lib/map-style/map-style.test.ts
@@ -20,6 +20,7 @@ import {
   SOURCE,
   BUILDING_3D_ROOF_LAYER,
   BUILDING_ROOF_EDGE_LAYER,
+  maplibreProjection,
 } from './build'
 import { BUILDING_3D_SOURCE, BUILDING_3D_TILES } from './detail-layers'
 import { setBarrelmanBuildingsReady } from './barrelman-buildings'
@@ -29,6 +30,7 @@ import { BUILDING_TINT } from './building-color.mjs'
 import { terrainSource } from './terrain'
 import { TREE_OPACITY } from './detail-layers'
 import { getCustomColorTint } from '@/lib/color-tint'
+import { ENGINE_PROJECTIONS, MapEngine, MapProjection } from '@/types/map.types'
 import lightTokens from './tokens.light.json'
 import darkTokens from './tokens.dark.json'
 
@@ -1149,5 +1151,35 @@ describe('assets the spec depends on', () => {
     expect(
       TRANSIT_POI_CLASSES.filter(c => names.includes(c) && !(`tile-${c}` in sprite)),
     ).toEqual([])
+  })
+})
+
+/**
+ * MapLibre draws two of the projections the setting offers. These pin down
+ * which two, and that the picker never offers a choice the map cannot honour.
+ */
+describe('projection', () => {
+  test('the sphere is the only thing that is not Mercator', () => {
+    expect(maplibreProjection(MapProjection.GLOBE)).toBe('globe')
+    expect(maplibreProjection(MapProjection.MERCATOR)).toBe('mercator')
+    expect(maplibreProjection(undefined)).toBe('mercator')
+  })
+
+  test("Mapbox's own projections fall back rather than reaching MapLibre", () => {
+    const mapboxOnly = Object.values(MapProjection).filter(
+      p => !ENGINE_PROJECTIONS[MapEngine.MAPLIBRE].includes(p),
+    )
+    expect(mapboxOnly.length).toBeGreaterThan(0)
+    expect(mapboxOnly.map(maplibreProjection)).toEqual(mapboxOnly.map(() => 'mercator'))
+  })
+
+  /**
+   * Two entries in the picker that draw the same thing would read as a setting
+   * that does nothing, which is how the Mapbox-only projections behaved here
+   * before they were filtered out of it.
+   */
+  test("every projection MapLibre is offered draws something different", () => {
+    const offered = ENGINE_PROJECTIONS[MapEngine.MAPLIBRE]
+    expect(new Set(offered.map(maplibreProjection)).size).toBe(offered.length)
   })
 })

--- a/web/src/lib/map-style/map-style.test.ts
+++ b/web/src/lib/map-style/map-style.test.ts
@@ -1174,6 +1174,22 @@ describe('projection', () => {
   })
 
   /**
+   * MapLibre scatters the globe's halo from the style's light, which the
+   * strategy keeps pointed at the real sun for building shadows — so a halo
+   * lights one limb of the globe and darkens the other, under the day/night
+   * layer's own terminator. Off in every style that has a sky.
+   */
+  test('no atmosphere doubles the day/night layer', () => {
+    const styles = [
+      buildMapStyle({ ...opts, theme: 'light' } as any),
+      buildMapStyle({ ...opts, theme: 'dark' } as any),
+      buildSatelliteStyle({ ...opts, hybrid: false } as any),
+      buildSatelliteStyle({ ...opts, hybrid: true } as any),
+    ]
+    expect(styles.map(s => s.sky?.['atmosphere-blend'])).toEqual([0, 0, 0, 0])
+  })
+
+  /**
    * Two entries in the picker that draw the same thing would read as a setting
    * that does nothing, which is how the Mapbox-only projections behaved here
    * before they were filtered out of it.

--- a/web/src/services/map.service.ts
+++ b/web/src/services/map.service.ts
@@ -257,6 +257,8 @@ function mapService() {
   // Tracks per-zoom state that is closed over by a 'move' listener.
   // Scoped to the module so that rebinding on engine switch resets it cleanly.
   let previousZoom: number | null = null
+  /** Last known globe state, so padding is only reset when it flips. */
+  let wasGlobeRendering: boolean | null = null
 
   /**
    * Bind all mapEventBus listeners used by the service.
@@ -314,6 +316,18 @@ function mapService() {
           }
         }, CONTROL_HIDE_DELAY)
       }
+    })
+
+    // Whether padding applies depends on the globe being on screen, and that
+    // answer changes with zoom alone — no panel moves, so nothing else would
+    // re-run it. Only on the crossing: `setPadding` rebuilds every matrix, and
+    // `move` fires continuously through a gesture.
+    wasGlobeRendering = null
+    mapEventBus.on('move', () => {
+      const globe = mapStrategy?.isGlobeRendering() ?? false
+      if (globe === wasGlobeRendering) return
+      wasGlobeRendering = globe
+      updateMapPadding()
     })
 
     // Track zoom state for conditional control visibility
@@ -692,7 +706,7 @@ function mapService() {
       }
 
       // Set padding to ensure the camera operation respects the visible area
-      adjustedCamera.padding = paddingResult.padding
+      adjustedCamera.padding = effectiveMapPadding() ?? paddingResult.padding
       return adjustedCamera
     } catch (error) {
       console.warn('Error adjusting camera for visible map area:', error)
@@ -1056,10 +1070,33 @@ function mapService() {
   function updateMapPadding() {
     if (!mapStrategy || !mapContainer || !isMapReady.value) return
 
-    const paddingResult = calculateMapPadding()
-    if (!paddingResult) return
+    const padding = effectiveMapPadding()
+    if (!padding) return
 
-    mapStrategy.mapInstance?.setPadding(paddingResult.padding as any)
+    mapStrategy.mapInstance?.setPadding(padding as any)
+  }
+
+  /**
+   * The padding the map should be using right now.
+   *
+   * Normally the visible area's, so the point the map is centred on stays out
+   * from behind a panel. Zeroed while a sphere is on screen: padding works by
+   * moving the focal point off the middle of the viewport, which is invisible
+   * on a flat map that covers the canvas edge to edge, and glaring on a globe,
+   * which is a discrete object with an obvious centre — a 400px panel leaves
+   * it sitting 200px right of the middle.
+   *
+   * Nothing is lost by dropping it there. Padding exists to keep a place from
+   * landing under a panel, and both engines have flattened to Mercator long
+   * before the zoom at which you would be looking at one.
+   */
+  function effectiveMapPadding(): MapCamera['padding'] | null {
+    const result = calculateMapPadding()
+    if (!result) return null
+    if (mapStrategy?.isGlobeRendering()) {
+      return { top: 0, bottom: 0, left: 0, right: 0 }
+    }
+    return result.padding
   }
 
   // Watch for changes in the visible map area and apply padding immediately.

--- a/web/src/services/map.service.ts
+++ b/web/src/services/map.service.ts
@@ -1,4 +1,5 @@
 import {
+  ENGINE_PROJECTIONS,
   MapCamera,
   MapEngine,
   MapProjection,
@@ -855,6 +856,13 @@ function mapService() {
     isMapReady.value = false // Reset map ready state
     queuedTrips.value = null // Clear any queued trips
     mapStore.settings.engine = mapEngine
+
+    // The two engines draw different sets of projections. Carrying a
+    // Mapbox-only one into MapLibre would leave the setting naming a shape the
+    // map is not drawing, and its picker with nothing selected.
+    if (!ENGINE_PROJECTIONS[mapEngine].includes(mapStore.settings.projection)) {
+      mapStore.settings.projection = MapProjection.MERCATOR
+    }
 
     // Only initialize map if we have a container
     if (!mapContainer) {

--- a/web/src/stores/command.store.ts
+++ b/web/src/stores/command.store.ts
@@ -26,7 +26,7 @@ import { useMapService } from '@/services/map.service'
 import { useI18n } from 'vue-i18n'
 import { useAuthService } from '@/services/auth.service'
 import { PermissionId } from '@/types/auth.types'
-import { MapEngine, MapProjection } from '@/types/map.types'
+import { ENGINE_PROJECTIONS, MapEngine } from '@/types/map.types'
 import { useSearchService } from '@/services/search.service'
 import { useCommandService } from '@/services/command.service'
 import { getCategoryColor } from '@/lib/place-colors'
@@ -583,7 +583,6 @@ export const useCommandStore = defineStore('command', () => {
       },
       {
         id: CommandName.MAP_PROJECTION,
-        engine: [MapEngine.MAPBOX],
         name: t('palette.commands.mapProjection.name'),
         description: t('palette.commands.mapProjection.description'),
         icon: GlobeIcon,
@@ -595,12 +594,15 @@ export const useCommandStore = defineStore('command', () => {
             name: t('palette.commands.mapProjection.arguments.projection.name'),
             type: 'string',
             getItems() {
-              return Object.values(MapProjection).map(projection => ({
-                value: projection,
-                name: t(
-                  `palette.commands.mapProjection.arguments.projection.values.${projection}`,
-                ),
-              }))
+              // Both engines project, but not into the same set of shapes.
+              return ENGINE_PROJECTIONS[settings.value.engine].map(
+                projection => ({
+                  value: projection,
+                  name: t(
+                    `palette.commands.mapProjection.arguments.projection.values.${projection}`,
+                  ),
+                }),
+              )
             },
           },
         ],

--- a/web/src/types/map.types.ts
+++ b/web/src/types/map.types.ts
@@ -36,6 +36,19 @@ export enum MapProjection {
   LAMBERT_CONFORMAL_CONIC = 'lambertConformalConic',
 }
 
+/**
+ * Which projections each engine can actually draw.
+ *
+ * Mapbox has the whole list. MapLibre has two — a flat Mercator plane and a
+ * sphere — and warns and falls back to Mercator when handed anything else, so
+ * the Mapbox-only projections are kept out of its picker rather than offered
+ * and quietly ignored.
+ */
+export const ENGINE_PROJECTIONS: Record<MapEngine, MapProjection[]> = {
+  [MapEngine.MAPBOX]: Object.values(MapProjection),
+  [MapEngine.MAPLIBRE]: [MapProjection.MERCATOR, MapProjection.GLOBE],
+}
+
 export enum MapTheme {
   LIGHT = 'light',
   DARK = 'dark',


### PR DESCRIPTION
Adds globe support to the MapLibre engine and wires it into the existing map
projection setting, which was Mapbox-only until now.

MapLibre projects onto a flat Mercator plane or onto a sphere, and nothing
else, so its picker offers those two while Mapbox keeps the full list.
`ENGINE_PROJECTIONS` records which engine can draw what; the command store
filters its options through it, which covers both the command palette and the
settings page since they read the same source. Switching engines while on a
Mapbox-only projection falls back to Mercator, so the setting never names a
shape the map is not drawing.

### The globe is not a sphere at every zoom

Both engines ease the globe into Mercator as you zoom in — MapLibre across
zoom 11–12, Mapbox across 5–6 — so a globe map is a flat map everywhere a
street is legible. Two things had to follow that rather than the setting:

* **The orthographic plan view.** Narrowing the field of view to 0.5° retreats
  the camera ~115 screen heights, which on a sphere leaves the sphere a speck.
  It now stands down while the globe is on screen and comes back with the flat
  map. Reading MapLibre's own `isGlobeRendering` off the transform does not
  work here: that flag is written during render, so an event handler reads the
  previous frame, and a zoom that ends past the boundary is never reconsidered.
  It is derived from zoom instead.
* **Panel padding.** The map leaves room so a searched place does not land
  under an open panel, which moves the focal point off the middle of the
  viewport. A flat map covers the canvas edge to edge and hides that; a globe
  is a discrete object with an obvious centre, and a 400px panel left it
  sitting 200px right of the middle. Padding is dropped while a sphere is on
  screen and restored when it flattens — nothing is lost, since both engines
  are flat long before the zoom where a panel matters. This fixes the shipped
  Mapbox globe too, not just the new one.

### Atmosphere

MapLibre scatters the globe's halo from the style's `light`, which the strategy
keeps pointed at the real sun so buildings cast their shadows the right way. On
a globe that lights one limb and darkens the other — a second, cruder
terminator under the day/night layer's own tuned twilight ramp. `atmosphere-blend`
is off. Building shadows are untouched.

With no halo, MapLibre draws nothing outside the sphere, so there is a backdrop
behind it: the basemap's own land tone by day, its night sky by dark.

### Verification

Typecheck clean, 1698 tests pass (4 new, in `map-style.test.ts`). Measured on
the running app rather than inferred:

| state | projection | plan-view FOV | padding | centre vs. midpoint |
|---|---|---|---|---|
| zoom 2.5, globe | `{type: 'globe'}`, sphere rendering | 36.87° (default) | zeroed | 614 vs. 613.5 |
| zoom 16, globe selected | flattened to Mercator | 0.5° + clip planes | restored | — |

The evaluated sky property reads `atmosphere-blend: 0`, not just the stylesheet.

The table above was measured before the rebase onto #431. Since then the dev
machine's barrelman tile source has been returning 502, so the map never
reaches `load`, `isMapReady` stays false, and `updateMapPadding` early-returns
— which makes the padding path (the app's own visible-area watcher included)
impossible to exercise there. The post-rebase checks are therefore static:
typecheck, the full suite, and that the merge kept `toContainerRect` at all
three call sites. The padding behaviour itself wants one more look on a machine
with tiles. No screenshot for the same reason.

### Two things worth knowing

* **Padding snaps rather than fades** at the crossing, so zooming in through
  zoom 12 with a wide panel open shifts the map by half the panel width in one
  frame. Scaling padding by the transition instead of switching on it would
  smooth this out; both engines expose the ramp. Left out as it is a contained
  follow-up.
* **Rebased on top of #431**, which fixed a separate cause of the same
  off-centre symptom — obstruction bounds are viewport-space while the map
  container is a flex sibling of the sidebar, so the sidebar was counted twice.
  The two compose: that fix corrects the padding value, this one drops padding
  altogether while a sphere is on screen. `effectiveMapPadding` wraps
  `calculateMapPadding`, so it inherits `toContainerRect` at every call site.
* The projection setting already defaults to `globe`, so existing MapLibre
  users will see the globe when zoomed out.
