### PR TITLE
Open a merged station label as the whole complex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@
 
 ### Fixed
 
+* Tapping a station label that covers a whole interchange now opens all of it. New York draws four separate stations named "Canal St" as one symbol, and tapping it opened whichever of the four the label happened to sit on — so the panel showed two lines where the map had drawn six. Tapping a single line's marker still opens just that station
 * The map keeps up with the sidebar as it is dragged or collapsed, resizing frame by frame rather than snapping once the panel has settled
 * Centring on a place, or fitting a route, no longer aims too far to the right when a panel is open over the map. The gutter the map was told to leave on the left included the sidebar's width a second time, even though the map never extended under it — worse the wider the sidebar
 * The globe sits in the middle of the map when a panel is open. That same gutter moves the point the map is centred on off the middle of the screen, which a flat map hides and a globe cannot, so it is dropped while the globe is on screen

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -411,7 +411,7 @@ function adaptDeparture(dep: BarrelmanDeparture, timezone: string): TransitDepar
 async function fetchTransitDepartures(
   params: {
     lat: number; lng: number; feedId?: string; stopId?: string
-    routeTypes?: string; name?: string
+    routeTypes?: string; name?: string; complex?: boolean
   },
   options?: { limit?: number; windowMinutes?: number },
 ): Promise<{
@@ -444,6 +444,8 @@ async function fetchTransitDepartures(
     if (params.stopId) queryParams.set('stopId', params.stopId)
     if (params.routeTypes) queryParams.set('routeTypes', params.routeTypes)
     if (params.name) queryParams.set('name', params.name)
+    // One board per station in the interchange, for a tap on a merged label.
+    if (params.complex) queryParams.set('complex', 'true')
     if (windowMinutes) queryParams.set('windowMinutes', String(windowMinutes))
 
     const response = await fetch(`${config!.host}/transit/departures?${queryParams}`, { headers })
@@ -641,6 +643,7 @@ export async function fetchWidgetData(
           stopId: params.stopId || undefined,
           routeTypes: params.routeTypes || undefined,
           name: params.name || undefined,
+          complex: params.complex === '1' || params.complex === 'true',
         },
         { limit, windowMinutes },
       )

--- a/web/src/composables/useWidgets.ts
+++ b/web/src/composables/useWidgets.ts
@@ -1,5 +1,6 @@
 import { shallowRef, triggerRef, watch, onUnmounted, type Ref } from 'vue'
 import axios from 'axios'
+import { useRoute } from 'vue-router'
 import { api } from '@/lib/api'
 import type { Place, WidgetDescriptor, WidgetResponse } from '@/types/place.types'
 import { WidgetDataType } from '@/types/place.types'
@@ -21,6 +22,19 @@ export function descriptorKey(desc: WidgetDescriptor): string {
 }
 
 export function useWidgets(place: Ref<Partial<Place> | null>) {
+  const route = useRoute()
+
+  /**
+   * Params the URL adds on top of the descriptor's own.
+   *
+   * `complex` comes from tapping a merged station label on the map — one
+   * symbol drawn over a whole interchange — and asks the transit widget for
+   * every station in it rather than the one the coordinates landed on. The
+   * descriptor is built server-side from the place alone and cannot know
+   * which symbol was tapped, so it rides the route instead.
+   */
+  const urlParams = (): Record<string, string> =>
+    route.query.complex ? { complex: '1' } : {}
   // shallowRef: Map mutations (.set/.delete) don't trigger Vue reactivity on their own.
   // We call triggerRef(widgetStates) after every mutation instead of replacing the Map.
   const widgetStates = shallowRef<Map<string, WidgetState>>(new Map())
@@ -31,8 +45,10 @@ export function useWidgets(place: Ref<Partial<Place> | null>) {
   onUnmounted(() => controller.abort())
 
   watch(
-    () => place.value?.widgets,
-    async (widgets) => {
+    // The URL's own params are part of the request, so a change to them has to
+    // refetch even when the place has not moved.
+    () => [place.value?.widgets, route.query.complex] as const,
+    async ([widgets]) => {
       // Abort any in-flight widget requests from the previous place
       controller.abort()
       controller = new AbortController()
@@ -71,7 +87,7 @@ export function useWidgets(place: Ref<Partial<Place> | null>) {
     try {
       const response = await api.get<WidgetResponse>(
         `/places/widgets/${descriptor.type}`,
-        { params: descriptor.params, signal },
+        { params: { ...descriptor.params, ...urlParams() }, signal },
       )
 
       widgetStates.value.set(key, {

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -450,14 +450,21 @@ function bindListeners() {
   // map, they go dormant while the layers are absent and wake when they
   // re-appear. Which place a feature identifies is decided in
   // portolan-ui (pure, tested); this only turns it into a route.
-  const targetAt = (e: any): { name: string; params: Record<string, string> } | null => {
+  const targetAt = (
+    e: any,
+  ): { name: string; params: Record<string, string>; query?: Record<string, string> } | null => {
     const target = stopTargetFor(e.features?.[0]?.properties)
     if (!target) return null
+    // Tapping the merged label asks about the interchange, so the panel is
+    // told to open all of it; tapping one corridor's marker still opens the
+    // single station it sits on.
+    const query = target.complex ? { complex: '1' } : undefined
     return target.kind === 'osm'
-      ? { name: AppRoute.PLACE, params: { type: target.type, id: target.id } }
+      ? { name: AppRoute.PLACE, params: { type: target.type, id: target.id }, query }
       : {
           name: AppRoute.PLACE_PROVIDER,
           params: { provider: 'transitland', placeId: target.stopKey },
+          query,
         }
   }
 

--- a/web/src/services/layers/features/portolan/portolan-ui.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-ui.test.ts
@@ -146,3 +146,39 @@ describe('which place a clicked station is', () => {
     }
   })
 })
+
+describe('opening a merged station', () => {
+  /**
+   * One drawn label can stand for a whole interchange: New York has four
+   * separate GTFS stations named "Canal St", and the map merges them. Tapping
+   * that label should open all of them, while tapping one corridor's marker
+   * opens only the station it sits on — Apple's hybrid.
+   */
+  test('marks the merged label as a complex', () => {
+    expect(
+      stopTargetFor({ ftype: 'station', nmarkers: 3, osm: 'node/7613354754' })?.complex,
+    ).toBe(true)
+  })
+
+  test('leaves a single-bundle station alone', () => {
+    expect(
+      stopTargetFor({ ftype: 'station', nmarkers: 1, osm: 'node/1' })?.complex,
+    ).toBeFalsy()
+  })
+
+  test("leaves one corridor's marker alone", () => {
+    // A marker carries the station's ids, not its own — so without this it
+    // would inherit the complex flag and open the whole interchange.
+    expect(
+      stopTargetFor({ ftype: 'marker', nmarkers: 3, osm: 'node/1' })?.complex,
+    ).toBeFalsy()
+  })
+
+  test('does not count gtfs_ids, which lists platforms too', () => {
+    // Q01, Q01N and Q01S are one station; counting pairs would call it three.
+    expect(
+      stopTargetFor({ ftype: 'station', nmarkers: 1, gtfs_ids: 'f:Q01;f:Q01N;f:Q01S' })
+        ?.complex,
+    ).toBeFalsy()
+  })
+})

--- a/web/src/services/layers/features/portolan/portolan-ui.ts
+++ b/web/src/services/layers/features/portolan/portolan-ui.ts
@@ -114,9 +114,23 @@ export function parseGtfsIds(raw: unknown): GtfsIdPair[] {
 /** Where a clicked station goes: an OSM object, or a transit.land stop
  *  key, or nowhere. Route names are the caller's (AppRoute) — this module
  *  stays free of the router. */
-export type StopTarget =
+export type StopTarget = (
   | { kind: 'osm'; type: string; id: string }
   | { kind: 'transitland'; stopKey: string }
+) & {
+  /**
+   * The symbol stands for a whole complex rather than one station, so the
+   * panel should open all of it.
+   *
+   * Read from `nmarkers`, not from `gtfs_ids`: that prop lists every stop
+   * merged into the station — platforms AND parent records — so even a plain
+   * two-platform station carries several pairs and counting them would call
+   * everything a complex. `nmarkers` is one per ribbon bundle the station's
+   * lines snap to, which is what actually makes a drawn label cover more than
+   * one station: Canal St is one symbol over four of them.
+   */
+  complex?: boolean
+}
 
 /**
  * Which place a click on this station feature identifies.
@@ -139,13 +153,21 @@ export type StopTarget =
  * be a link.
  */
 export function stopTargetFor(props: any): StopTarget | null {
+  // The merged label is the whole interchange; one corridor's marker is not.
+  // Present only when true, so a plain station's target stays exactly what it
+  // has always been.
+  const complex =
+    props?.ftype === 'station' && Number(props?.nmarkers ?? 0) > 1
+      ? { complex: true as const }
+      : {}
+
   const osm = String(props?.osm ?? '')
   const slash = osm.indexOf('/')
   if (slash > 0 && slash < osm.length - 1) {
-    return { kind: 'osm', type: osm.slice(0, slash), id: osm.slice(slash + 1) }
+    return { kind: 'osm', type: osm.slice(0, slash), id: osm.slice(slash + 1), ...complex }
   }
   // a merged complex can carry several pairs; the tiler orders them by
   // importance, so the first is the one to open
   const pairs = parseGtfsIds(props?.gtfs_ids)
-  return pairs.length ? { kind: 'transitland', stopKey: pairs[0].stopKey } : null
+  return pairs.length ? { kind: 'transitland', stopKey: pairs[0].stopKey, ...complex } : null
 }


### PR DESCRIPTION
The client half of Apple's hybrid. Pairs with barrelman#87.

## The problem

Clicking the "Canal St N Q R W" label opened a panel headed **N Q**, with R and W listed as transfers. That is correct GTFS — the MTA models Broadway's Canal St as two stations, `Q01` (N/Q express) and `R23` (R/W local, 179 m away) — but the map had just drawn them as one symbol with four bullets, so the panel contradicted the thing that was tapped.

`stopTargetFor` already knew a merged symbol existed; its comment read *"the tiler orders them by importance, so the first is the one to open"*. It opened station #1 of the group.

## What changed

A station symbol covering more than one bundle now rides the route as `?complex=1`, and the transit widget passes it to barrelman, which returns a board per station in the interchange.

**Detected from `nmarkers`, not `gtfs_ids`.** That prop lists every stop merged into the station — platforms *and* parent records — so `Q01;Q01N;Q01S` is one station with three pairs, and counting them would call everything a complex. `nmarkers` is one per ribbon bundle the station's lines snap to, which is what actually makes a label cover several stations.

Markers are excluded deliberately: a marker carries the *station's* ids rather than its own, so without the `ftype === 'station'` check it would inherit the flag and one corridor's tap would open the whole interchange. Tapping a marker keeps opening the single station it sits on — the other half of the hybrid.

`useWidgets` sends the flag because the descriptor is built server-side from the place alone and cannot know which symbol was tapped; it also watches the query so changing it refetches without the place moving.

## Note

`complex` is only set when true, so a plain station's `StopTarget` is byte-identical to before — the existing `toEqual` assertions still hold.

122 portolan tests pass, 29 widget tests pass, `vue-tsc` clean.

Needs barrelman#87 released before it does anything; production ignores the unknown query param until then.