### PR TITLE
Canvas order and speed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@
 * Pins on a canvas are drawn the way search results are, glyph and all — the icon you choose is the icon on the map, at the same size whatever the zoom. Saved places shrink and fade as you zoom out because the question there is "where have I saved things"; a pin you placed deliberately stays where and what you put it
 * Canvas layers keep their colour on a night basemap. Mapbox dims the map after dark, which is right for buildings and wrong for something you drew, so marks and data layers now light themselves
 * A canvas's layers and marks are one reorderable list now, bottom to top, so what covers what is whatever the list says. Related things can be gathered into a group with its own name and switch
+* Canvases holding large imported datasets stay responsive as you edit them, and save without sending the whole document back and forth
 * A pin on a canvas can be a circle, a square or just its icon. A square reads as a station or a stop the way the basemap already draws them, and a bare icon keeps a busy map quiet
 * Canvases appear in the layer selector under their own group, so one can be switched on or off from the map without opening your library
 
@@ -51,6 +52,10 @@
 * The tick beside a custom colour now applies it and closes the picker, rather than leaving the picker open with nothing apparently happening
 * Escape works again in views that bind it alongside another. Several parts of the app listen for Escape at once, and closing any one of them quietly took the others' handling with it — so Escape could stop dismissing a panel until the page was reloaded
 * Undo and redo on a canvas now work while the cursor is in a text field. Naming a mark and then pressing ⌘Z used to do nothing, though the toolbar button worked
+* Reordering a canvas's layers and marks now changes what covers what on the map straight away, instead of only after something else made it redraw
+* Restyling a canvas layer no longer quietly lifts it above the layers it was sitting under
+* Marks around the one you are reshaping or hiding no longer flicker off the map and back
+* A travel time area is no longer lost when you change its mode or reach while it is still being worked out
 
 ## [0.8.3] - 2026-09-02
 

--- a/server/src/controllers/library/canvases.controller.ts
+++ b/server/src/controllers/library/canvases.controller.ts
@@ -86,7 +86,14 @@ const canvasesRouter = new Elysia({ prefix: '/canvases' })
         metadataKeyVersion: t.Optional(t.Number()),
         bodyEncrypted: t.Optional(t.Union([t.String(), t.Null()])),
       }),
-      detail: { tags: ['Library'], summary: 'Update a canvas' },
+      detail: {
+        tags: ['Library'],
+        summary: 'Update a canvas',
+        description:
+          'Returns the canvas without its body: a canvas saves itself as it ' +
+          'is edited, and the document it has just sent is the one thing the ' +
+          'client already holds. Read it back with GET /canvases/:id.',
+      },
     },
   )
 

--- a/server/src/services/library/canvases.service.db.test.ts
+++ b/server/src/services/library/canvases.service.db.test.ts
@@ -52,6 +52,26 @@ async function seedServerKey() {
   return canvas.id
 }
 
+describe('updateCanvas', () => {
+  test('answers without the document it was just handed', async () => {
+    const id = await seedServerKey()
+
+    const updated = await updateCanvas(id, userId, { name: 'Sunday ride' })
+
+    // A canvas saves itself as it is edited, so the body it just sent is the
+    // one thing the client already holds — echoing it doubled every save.
+    expect(updated?.name).toBe('Sunday ride')
+    expect(updated).not.toHaveProperty('body')
+    expect(updated).not.toHaveProperty('bodyEncrypted')
+    // And it is still there to be read back.
+    expect((await getCanvasById(id, userId))?.body).toEqual({
+      layers: [{ id: 'a', kind: 'library', layerId: 'l1', visible: true }],
+    })
+
+    await deleteCanvas(id, userId)
+  })
+})
+
 describe('changeCanvasScheme', () => {
   test('going private clears every cleartext column', async () => {
     const id = await seedServerKey()

--- a/server/src/services/library/canvases.service.ts
+++ b/server/src/services/library/canvases.service.ts
@@ -6,7 +6,7 @@ import {
   type NewCanvas,
 } from '../../schema/canvases.schema'
 import type { CollectionScheme } from '../../schema/library.schema'
-import { and, eq, desc } from 'drizzle-orm'
+import { and, eq, desc, getTableColumns } from 'drizzle-orm'
 import { generateId } from '../../util'
 import { randomBytes } from 'node:crypto'
 
@@ -29,6 +29,19 @@ export interface CreateCanvasParams {
   scheme?: CollectionScheme
   isPublic?: boolean
 }
+
+/**
+ * Everything about a canvas except the document itself.
+ *
+ * A canvas saves itself every second or so, and the body it just sent back
+ * is the one thing the client already has — echoing it doubled the cost of
+ * every save, on a document that can carry megabytes of imported features.
+ * Callers that need the body read it (`getCanvasById`) or hold it already.
+ */
+const { body: _body, bodyEncrypted: _bodyEncrypted, ...canvasSummary } =
+  getTableColumns(canvases)
+
+export type CanvasSummary = Omit<Canvas, 'body' | 'bodyEncrypted'>
 
 export interface UpdateCanvasParams {
   isPublic?: boolean
@@ -104,7 +117,7 @@ export async function updateCanvas(
   id: string,
   userId: string,
   updates: UpdateCanvasParams,
-): Promise<Canvas | undefined> {
+): Promise<CanvasSummary | undefined> {
   // Spread only the keys the caller actually sent, so a partial update can't
   // null out a body it never mentioned.
   const set: Record<string, unknown> = { updatedAt: new Date() }
@@ -116,7 +129,7 @@ export async function updateCanvas(
     .update(canvases)
     .set(set)
     .where(and(eq(canvases.id, id), eq(canvases.userId, userId)))
-    .returning()
+    .returning(canvasSummary)
   return updated
 }
 

--- a/web/src/components/library/canvas/AddCanvasLayerDialog.vue
+++ b/web/src/components/library/canvas/AddCanvasLayerDialog.vue
@@ -19,7 +19,7 @@ import { useLayersStore } from '@/stores/layers.store'
 import { useCollectionsStore } from '@/stores/library/collections.store'
 import { useRoutesStore } from '@/stores/library/routes.store'
 import { fuzzyFilter, type ThemeColor } from '@/lib/utils'
-import type { CanvasLayer } from '@/types/canvas.types'
+import { newCanvasId, type CanvasLayer } from '@/types/canvas.types'
 import { SearchIcon } from 'lucide-vue-next'
 
 const open = defineModel<boolean>('open', { required: true })
@@ -66,7 +66,7 @@ const filteredCollections = computed(() => filtered(collections.value))
 const filteredRoutes = computed(() => filtered(routes.value))
 
 function newId() {
-  return `cl-${Math.random().toString(36).slice(2, 10)}`
+  return newCanvasId('cl')
 }
 
 function addLibraryLayer(layerId: string) {

--- a/web/src/components/library/canvas/CanvasAnnotationRow.vue
+++ b/web/src/components/library/canvas/CanvasAnnotationRow.vue
@@ -60,10 +60,9 @@ import { useMeasureUnits } from '@/composables/useMeasureUnits'
 
 const props = defineProps<{
   annotation: CanvasAnnotation
+  /** An open mark is the selected one; there is no third state to draw. */
   expanded?: boolean
 }>()
-
-/** An open mark is the selected one; there is no third state to draw. */
 
 const emit = defineEmits<{
   update: [patch: Partial<CanvasAnnotation>]

--- a/web/src/components/library/canvas/CanvasAnnotationStyle.vue
+++ b/web/src/components/library/canvas/CanvasAnnotationStyle.vue
@@ -26,7 +26,12 @@ import {
   annotationStyle,
   DEFAULT_ANNOTATION_COLOR,
 } from '@/lib/canvas-annotations'
-import { hasStyleOption, type DrawOption } from '@/lib/canvas-draw-style'
+import {
+  hasStyleOption,
+  percentLabel,
+  STYLE_RANGES,
+  type DrawOption,
+} from '@/lib/canvas-draw-style'
 import type { MarkerShape } from '@/lib/map-marker'
 import {
   ANNOTATION_STROKE_CAPS,
@@ -61,10 +66,6 @@ const strokeCaps = computed(() =>
     label: t(`canvases.annotations.strokeCaps.${value}`),
   })),
 )
-
-function percent(value: number) {
-  return `${Math.round(value * 100)}%`
-}
 </script>
 
 <template>
@@ -77,9 +78,7 @@ function percent(value: number) {
         <span class="flex items-center gap-2">
           <Slider
             :model-value="[style.strokeWidth]"
-            :min="1"
-            :max="24"
-            :step="1"
+            v-bind="STYLE_RANGES.strokeWidth"
             class="w-24"
             @update:model-value="v => emit('update', { strokeWidth: v?.[0] })"
           />
@@ -151,16 +150,14 @@ function percent(value: number) {
         <span class="flex items-center gap-2">
           <Slider
             :model-value="[style.strokeOpacity * 100]"
-            :min="0"
-            :max="100"
-            :step="5"
+            v-bind="STYLE_RANGES.strokeOpacity"
             class="w-24"
             @update:model-value="
               v => emit('update', { strokeOpacity: (v?.[0] ?? 100) / 100 })
             "
           />
           <span class="w-8 text-right text-xs tabular-nums text-muted-foreground">
-            {{ percent(style.strokeOpacity) }}
+            {{ percentLabel(style.strokeOpacity) }}
           </span>
         </span>
       </div>
@@ -190,16 +187,14 @@ function percent(value: number) {
         <span class="flex items-center gap-2">
           <Slider
             :model-value="[style.fillOpacity * 100]"
-            :min="0"
-            :max="100"
-            :step="5"
+            v-bind="STYLE_RANGES.fillOpacity"
             class="w-24"
             @update:model-value="
               v => emit('update', { fillOpacity: (v?.[0] ?? 0) / 100 })
             "
           />
           <span class="w-8 text-right text-xs tabular-nums text-muted-foreground">
-            {{ percent(style.fillOpacity) }}
+            {{ percentLabel(style.fillOpacity) }}
           </span>
         </span>
       </div>
@@ -231,9 +226,7 @@ function percent(value: number) {
       <span class="flex items-center gap-2">
         <Slider
           :model-value="[style.markerSize]"
-          :min="4"
-          :max="20"
-          :step="0.5"
+          v-bind="STYLE_RANGES.markerSize"
           class="w-24"
           @update:model-value="v => emit('update', { markerSize: v?.[0] })"
         />
@@ -253,9 +246,7 @@ function percent(value: number) {
       <span class="flex items-center gap-2">
         <Slider
           :model-value="[style.labelSize]"
-          :min="8"
-          :max="32"
-          :step="1"
+          v-bind="STYLE_RANGES.labelSize"
           class="w-24"
           @update:model-value="v => emit('update', { labelSize: v?.[0] })"
         />

--- a/web/src/components/library/canvas/CanvasLayerRow.vue
+++ b/web/src/components/library/canvas/CanvasLayerRow.vue
@@ -130,11 +130,6 @@ const borrowed = computed(() => {
   }
 })
 
-/**
- * The second line. A data layer says what it is and where it came from — an
- * imported file is worth naming, and a drawn one is worth distinguishing from
- * one that arrived as a file.
- */
 /** Style layers open the layer editor; data layers open their own settings. */
 const isEditable = computed(
   () => props.layer.kind === 'style' || props.layer.kind === 'data',
@@ -153,6 +148,11 @@ const {
   onCommit: name => emit('rename', name),
 })
 
+/**
+ * The second line. A data layer says what it is and where it came from — an
+ * imported file is worth naming, and a drawn one is worth distinguishing from
+ * one that arrived as a file.
+ */
 const subtitle = computed(() => {
   const layer = props.layer
   if (layer.kind !== 'data') return t(`canvases.layers.kinds.${layer.kind}`)
@@ -161,8 +161,6 @@ const subtitle = computed(() => {
   parts.push(t('canvases.layers.featureCount', count))
   return parts.join(' · ')
 })
-
-
 </script>
 
 <template>

--- a/web/src/components/library/canvas/CanvasToolOptions.vue
+++ b/web/src/components/library/canvas/CanvasToolOptions.vue
@@ -33,6 +33,8 @@ import {
 import { annotationStyle } from '@/lib/canvas-annotations'
 import {
   hasStyleOption,
+  percentLabel,
+  STYLE_RANGES,
   type DrawStyle,
 } from '@/lib/canvas-draw-style'
 import { maxMinutesForMode } from '@/lib/isochrone.utils'
@@ -73,8 +75,6 @@ const style = computed(() => annotationStyle({ tool: props.tool, ...props.style 
 const color = computed(() => props.style.color ?? 'compass')
 const has = (option: Parameters<typeof hasStyleOption>[1]) =>
   hasStyleOption(props.tool, option)
-
-const percent = (value: number) => `${Math.round(value * 100)}%`
 
 /** A dash pattern is shown as one, not named. */
 const STROKE_DASHES: Record<AnnotationStrokeStyle, string> = {
@@ -143,9 +143,7 @@ const maxMinutes = computed(() => maxMinutesForMode(props.isochroneMode))
       v-if="has('markerSize')"
       :label="t('canvases.annotations.markerSize')"
       :model-value="style.markerSize"
-      :min="4"
-      :max="20"
-      :step="0.5"
+      v-bind="STYLE_RANGES.markerSize"
       @update:model-value="markerSize => emit('update:style', { markerSize })"
     >
       <template #glyph>
@@ -166,9 +164,7 @@ const maxMinutes = computed(() => maxMinutesForMode(props.isochroneMode))
       v-if="has('strokeWidth')"
       :label="t('canvases.annotations.strokeWidth')"
       :model-value="style.strokeWidth"
-      :min="1"
-      :max="24"
-      :step="1"
+      v-bind="STYLE_RANGES.strokeWidth"
       @update:model-value="strokeWidth => emit('update:style', { strokeWidth })"
     >
       <template #glyph>
@@ -237,10 +233,8 @@ const maxMinutes = computed(() => maxMinutesForMode(props.isochroneMode))
       v-if="has('strokeOpacity')"
       :label="t('canvases.annotations.strokeOpacity')"
       :model-value="style.strokeOpacity * 100"
-      :display="percent(style.strokeOpacity)"
-      :min="0"
-      :max="100"
-      :step="5"
+      :display="percentLabel(style.strokeOpacity)"
+      v-bind="STYLE_RANGES.strokeOpacity"
       @update:model-value="
         value => emit('update:style', { strokeOpacity: value / 100 })
       "
@@ -271,10 +265,8 @@ const maxMinutes = computed(() => maxMinutesForMode(props.isochroneMode))
       <CanvasToolNumber
         :label="t('canvases.annotations.fillOpacity')"
         :model-value="style.fillOpacity * 100"
-        :display="percent(style.fillOpacity)"
-        :min="0"
-        :max="100"
-        :step="5"
+        :display="percentLabel(style.fillOpacity)"
+        v-bind="STYLE_RANGES.fillOpacity"
         @update:model-value="
           value => emit('update:style', { fillOpacity: value / 100 })
         "

--- a/web/src/composables/useAnnotationEditing.ts
+++ b/web/src/composables/useAnnotationEditing.ts
@@ -14,11 +14,9 @@
 
 import { computed, onScopeDispose, ref, watch, type Ref } from 'vue'
 import type { Position } from 'geojson'
-import { useMapStore } from '@/stores/map.store'
-import {
-  RouteSnapAborted,
-  snapWaypointsToPath,
-} from '@/lib/route-snapping'
+import { useDrawingSurface } from '@/composables/useDrawingSurface'
+import { snapWaypointsToPath } from '@/lib/route-snapping'
+import { SUPERSEDED, useLatestRequest } from '@/composables/useLatestRequest'
 import { fetchIsochroneBands } from '@/lib/isochrone-request'
 import { contourDurations } from '@/lib/isochrone.utils'
 import type { IsochroneMode } from '@server/types/isochrone.types'
@@ -50,13 +48,6 @@ import { themeColorToHex } from '@/lib/utils'
 const GRAB_PX = VERTEX_NEAR_PX
 const MIDPOINT_GRAB_PX = INSERT_THRESHOLD_PX
 
-interface EditableMap {
-  project: (position: Position) => { x: number; y: number }
-  unproject: (point: [number, number]) => { lng: number; lat: number }
-  getCanvas: () => HTMLCanvasElement
-  dragPan?: { enable: () => void; disable: () => void }
-}
-
 type Grab = AnnotationNode & { pointerId: number }
 
 export function useAnnotationEditing(options: {
@@ -66,7 +57,15 @@ export function useAnnotationEditing(options: {
   enabled: Ref<boolean>
   onChange: (id: string, patch: Partial<CanvasAnnotation>) => void
 }) {
-  const mapStore = useMapStore()
+  const surface = useDrawingSurface()
+
+  /**
+   * A route's path and an isochrone's reach both have to be asked for again
+   * when their origin moves, and a drag asks repeatedly — so each keeps only
+   * its newest ask. See `useLatestRequest`.
+   */
+  const snapping = useLatestRequest('failed to re-snap a route')
+  const reaching = useLatestRequest('failed to move an isochrone')
 
   /** The live position of the handle being dragged, before it is written. */
   const dragging = ref<Grab | null>(null)
@@ -79,10 +78,6 @@ export function useAnnotationEditing(options: {
       options.annotations.value.find(a => a.id === options.selectedId.value) ??
       null,
   )
-
-  function mapInstance(): EditableMap | undefined {
-    return mapStore.getMapStrategy()?.mapInstance as EditableMap | undefined
-  }
 
   /** The mark as it looks right now, drag included. */
   const edited = computed<CanvasAnnotation | null>(() => {
@@ -161,15 +156,6 @@ export function useAnnotationEditing(options: {
     dragging.value ? (selected.value?.id ?? null) : null,
   )
 
-  function pointToPosition(map: EditableMap, event: PointerEvent): Position {
-    const rect = map.getCanvas().getBoundingClientRect()
-    const { lng, lat } = map.unproject([
-      event.clientX - rect.left,
-      event.clientY - rect.top,
-    ])
-    return [lng, lat]
-  }
-
   type Hit =
     | { kind: 'node'; node: AnnotationNode; nodeIndex: number }
     | { kind: 'midpoint'; midpoint: { index: number; position: Position } }
@@ -182,9 +168,10 @@ export function useAnnotationEditing(options: {
    * taking them in order would make one of them impossible to pick up.
    * Vertices are tried before midpoints, since a midpoint is only an offer.
    */
-  function hitTest(map: EditableMap, x: number, y: number): Hit | null {
-    const distance = (position: Position) =>
-      distancePx(map.project(position), { x, y })
+  function hitTest(at: { x: number; y: number }): Hit | null {
+    const project = surface.map()?.project
+    if (!project) return null
+    const distance = (position: Position) => distancePx(project(position), at)
 
     let closest: { index: number; away: number } | null = null
     nodes.value.forEach((node, index) => {
@@ -205,24 +192,16 @@ export function useAnnotationEditing(options: {
     return null
   }
 
-  function relative(map: EditableMap, event: PointerEvent) {
-    const rect = map.getCanvas().getBoundingClientRect()
-    return { x: event.clientX - rect.left, y: event.clientY - rect.top }
-  }
-
   function onPointerDown(event: PointerEvent) {
     if (!options.enabled.value || !selected.value) return
-    const map = mapInstance()
-    if (!map) return
-
-    const { x, y } = relative(map, event)
-    const hit = hitTest(map, x, y)
+    const at = surface.pointAt(event)
+    const hit = at && hitTest(at)
     if (!hit) return
 
     // The map would otherwise start panning under the drag.
     event.preventDefault()
     event.stopPropagation()
-    map.dragPan?.disable()
+    surface.setPanning(false)
 
     if (hit.kind === 'midpoint') {
       // Dragging a midpoint turns it into a real vertex, and then drags that.
@@ -243,12 +222,12 @@ export function useAnnotationEditing(options: {
       dragPosition.value = hit.node.position
     }
 
-    map.getCanvas().style.cursor = 'grabbing'
+    surface.setCursor('grabbing')
     // Capture so the release still arrives if the pointer leaves the window
     // mid-drag. Without it a drag let go outside the page never ends, and the
     // mark stays held out of the style — invisible until the page reloads.
     try {
-      map.getCanvas().setPointerCapture(event.pointerId)
+      surface.element()?.setPointerCapture(event.pointerId)
     } catch {
       // Capture is a nicety; the window listeners below are the guarantee.
     }
@@ -259,10 +238,8 @@ export function useAnnotationEditing(options: {
   }
 
   function onPointerMove(event: PointerEvent) {
-    const map = mapInstance()
-    if (!map || !dragging.value) return
-    if (event.pointerId !== dragging.value.pointerId) return
-    dragPosition.value = pointToPosition(map, event)
+    if (event.pointerId !== dragging.value?.pointerId) return
+    dragPosition.value = surface.positionAt(event) ?? dragPosition.value
   }
 
   /** Hovering a handle without pressing, so it can say it is grabbable. */
@@ -272,36 +249,31 @@ export function useAnnotationEditing(options: {
       hovered.value = null
       return
     }
-    const map = mapInstance()
-    if (!map) return
-    const { x, y } = relative(map, event)
-    const hit = hitTest(map, x, y)
+    const at = surface.pointAt(event)
+    if (!at) return
+    const hit = hitTest(at)
     const next = hit?.kind === 'node' ? hit.nodeIndex : null
     if (next === hovered.value && !hit) return
     hovered.value = next
     // A handle you can pick up should look like one.
-    const canvas = map.getCanvas()
-    if (hit) canvas.style.cursor = 'grab'
-    else if (canvas.style.cursor === 'grab') canvas.style.cursor = ''
+    if (hit) surface.setCursor('grab')
+    else surface.clearCursor('grab')
   }
 
   /** Put everything back, whether the drag finished or was taken away. */
   function endDrag(): { annotation: CanvasAnnotation; grab: Grab; to: Position } | null {
     const grab = dragging.value
-    const map = mapInstance()
     window.removeEventListener('pointermove', onPointerMove)
     window.removeEventListener('pointerup', onPointerUp)
     window.removeEventListener('pointercancel', onPointerUp)
     window.removeEventListener('blur', endDrag)
-    map?.dragPan?.enable()
-    if (map) {
-      map.getCanvas().style.cursor = ''
-      if (grab) {
-        try {
-          map.getCanvas().releasePointerCapture(grab.pointerId)
-        } catch {
-          // Already released, or never captured.
-        }
+    surface.setPanning(true)
+    surface.setCursor('')
+    if (grab) {
+      try {
+        surface.element()?.releasePointerCapture(grab.pointerId)
+      } catch {
+        // Already released, or never captured.
       }
     }
 
@@ -344,43 +316,34 @@ export function useAnnotationEditing(options: {
     const previous = annotation.isochrone
     if (!origin || !previous) return
 
-    snapRequest?.abort()
-    const controller = new AbortController()
-    snapRequest = controller
-    try {
-      const { bands } = await fetchIsochroneBands({
+    const answer = await reaching.run(signal =>
+      fetchIsochroneBands({
         origin: { lng: origin[0], lat: origin[1] },
         mode: previous.mode as IsochroneMode,
         durations: contourDurations(previous.minutes, 1),
-        signal: controller.signal,
-      })
-      const geometry = bands[bands.length - 1]?.geometry
-      if (!geometry) return
-      options.onChange(annotation.id, {
-        isochrone: {
-          ...previous,
-          geometry:
-            geometry.type === 'Polygon'
-              ? geometry.coordinates
-              : geometry.coordinates.flat(),
-        },
-      })
-    } catch (error) {
-      if (!(error as Error)?.name?.includes('Abort')) {
-        console.error('[canvas] failed to move an isochrone', error)
-      }
-    } finally {
-      if (snapRequest === controller) snapRequest = undefined
-    }
+        signal,
+      }),
+    )
+    if (!answer || answer === SUPERSEDED) return
+    const geometry = answer.bands[answer.bands.length - 1]?.geometry
+    if (!geometry) return
+
+    options.onChange(annotation.id, {
+      isochrone: {
+        ...previous,
+        geometry:
+          geometry.type === 'Polygon'
+            ? geometry.coordinates
+            : geometry.coordinates.flat(),
+      },
+    })
   }
 
   /** Double-clicking a vertex takes it out, if the shape can spare it. */
   function onDoubleClick(event: PointerEvent) {
     if (!options.enabled.value || !selected.value) return
-    const map = mapInstance()
-    if (!map) return
-    const { x, y } = relative(map, event)
-    const hit = hitTest(map, x, y)
+    const at = surface.pointAt(event)
+    const hit = at && hitTest(at)
     if (hit?.kind !== 'node' || hit.node.kind === 'radius') return
 
     const patch = removeNode(selected.value, hit.node.index)
@@ -393,34 +356,24 @@ export function useAnnotationEditing(options: {
     }
   }
 
-  let snapRequest: AbortController | undefined
-
   async function resnap(annotation: CanvasAnnotation) {
-    snapRequest?.abort()
-    const controller = new AbortController()
-    snapRequest = controller
-    try {
-      const path = await snapWaypointsToPath({
+    const mode = annotation.routed?.mode ?? 'walking'
+    const path = await snapping.run(signal =>
+      snapWaypointsToPath({
         waypoints: annotation.positions.map(([lng, lat]) => ({ lat, lng })),
-        mode: annotation.routed?.mode ?? 'walking',
-        signal: controller.signal,
-      })
-      if (!path) return
-      options.onChange(annotation.id, {
-        routed: {
-          geometry: path.geometry,
-          mode: annotation.routed?.mode ?? 'walking',
-          distance: path.stats.distance,
-          duration: path.stats.duration,
-        },
-      })
-    } catch (error) {
-      if (!(error instanceof RouteSnapAborted)) {
-        console.error('[canvas] failed to re-snap a route', error)
-      }
-    } finally {
-      if (snapRequest === controller) snapRequest = undefined
-    }
+        mode,
+        signal,
+      }),
+    )
+    if (!path || path === SUPERSEDED) return
+    options.onChange(annotation.id, {
+      routed: {
+        geometry: path.geometry,
+        mode,
+        distance: path.stats.distance,
+        duration: path.stats.duration,
+      },
+    })
   }
 
   /**
@@ -429,8 +382,7 @@ export function useAnnotationEditing(options: {
    * win the press before panning starts.
    */
   function listen(active: boolean) {
-    const map = mapInstance()
-    const canvas = map?.getCanvas()
+    const canvas = surface.element()
     if (!canvas) return
     canvas.removeEventListener('pointerdown', onPointerDown, true)
     canvas.removeEventListener('pointermove', onHoverMove)
@@ -449,7 +401,6 @@ export function useAnnotationEditing(options: {
 
   onScopeDispose(() => {
     listen(false)
-    snapRequest?.abort()
     endDrag()
   })
 

--- a/web/src/composables/useCanvasAnnotations.test.ts
+++ b/web/src/composables/useCanvasAnnotations.test.ts
@@ -6,6 +6,7 @@ import { useMapToolsStore } from '@/stores/map-tools.store'
 import { useIntegrationsStore } from '@/stores/integrations.store'
 import { useCanvasAnnotations } from './useCanvasAnnotations'
 import { mapEventBus } from '@/lib/eventBus'
+import { fetchIsochroneBands } from '@/lib/isochrone-request'
 import type { CanvasAnnotation } from '@/types/canvas.types'
 import type { DrawStyle } from '@/lib/canvas-draw-style'
 
@@ -21,6 +22,10 @@ import type { DrawStyle } from '@/lib/canvas-draw-style'
 vi.mock('@/lib/route-snapping', () => ({
   RouteSnapAborted: class extends Error {},
   snapWaypointsToPath: vi.fn(async () => null),
+}))
+
+vi.mock('@/lib/isochrone-request', () => ({
+  fetchIsochroneBands: vi.fn(),
 }))
 
 function fakeMap() {
@@ -209,5 +214,70 @@ describe('what the tool is set to', () => {
     expect(mark.color).toBe('compass')
     expect(mark.markerSize).toBeUndefined()
     expect(mark.markerShape).toBeUndefined()
+  })
+})
+
+/**
+ * An isochrone is the one tool whose mark is not finished by the user: the
+ * origin is clicked, the engine supplies the shape, and only then is there
+ * anything to keep. Changing the reach in the meantime asks again — and the
+ * ask it replaces must leave the origin alone, or the answer still on its
+ * way arrives to find nothing to attach itself to.
+ */
+describe('an isochrone whose reach changes while the engine is thinking', () => {
+  const band = {
+    bands: [
+      {
+        geometry: {
+          type: 'Polygon' as const,
+          coordinates: [[[0, 0], [1, 0], [1, 1], [0, 0]]],
+        },
+      },
+    ],
+  }
+
+  it('still lands the mark the second answer is for', async () => {
+    useIntegrationsStore()
+    vi.spyOn(useIntegrationsStore(), 'isRoutingActive', 'get').mockReturnValue(
+      true,
+    )
+    const committed: CanvasAnnotation[] = []
+    const fetched = vi.mocked(fetchIsochroneBands)
+
+    // The first ask never answers; it is abandoned when the reach changes.
+    let release: (value: unknown) => void = () => {}
+    fetched.mockImplementationOnce(
+      (({ signal }: { signal: AbortSignal }) =>
+        new Promise((_resolve, reject) => {
+          signal.addEventListener('abort', () => {
+            const aborted = new Error('aborted')
+            aborted.name = 'AbortError'
+            reject(aborted)
+          })
+        })) as never,
+    )
+    fetched.mockImplementationOnce(
+      (() =>
+        new Promise(resolve => {
+          release = resolve
+        })) as never,
+    )
+
+    const session = tools(annotation => committed.push(annotation))
+    session.arm('isochrone')
+    mapEventBus.emit('click', { lngLat: { lng: 1, lat: 2 } } as never)
+    await Promise.resolve()
+
+    session.isochroneMinutes.value = 30
+    // Let the abandoned ask reject before the live one answers.
+    await Promise.resolve()
+    await Promise.resolve()
+    release(band)
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(committed).toHaveLength(1)
+    expect(committed[0].isochrone?.minutes).toBe(30)
+    session.dispose()
   })
 })

--- a/web/src/composables/useCanvasAnnotations.ts
+++ b/web/src/composables/useCanvasAnnotations.ts
@@ -15,15 +15,13 @@
 import { computed, onScopeDispose, ref, watch } from 'vue'
 import type { Position } from 'geojson'
 import { mapEventBus } from '@/lib/eventBus'
-import { useMapStore } from '@/stores/map.store'
+import { useDrawingSurface } from '@/composables/useDrawingSurface'
 import { useMapToolsStore } from '@/stores/map-tools.store'
 import { useIntegrationsStore } from '@/stores/integrations.store'
 import { themeColorToHex } from '@/lib/utils'
 import type { OverlayScene } from '@/composables/useDrawOverlay'
-import {
-  RouteSnapAborted,
-  snapWaypointsToPath,
-} from '@/lib/route-snapping'
+import { snapWaypointsToPath } from '@/lib/route-snapping'
+import { SUPERSEDED, useLatestRequest } from '@/composables/useLatestRequest'
 import type { RouteMode } from '@/types/routes.types'
 import type { IsochroneMode } from '@server/types/isochrone.types'
 import { fetchIsochroneBands } from '@/lib/isochrone-request'
@@ -78,8 +76,8 @@ export function useCanvasAnnotations(options: {
    */
   styleFor: (tool: AnnotationTool | null) => DrawStyle
 }) {
-  const mapStore = useMapStore()
   const mapToolsStore = useMapToolsStore()
+  const surface = useDrawingSurface()
   const integrationsStore = useIntegrationsStore()
 
   /** The Route tool needs a routing engine; without one it isn't offered. */
@@ -102,24 +100,9 @@ export function useCanvasAnnotations(options: {
     // Escape belongs to the tool while one is armed — see the store.
     mapToolsStore.escapeCapture = active
 
-    const map = mapStore.getMapStrategy()?.mapInstance as
-      | {
-          doubleClickZoom?: { enable: () => void; disable: () => void }
-          boxZoom?: { enable: () => void; disable: () => void }
-          getCanvas?: () => HTMLCanvasElement
-        }
-      | undefined
-    if (!map) return
-    if (active) {
-      map.doubleClickZoom?.disable()
-      // Shift+click is the engine's box zoom, and it swallows the click
-      // outright — so holding shift to constrain a shape placed nothing at
-      // all. The tool needs the modifier more than the map does.
-      map.boxZoom?.disable()
-    } else {
-      map.doubleClickZoom?.enable()
-      map.boxZoom?.enable()
-    }
+    // The tool needs the double-click and the shift key more than the map
+    // does — see `setMapGestures`.
+    surface.setMapGestures(!active)
     applyCursor()
   }
 
@@ -159,13 +142,8 @@ export function useCanvasAnnotations(options: {
   let detachPointer: (() => void) | undefined
 
   function trackPointer(active: boolean) {
-    const map = mapStore.getMapStrategy()?.mapInstance as
-      | {
-          on: (event: string, handler: (e: any) => void) => void
-          off: (event: string, handler: (e: any) => void) => void
-        }
-      | undefined
-    if (!map) return
+    const map = surface.map()
+    if (!map?.on || !map.off) return
 
     detachPointer?.()
     detachPointer = undefined
@@ -212,16 +190,16 @@ export function useCanvasAnnotations(options: {
       shift.value = event.shiftKey
     }
 
-    map.on('mousemove', onMove)
-    map.on('mouseout', onOut)
-    map.on('dblclick', onDoubleClick)
+    map.on('mousemove', onMove as never)
+    map.on('mouseout', onOut as never)
+    map.on('dblclick', onDoubleClick as never)
     window.addEventListener('keydown', onKey)
     window.addEventListener('keyup', onKey)
     detachPointer = () => {
       if (frame) cancelAnimationFrame(frame)
-      map.off('mousemove', onMove)
-      map.off('mouseout', onOut)
-      map.off('dblclick', onDoubleClick)
+      map.off?.('mousemove', onMove as never)
+      map.off?.('mouseout', onOut as never)
+      map.off?.('dblclick', onDoubleClick as never)
       window.removeEventListener('keydown', onKey)
       window.removeEventListener('keyup', onKey)
       shift.value = false
@@ -237,8 +215,7 @@ export function useCanvasAnnotations(options: {
 
   const routeMode = ref<RouteMode>('walking')
   const routed = ref<CanvasAnnotation['routed'] | null>(null)
-  const isSnapping = ref(false)
-  let snapRequest: AbortController | undefined
+  const snapping = useLatestRequest('failed to snap a route')
 
   async function snapRoute() {
     if (tool.value !== 'route' || positions.value.length < 2) {
@@ -246,36 +223,23 @@ export function useCanvasAnnotations(options: {
       return
     }
 
-    snapRequest?.abort()
-    const controller = new AbortController()
-    snapRequest = controller
-    isSnapping.value = true
-
-    try {
-      const path = await snapWaypointsToPath({
+    const mode = routeMode.value
+    const path = await snapping.run(signal =>
+      snapWaypointsToPath({
         waypoints: positions.value.map(([lng, lat]) => ({ lat, lng })),
-        mode: routeMode.value,
-        signal: controller.signal,
-      })
-      // A miss leaves the last good path in place: the straight fallback is
-      // still drawn from the waypoints, so nothing is lost either way.
-      if (path) {
-        routed.value = {
-          geometry: path.geometry,
-          mode: routeMode.value,
-          distance: path.stats.distance,
-          duration: path.stats.duration,
-        }
-      }
-    } catch (error) {
-      if (!(error instanceof RouteSnapAborted)) {
-        console.error('[canvas] failed to snap route', error)
-      }
-    } finally {
-      if (snapRequest === controller) {
-        isSnapping.value = false
-        snapRequest = undefined
-      }
+        mode,
+        signal,
+      }),
+    )
+    // A miss leaves the last good path in place: the straight fallback is
+    // still drawn from the waypoints, so nothing is lost either way. So does
+    // an ask that a newer one replaced.
+    if (!path || path === SUPERSEDED) return
+    routed.value = {
+      geometry: path.geometry,
+      mode,
+      distance: path.stats.distance,
+      duration: path.stats.duration,
     }
   }
 
@@ -288,41 +252,19 @@ export function useCanvasAnnotations(options: {
 
   const isDoodling = ref(false)
 
-  function doodlePosition(event: PointerEvent): Position | null {
-    const map = mapStore.getMapStrategy()?.mapInstance as
-      | {
-          unproject?: (point: [number, number]) => { lng: number; lat: number }
-          getCanvas?: () => HTMLCanvasElement
-        }
-      | undefined
-    const canvas = map?.getCanvas?.()
-    if (!map?.unproject || !canvas) return null
-    const rect = canvas.getBoundingClientRect()
-    const { lng, lat } = map.unproject([
-      event.clientX - rect.left,
-      event.clientY - rect.top,
-    ])
-    return [lng, lat]
-  }
-
   function onDoodleDown(event: PointerEvent) {
     if (tool.value !== 'doodle' || event.button !== 0) return
-    const at = doodlePosition(event)
+    const at = surface.positionAt(event)
     if (!at) return
 
     event.preventDefault()
     event.stopPropagation()
     isDoodling.value = true
     positions.value = [at]
-    setPanning(false)
+    surface.setPanning(false)
 
-    const canvas = (
-      mapStore.getMapStrategy()?.mapInstance as
-        | { getCanvas?: () => HTMLCanvasElement }
-        | undefined
-    )?.getCanvas?.()
     try {
-      canvas?.setPointerCapture(event.pointerId)
+      surface.element()?.setPointerCapture(event.pointerId)
     } catch {
       // Capture is a nicety; the window listeners are the guarantee.
     }
@@ -333,7 +275,7 @@ export function useCanvasAnnotations(options: {
 
   function onDoodleMove(event: PointerEvent) {
     if (!isDoodling.value) return
-    const at = doodlePosition(event)
+    const at = surface.positionAt(event)
     if (at) positions.value = [...positions.value, at]
   }
 
@@ -343,7 +285,7 @@ export function useCanvasAnnotations(options: {
     window.removeEventListener('pointerup', onDoodleUp)
     window.removeEventListener('pointercancel', onDoodleUp)
     isDoodling.value = false
-    setPanning(true)
+    surface.setPanning(true)
 
     // Tidy the stroke before it is kept: a hand leaves far more points than
     // the shape needs, and shakier ones than it meant.
@@ -352,21 +294,8 @@ export function useCanvasAnnotations(options: {
     else positions.value = []
   }
 
-  /** The map's own drag has to stand down for the length of a stroke. */
-  function setPanning(enabled: boolean) {
-    const map = mapStore.getMapStrategy()?.mapInstance as
-      | { dragPan?: { enable: () => void; disable: () => void } }
-      | undefined
-    if (enabled) map?.dragPan?.enable()
-    else map?.dragPan?.disable()
-  }
-
   function trackDoodle(active: boolean) {
-    const canvas = (
-      mapStore.getMapStrategy()?.mapInstance as
-        | { getCanvas?: () => HTMLCanvasElement }
-        | undefined
-    )?.getCanvas?.()
+    const canvas = surface.element()
     if (!canvas) return
     canvas.removeEventListener('pointerdown', onDoodleDown, true)
     if (active) canvas.addEventListener('pointerdown', onDoodleDown, true)
@@ -381,51 +310,45 @@ export function useCanvasAnnotations(options: {
   const isochroneMode = ref<IsochroneMode>('walk')
   const isochroneMinutes = ref(15)
   const isochrone = ref<CanvasAnnotation['isochrone'] | null>(null)
-  const isFetchingIsochrone = ref(false)
-  let isochroneRequest: AbortController | undefined
+  const reaching = useLatestRequest('failed to fetch an isochrone')
 
   async function requestIsochrone() {
     const origin = positions.value[0]
     if (tool.value !== 'isochrone' || !origin) return
 
-    isochroneRequest?.abort()
-    const controller = new AbortController()
-    isochroneRequest = controller
-    isFetchingIsochrone.value = true
-
-    try {
-      const { bands } = await fetchIsochroneBands({
+    const mode = isochroneMode.value
+    const minutes = isochroneMinutes.value
+    const answer = await reaching.run(signal =>
+      fetchIsochroneBands({
         origin: { lng: origin[0], lat: origin[1] },
-        mode: isochroneMode.value,
+        mode,
         // One contour: a mark is one shape, and bands would be several.
-        durations: contourDurations(isochroneMinutes.value, 1),
-        signal: controller.signal,
-      })
-      // The outermost band is the whole reachable area.
-      const band = bands[bands.length - 1]
-      const geometry = band?.geometry
-      if (!geometry) return
-
-      isochrone.value = {
-        geometry:
-          geometry.type === 'Polygon'
-            ? geometry.coordinates
-            : geometry.coordinates.flat(),
-        mode: isochroneMode.value,
-        minutes: isochroneMinutes.value,
-      }
-      commit()
-    } catch (error) {
-      if (!(error as Error)?.name?.includes('Abort')) {
-        console.error('[canvas] failed to fetch an isochrone', error)
-      }
+        durations: contourDurations(minutes, 1),
+        signal,
+      }),
+    )
+    // Changing the mode or the reach asks again, and the ask it replaced
+    // must leave the origin alone — dropping it there used to lose the mark
+    // outright, since the answer still on its way had nothing to commit to.
+    if (answer === SUPERSEDED) return
+    if (!answer) {
       positions.value = []
-    } finally {
-      if (isochroneRequest === controller) {
-        isFetchingIsochrone.value = false
-        isochroneRequest = undefined
-      }
+      return
     }
+
+    // The outermost band is the whole reachable area.
+    const geometry = answer.bands[answer.bands.length - 1]?.geometry
+    if (!geometry) return
+
+    isochrone.value = {
+      geometry:
+        geometry.type === 'Polygon'
+          ? geometry.coordinates
+          : geometry.coordinates.flat(),
+      mode,
+      minutes,
+    }
+    commit()
   }
 
   // A new origin, or a change of reach, asks the engine again.
@@ -441,21 +364,6 @@ export function useCanvasAnnotations(options: {
   })
 
   /**
-   * Screen distance between two positions, or null if the map can't say.
-   * Snapping has to be judged in pixels: two points a metre apart are the
-   * same click at one zoom and far apart at another.
-   */
-  function screenDistance(a: Position, b: Position): number | null {
-    const map = mapStore.getMapStrategy()?.mapInstance as
-      | { project?: (position: Position) => { x: number; y: number } }
-      | undefined
-    if (!map?.project) return null
-    const from = map.project(a)
-    const to = map.project(b)
-    return Math.hypot(from.x - to.x, from.y - to.y)
-  }
-
-  /**
    * Whether the cursor is close enough to the first vertex to close the shape.
    *
    * Clicking back on the start is how everyone expects to finish a polygon,
@@ -464,7 +372,7 @@ export function useCanvasAnnotations(options: {
   const snapToStart = computed(() => {
     if (tool.value !== 'polygon' || !cursor.value) return false
     if (positions.value.length < TOOL_MINIMUM.polygon) return false
-    const distance = screenDistance(cursor.value, positions.value[0])
+    const distance = surface.screenDistance(cursor.value, positions.value[0])
     return distance !== null && distance <= SNAP_PX
   })
 
@@ -490,23 +398,14 @@ export function useCanvasAnnotations(options: {
    * the shape, the cursor turns into a pointer.
    */
   function applyCursor() {
-    const canvas = (
-      mapStore.getMapStrategy()?.mapInstance as
-        | { getCanvas?: () => HTMLCanvasElement }
-        | undefined
-    )?.getCanvas?.()
-    if (!canvas) return
-
     if (!tool.value) {
-      canvas.style.cursor = ''
+      surface.setCursor('')
       return
     }
     // The eraser only does something over a mark, so it only offers there.
-    if (tool.value === 'erase') {
-      canvas.style.cursor = eraseTarget.value ? 'pointer' : 'crosshair'
-      return
-    }
-    canvas.style.cursor = snapToStart.value ? 'pointer' : 'crosshair'
+    const offering =
+      tool.value === 'erase' ? !!eraseTarget.value : snapToStart.value
+    surface.setCursor(offering ? 'pointer' : 'crosshair')
   }
 
   // The cursor tracks how far into a shape you are, and whether the next
@@ -523,26 +422,8 @@ export function useCanvasAnnotations(options: {
    * decides which of the ids are its own.
    */
   function markUnder(position: Position): string | null {
-    const map = mapStore.getMapStrategy()?.mapInstance as
-      | {
-          project?: (position: Position) => { x: number; y: number }
-          queryRenderedFeatures?: (
-            geometry: [[number, number], [number, number]],
-          ) => { properties?: Record<string, unknown> | null }[]
-        }
-      | undefined
-    if (!map?.project || !map.queryRenderedFeatures) return null
-
-    const { x, y } = map.project(position)
     // A box rather than a point: a hairline is otherwise almost unhittable.
-    const found = map.queryRenderedFeatures([
-      [x - ERASE_HIT_PX, y - ERASE_HIT_PX],
-      [x + ERASE_HIT_PX, y + ERASE_HIT_PX],
-    ])
-    const ids = found
-      .map(feature => feature.properties?.id)
-      .filter((id): id is string => typeof id === 'string')
-    return options.eraseTarget(ids)
+    return options.eraseTarget(surface.idsAround(position, ERASE_HIT_PX))
   }
 
   /** What the eraser is over, for the cursor. */
@@ -602,7 +483,7 @@ export function useCanvasAnnotations(options: {
         : null,
       color: themeColorToHex(color.value),
       guide: guide.value,
-      pending: isSnapping.value || isFetchingIsochrone.value,
+      pending: snapping.pending.value || reaching.pending.value,
       width: drawing.value === 'doodle' ? resolved.value.strokeWidth : undefined,
       cap: resolved.value.strokeCap,
       handles: (drawing.value === 'doodle' ? [] : positions.value).map((position, index) => ({
@@ -687,8 +568,8 @@ export function useCanvasAnnotations(options: {
   function disarm() {
     if (tool.value) mapEventBus.removeOverride('click', onMapClick)
     eraseTarget.value = null
-    snapRequest?.abort()
-    isochroneRequest?.abort()
+    snapping.abort()
+    reaching.abort()
     trackDoodle(false)
     onDoodleUp()
     tool.value = null
@@ -751,7 +632,7 @@ export function useCanvasAnnotations(options: {
   return {
     tool,
     routeMode,
-    isSnapping,
+    isSnapping: snapping.pending,
     isArmed,
     canFinish,
     canUndo,
@@ -762,7 +643,7 @@ export function useCanvasAnnotations(options: {
     isBusy: isDoodling,
     isochroneMode,
     isochroneMinutes,
-    isFetchingIsochrone,
+    isFetchingIsochrone: reaching.pending,
     scene,
     vertexCount: computed(() => positions.value.length),
     arm,

--- a/web/src/composables/useCanvasHistory.test.ts
+++ b/web/src/composables/useCanvasHistory.test.ts
@@ -171,6 +171,33 @@ describe('useCanvasHistory', () => {
     editor.dispose()
   })
 
+  it('puts back the document that was there, rather than a copy of it', async () => {
+    const editor = history()
+    const original = editor.body.value
+
+    editor.body.value = withPin(original, 'an-1')
+    await settle()
+    await pause()
+    editor.undo()
+
+    // A step holds the editor's own values: a canvas carrying megabytes of
+    // imported features is never serialised to take one, and undoing back to
+    // what was saved reads as saved rather than as another change.
+    expect(editor.body.value).toBe(original)
+  })
+
+  it('leaves the parts an edit never touched exactly where they were', async () => {
+    const editor = history()
+    const drawing = editor.drawing.value
+
+    editor.body.value = withPin(editor.body.value, 'an-1')
+    await settle()
+    await pause()
+    editor.undo()
+
+    expect(editor.drawing.value).toBe(drawing)
+  })
+
   it('forgets everything when another canvas is loaded', async () => {
     const editor = history()
     editor.body.value = withPin(editor.body.value, 'a')

--- a/web/src/composables/useCanvasHistory.ts
+++ b/web/src/composables/useCanvasHistory.ts
@@ -161,7 +161,6 @@ export function useCanvasHistory<T extends object>(options: {
     undo,
     redo,
     reset,
-    checkpoint,
     canUndo: computed(() => past.value.length > 0),
     canRedo: computed(() => future.value.length > 0),
   }

--- a/web/src/composables/useCanvasHistory.ts
+++ b/web/src/composables/useCanvasHistory.ts
@@ -13,12 +13,18 @@
  * half-drawn. Undo walks back through placing a vertex, finishing a shape,
  * recolouring it and deleting it without caring which of those it is.
  *
- * Snapshots rather than a log of operations: a canvas body is small, saved
- * whole anyway, and every edit already replaces it — so a stack of snapshots
- * is both simpler and impossible to get out of step with the document.
+ * Snapshots rather than a log of operations: every edit already replaces the
+ * thing it edits, so a stack of snapshots is both simpler and impossible to
+ * get out of step with the document.
+ *
+ * A snapshot is a flat set of values, each of which is replaced rather than
+ * changed in place — that is what lets a step be the values themselves
+ * rather than a copy of them. Steps share everything an edit did not touch,
+ * so a hundred of them cost about as much as one, and a canvas carrying
+ * megabytes of imported GeoJSON is never serialised to take a step at all.
  */
 
-import { computed, ref, watch, type Ref } from 'vue'
+import { computed, shallowRef, watch, type Ref } from 'vue'
 
 /**
  * How long an edit waits for the next one before its step closes.
@@ -29,11 +35,18 @@ import { computed, ref, watch, type Ref } from 'vue'
  * however fast they come.
  */
 const IDLE_MS = 250
-/** Far more than anyone reaches for, and still nothing in memory terms. */
+/**
+ * Far more than anyone reaches for, and nothing in memory terms: steps share
+ * every part of the document an edit did not touch.
+ */
 const LIMIT = 100
 
-export function useCanvasHistory<T>(options: {
-  /** Everything an undo would have to put back. */
+export function useCanvasHistory<T extends object>(options: {
+  /**
+   * Everything an undo would have to put back, flat: every value replaced
+   * rather than mutated, so two snapshots differ exactly where an edit
+   * landed.
+   */
   snapshot: () => T
   restore: (snapshot: T) => void
   /**
@@ -43,10 +56,22 @@ export function useCanvasHistory<T>(options: {
    */
   busy?: Ref<boolean>
 }) {
-  const past = ref<string[]>([])
-  const future = ref<string[]>([])
+  // Shallow: a step holds the editor's own values, and making them reactive
+  // all over again would both cost the walk and break the identity the
+  // steps are compared by.
+  const past = shallowRef<T[]>([])
+  const future = shallowRef<T[]>([])
 
-  const take = () => JSON.stringify(options.snapshot())
+  const take = () => options.snapshot()
+
+  /** Nothing moved: every part of the snapshot is the same object as before. */
+  function unchanged(a: T, b: T) {
+    const keys = Object.keys(a) as (keyof T)[]
+    return (
+      keys.length === Object.keys(b).length &&
+      keys.every(key => Object.is(a[key], b[key]))
+    )
+  }
 
   /** The snapshot the stacks are relative to. */
   let current = take()
@@ -61,7 +86,7 @@ export function useCanvasHistory<T>(options: {
     if (options.busy?.value) return
 
     const next = take()
-    if (next === current) return
+    if (unchanged(next, current)) return
 
     const now = Date.now()
     // Still inside the idle window: the step already on the stack absorbs
@@ -85,11 +110,11 @@ export function useCanvasHistory<T>(options: {
     },
   )
 
-  function apply(snapshot: string) {
+  function apply(snapshot: T) {
     applying = true
     clearTimeout(timer)
     timer = undefined
-    options.restore(JSON.parse(snapshot) as T)
+    options.restore(snapshot)
     current = snapshot
     lastChangeAt = 0
     // Released after the watcher has seen the write and skipped it.

--- a/web/src/composables/useCanvasRendering.test.ts
+++ b/web/src/composables/useCanvasRendering.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest'
-import { computed, effectScope, nextTick } from 'vue'
+import { computed, effectScope, nextTick, ref, type Ref } from 'vue'
 import { createPinia, setActivePinia } from 'pinia'
 import { useMapStore } from '@/stores/map.store'
 import { useThemeStore } from '@/stores/theme.store'
@@ -70,7 +70,9 @@ function fakeStrategy() {
       if (!sources.has(id)) throw new Error(`source ${id} does not exist`)
       calls.push(`setSourceData:${id}`)
     },
-    toggleLayerVisibility() {},
+    toggleLayerVisibility(id: string, visible: boolean) {
+      calls.push(`visibility:${id}:${visible}`)
+    },
     fitBounds() {},
   }
 }
@@ -457,5 +459,213 @@ describe('one stack, marks and layers alike', () => {
         (strategy.configurations.get(id) as { layout?: Record<string, unknown> })
           .layout?.visibility === 'none'),
     ).toBe(true)
+  })
+})
+
+/**
+ * The engine has no "move this layer" — adding one puts it on top — so the
+ * order the panel shows only reaches the map if the renderer notices that
+ * what is mounted no longer matches what the stack says. Nothing about a
+ * layer's configuration records where it draws, so two swapped layers both
+ * look untouched: a reorder used to reach the engine as nothing at all.
+ */
+describe('reordering the stack', () => {
+  const added = () =>
+    strategy.calls
+      .filter(call => call.startsWith('addLayer:'))
+      .map(call => call.slice('addLayer:'.length))
+
+  const two = (): CanvasBody => ({
+    layers: [dataLayer({ id: 'cl-a' }), dataLayer({ id: 'cl-b' })],
+    order: ['cl-a', 'cl-b'],
+  })
+
+  it('lays the swapped layers back down in their new order', () => {
+    const body = two()
+    const instance = render('map', body)
+
+    strategy.calls.length = 0
+    body.order = ['cl-b', 'cl-a']
+    instance.render()
+
+    expect(added()).toEqual([
+      'canvas-map-canvas-1-cl-b-points',
+      'canvas-map-canvas-1-cl-a-points',
+    ])
+  })
+
+  it('leaves everything under the change where it is', () => {
+    const body = two()
+    const instance = render('map', body)
+
+    strategy.calls.length = 0
+    // Restyling the top layer says nothing about the one beneath it.
+    body.layers = [
+      dataLayer({ id: 'cl-a' }),
+      dataLayer({ id: 'cl-b', style: { color: '#ff0000' } } as never),
+    ]
+    instance.render()
+
+    expect(added()).toEqual(['canvas-map-canvas-1-cl-b-points'])
+  })
+
+  it('carries the layers above a restyled one back up with it', () => {
+    const body = two()
+    const instance = render('map', body)
+
+    strategy.calls.length = 0
+    // Re-adding the bottom layer puts it on top of the style; anything that
+    // was above it has to follow, or a recolour quietly reorders the canvas.
+    body.layers = [
+      dataLayer({ id: 'cl-a', style: { color: '#ff0000' } } as never),
+      dataLayer({ id: 'cl-b' }),
+    ]
+    instance.render()
+
+    expect(added()).toEqual([
+      'canvas-map-canvas-1-cl-a-points',
+      'canvas-map-canvas-1-cl-b-points',
+    ])
+  })
+
+  it('flips a switch without taking the layer off the map', () => {
+    const body = two()
+    const instance = render('map', body)
+
+    strategy.calls.length = 0
+    body.layers = [
+      dataLayer({ id: 'cl-a', visible: false }),
+      dataLayer({ id: 'cl-b' }),
+    ]
+    instance.render()
+
+    // A rebuild would also have moved it to the top of the style.
+    expect(strategy.calls).toEqual([
+      'visibility:canvas-map-canvas-1-cl-a-points:false',
+    ])
+  })
+})
+
+describe('a run of marks keeps its name', () => {
+  const mark = (id: string): CanvasAnnotation =>
+    ({ id, tool: 'line', positions: [[0, 0], [1, 1]] }) as CanvasAnnotation
+
+  /** A mark held out of the style because the overlay is drawing it. */
+  function renderWithSuppressed(body: CanvasBody, suppressed: Ref<string | null>) {
+    const scope = effectScope()
+    return scope.run(() =>
+      useCanvasRendering(
+        computed(() => [
+          {
+            id: 'canvas-1',
+            body,
+            suppressedAnnotationId: suppressed.value,
+          },
+        ]),
+        { key: 'map' },
+      ),
+    )!
+  }
+
+  it('does not rebuild the run when the mark at its foot is picked up', async () => {
+    const body: CanvasBody = {
+      layers: [],
+      annotations: [mark('an-1'), mark('an-2')],
+      order: ['an-1', 'an-2'],
+    }
+    const suppressed = ref<string | null>(null)
+    renderWithSuppressed(body, suppressed)
+
+    strategy.calls.length = 0
+    suppressed.value = 'an-1'
+    await nextTick()
+
+    // Naming the run after what is left of it renamed every layer in it, so
+    // reshaping the bottom mark tore the whole run down and put it back —
+    // the flash the runs exist to avoid.
+    expect(strategy.calls.filter(c => c.startsWith('addSource'))).toEqual([])
+    expect(strategy.calls.filter(c => c.startsWith('removeSource'))).toEqual([])
+    expect(strategy.calls).toEqual([
+      'setSourceData:canvas-map-canvas-1-annotations:an-1-source',
+    ])
+  })
+
+  it('keeps its name when the mark at its foot is hidden', async () => {
+    const body: CanvasBody = {
+      layers: [],
+      annotations: [
+        { ...mark('an-1'), visible: false } as CanvasAnnotation,
+        mark('an-2'),
+      ],
+      order: ['an-1', 'an-2'],
+    }
+    render('map', body)
+
+    expect([...strategy.sources]).toEqual([
+      'canvas-map-canvas-1-annotations:an-1-source',
+    ])
+  })
+})
+
+/**
+ * A run used to be given every layer any mark could need, whether or not
+ * anything in it was a pin or drew an area — and a canvas with marks between
+ * its layers pays for that set again in every run.
+ */
+describe('the layers a run actually asks for', () => {
+  /** What each of the run's layers is for, with the run's own name dropped. */
+  const suffixes = () =>
+    [...strategy.layers]
+      .map(id => /annotations:an-\w+-(.+)$/.exec(id)?.[1])
+      .filter((suffix): suffix is string => !!suffix)
+
+  it('asks for no pin, fill or label layer for a plain line', () => {
+    render('map', {
+      layers: [],
+      annotations: [
+        { id: 'an-1', tool: 'line', positions: [[0, 0], [1, 1]] } as CanvasAnnotation,
+      ],
+    })
+
+    expect(suffixes()).toEqual(['stroke-solid-round'])
+  })
+
+  it('asks for a fill where something draws an area', () => {
+    render('map', {
+      layers: [],
+      annotations: [
+        {
+          id: 'an-1',
+          tool: 'polygon',
+          positions: [[0, 0], [1, 0], [1, 1]],
+        } as CanvasAnnotation,
+      ],
+    })
+
+    expect(suffixes()).toContain('fill')
+  })
+
+  it('asks only for the marker shapes its pins wear', () => {
+    render('map', {
+      layers: [],
+      annotations: [
+        { id: 'an-1', tool: 'pin', positions: [[0, 0]] } as CanvasAnnotation,
+      ],
+    })
+
+    // A disc is a circle plate with a glyph over it; the other shapes carry
+    // their plate in the image, and nothing here wears one.
+    expect(suffixes()).toEqual(['pins-disc', 'pins-disc-glyph'])
+  })
+
+  it('asks for a label layer only once a mark carries one', () => {
+    render('map', {
+      layers: [],
+      annotations: [
+        { id: 'an-1', tool: 'pin', positions: [[0, 0]], label: 'Home' } as CanvasAnnotation,
+      ],
+    })
+
+    expect(suffixes()).toContain('labels')
   })
 })

--- a/web/src/composables/useCanvasRendering.ts
+++ b/web/src/composables/useCanvasRendering.ts
@@ -938,5 +938,7 @@ export function useCanvasRendering(
     teardown()
   })
 
-  return { render, teardown, fitToLayer, key: options.key }
+  // `render` is here for the tests, which drive a pass and read what the
+  // engine was asked to do; everything else happens on its own.
+  return { render, fitToLayer }
 }

--- a/web/src/composables/useCanvasRendering.ts
+++ b/web/src/composables/useCanvasRendering.ts
@@ -54,7 +54,7 @@ import {
 import {
   ensureMarkerImages,
   markerLayers,
-  MARKER_SHAPES,
+  type MarkerShape,
 } from '@/lib/map-marker'
 import { canvasStack, stackDrawOrder } from '@/lib/canvas-stack'
 import type {
@@ -122,23 +122,91 @@ const STROKE_DASHES: Record<string, number[] | undefined> = {
   dotted: [0.2, 1.8],
 }
 
+/** The tools that draw an area, and so need a fill layer under them. */
+const AREA_TOOLS = new Set(['polygon', 'rectangle', 'circle', 'isochrone'])
+
 /**
- * The dash-and-cap pairs a run of marks actually asks for, in a stable order.
+ * What a run of marks actually asks the style for.
  *
- * Pins draw no stroke, so they ask for nothing. Everything else contributes
- * the pair it is drawn with, which is usually one — a canvas full of solid
- * round-ended marks costs the single layer it always did.
+ * A run used to be given every layer any mark could ever need — a fill, four
+ * pin layers, a halo and a label layer — whether or not anything in it drew
+ * an area or was a pin. Most of them could never match a feature, and a
+ * canvas with marks between its layers pays for the whole set again in every
+ * run. So the run is read once, and asked for only what it uses.
+ *
+ * The dash-and-cap pairs come out the same way, and for a harder reason:
+ * neither can be read from a feature, so each pair in use needs a line layer
+ * of its own. A canvas of solid round-ended marks costs the single one it
+ * always did.
  */
-function strokeVariants(
-  annotations: CanvasAnnotation[],
-): { style: AnnotationStrokeStyle; cap: AnnotationStrokeCap }[] {
-  const seen = new Map<string, { style: AnnotationStrokeStyle; cap: AnnotationStrokeCap }>()
+interface RunLayers {
+  strokes: { style: AnnotationStrokeStyle; cap: AnnotationStrokeCap }[]
+  /** The marker shapes its pins wear; one set of layers each. */
+  shapes: MarkerShape[]
+  fill: boolean
+  labels: boolean
+}
+
+function runLayers(annotations: CanvasAnnotation[]): RunLayers {
+  const strokes = new Map<
+    string,
+    { style: AnnotationStrokeStyle; cap: AnnotationStrokeCap }
+  >()
+  const shapes = new Set<MarkerShape>()
+  let fill = false
+  let labels = false
+
   for (const annotation of annotations) {
-    if (annotation.tool === 'pin') continue
-    const { strokeStyle, strokeCap } = annotationStyle(annotation)
-    seen.set(`${strokeStyle}|${strokeCap}`, { style: strokeStyle, cap: strokeCap })
+    const style = annotationStyle(annotation)
+    if (annotation.tool === 'pin') {
+      shapes.add(style.markerShape)
+    } else {
+      // Pins draw no stroke, so they ask for no line layer.
+      strokes.set(`${style.strokeStyle}|${style.strokeCap}`, {
+        style: style.strokeStyle,
+        cap: style.strokeCap,
+      })
+    }
+    if (AREA_TOOLS.has(annotation.tool)) fill = true
+    if (annotation.label && annotation.labelVisible !== false) labels = true
   }
-  return [...seen.values()]
+
+  return { strokes: [...strokes.values()], shapes: [...shapes], fill, labels }
+}
+
+/**
+ * The serialised form of a source's data, remembered against the object it
+ * came from.
+ *
+ * A canvas can hold megabytes of imported GeoJSON, and it is handed over as
+ * the same object on every pass — so serialising it only to find it had not
+ * changed was the most expensive thing a render pass did. Marks are rebuilt
+ * each pass and miss the cache, but there is little of them.
+ */
+const dataSignatures = new WeakMap<object, string>()
+
+function dataSignature(data: unknown): string {
+  if (typeof data !== 'object' || data === null) return JSON.stringify(data)
+  const cached = dataSignatures.get(data)
+  if (cached !== undefined) return cached
+  const signature = JSON.stringify(data)
+  dataSignatures.set(data, signature)
+  return signature
+}
+
+/**
+ * A source spec split in two, because the halves cost different things to
+ * act on: everything but the data, which can only be changed by rebuilding
+ * the source, and the data itself, which a live source will take in place.
+ */
+interface SourceSignature {
+  shape: string
+  data: string
+}
+
+function sourceSignature(spec: Record<string, unknown>): SourceSignature {
+  const { data, ...shape } = spec
+  return { shape: JSON.stringify(shape), data: dataSignature(data) }
 }
 
 const EMISSIVE_KEYS: Record<string, string> = {
@@ -213,10 +281,16 @@ export function useCanvasRendering(
   const pointsStore = useEncryptedPointsStore()
   const { layers: libraryLayers } = storeToRefs(layersStore)
 
-  /** Layer id → the configuration on the map, so an unchanged layer is left alone. */
+  /**
+   * Layer id → the configuration on the map, so an unchanged layer is left
+   * alone. Insertion order is the order the engine holds them in, which is
+   * what a reorder is checked against.
+   */
   let mountedLayers = new Map<string, string>()
-  /** Source id → the spec currently on the map, so we only rebuild on change. */
-  let mountedSources = new Map<string, string>()
+  /** Layer id → whether it is currently switched on. */
+  let mountedVisible = new Map<string, boolean>()
+  /** Source id → the signature currently on the map, so we rebuild on change. */
+  let mountedSources = new Map<string, SourceSignature>()
 
   function collectionPlaces(layer: Extract<CanvasLayer, { kind: 'collection' }>) {
     const collection = collectionsStore.collections.find(
@@ -449,6 +523,13 @@ export function useCanvasRendering(
   function planAnnotations(
     strategy: MapStrategy,
     canvas: RenderableCanvas,
+    /**
+     * The run's name on the map. Taken from the mark at the bottom of the
+     * run *before* anything is held out of it — a hidden or reshaped mark
+     * must not rename the run around it, or the whole run comes off the map
+     * and goes back on, which is the flash this all exists to avoid.
+     */
+    scope: string,
     run: CanvasAnnotation[],
   ): LayerPlan {
     const annotations = run.filter(
@@ -456,11 +537,6 @@ export function useCanvasRendering(
     )
     if (!annotations.length) return EMPTY_PLAN
 
-    // Marks draw in runs now rather than as one bundle on top, so the ids are
-    // scoped to the run rather than to the canvas. Keyed by the mark at the
-    // bottom of the run: stable while the run keeps its footing, where a
-    // running index would renumber every run below an insertion.
-    const scope = `annotations:${annotations[0].id}`
     const sourceId = scopedId(options.key, canvas.id, scope, '-source')
     const id = (suffix: string) => scopedId(options.key, canvas.id, scope, suffix)
     const labels = themeStore.isDark ? LABEL_COLORS.night : LABEL_COLORS.day
@@ -470,6 +546,12 @@ export function useCanvasRendering(
     void ensureMarkerImages(
       strategy.mapInstance as never,
       annotationMarkerSpecs(annotations, themeColorToHex, themeStore.isDark),
+    )
+
+    // Only what this run's marks actually draw with — see `runLayers`.
+    const needed = runLayers(annotations)
+    const selected = annotations.some(
+      annotation => annotation.id === canvas.selectedAnnotationId,
     )
 
     return {
@@ -485,19 +567,23 @@ export function useCanvasRendering(
         },
       },
       layers: [
-        toLayer(
-          id('-fill'),
-          {
-            type: 'fill',
-            source: sourceId,
-            filter: ['==', ['geometry-type'], 'Polygon'],
-            paint: {
-              'fill-color': ['get', 'fillColor'],
-              'fill-opacity': ['get', 'fillOpacity'],
-            },
-          },
-          true,
-        ),
+        ...(needed.fill
+          ? [
+              toLayer(
+                id('-fill'),
+                {
+                  type: 'fill',
+                  source: sourceId,
+                  filter: ['==', ['geometry-type'], 'Polygon'],
+                  paint: {
+                    'fill-color': ['get', 'fillColor'],
+                    'fill-opacity': ['get', 'fillOpacity'],
+                  },
+                },
+                true,
+              ),
+            ]
+          : []),
         // One layer per dash pattern and cap in the run, and only the pairs
         // actually in it.
         //
@@ -506,7 +592,7 @@ export function useCanvasRendering(
         // constant `line-cap` — round dashes for a round cap, which is what
         // makes a dotted line read as dots — and a data-driven one leaves
         // them with no answer, so the dashes come out wrong or not at all.
-        ...strokeVariants(annotations).map(({ style, cap }) =>
+        ...needed.strokes.map(({ style, cap }) =>
           toLayer(
             id(`-stroke-${style}-${cap}`),
             {
@@ -531,37 +617,42 @@ export function useCanvasRendering(
             true,
           ),
         ),
-        // A halo under the selected annotation, so clicking one shows.
-        toLayer(
-          id('-selected'),
-          {
-            type: 'circle',
-            source: sourceId,
-            filter: [
-              'all',
-              ['==', ['geometry-type'], 'Point'],
-              ['to-boolean', ['get', 'selected']],
-            ],
-            paint: {
-              'circle-color': ['get', 'color'],
-              'circle-radius': 14,
-              'circle-opacity': 0.25,
-            },
-          },
-          true,
-        ),
+        // A halo under the selected annotation, so clicking one shows. Only
+        // the run holding it needs one.
+        ...(selected
+          ? [
+              toLayer(
+                id('-selected'),
+                {
+                  type: 'circle',
+                  source: sourceId,
+                  filter: [
+                    'all',
+                    ['==', ['geometry-type'], 'Point'],
+                    ['to-boolean', ['get', 'selected']],
+                  ],
+                  paint: {
+                    'circle-color': ['get', 'color'],
+                    'circle-radius': 14,
+                    'circle-opacity': 0.25,
+                  },
+                },
+                true,
+              ),
+            ]
+          : []),
         // A pin is drawn the way a search result is — the plate, then the glyph
         // inside it — at full size whatever the zoom. Saved places shrink and
         // fade on the way out because the low-zoom question is "where have I
         // saved things"; a pin someone placed on a canvas is answering a
         // different one and has to stay where and what it was put down as.
         //
-        // One set of layers per shape, filtered on the pin's own `markerShape`.
-        // A disc gets a circle plate with a glyph over it; a square or a bare
-        // glyph is a single symbol drawing an image that already carries its
-        // plate — see `map-marker/marker-layers` for why the two cannot be the
-        // same layer.
-        ...MARKER_SHAPES.flatMap(shape =>
+        // One set of layers per shape *the run's pins actually wear*, filtered
+        // on the pin's own `markerShape`. A disc gets a circle plate with a
+        // glyph over it; a square or a bare glyph is a single symbol drawing
+        // an image that already carries its plate — see
+        // `map-marker/marker-layers` for why the two cannot be the same layer.
+        ...needed.shapes.flatMap(shape =>
           markerLayers({
             shape,
             id: id(`-pins-${shape}`),
@@ -587,111 +678,96 @@ export function useCanvasRendering(
             iconOpacity: 1,
           }).map(layer => toLayer(layer.id, layer as never, true)),
         ),
-        toLayer(
-          id('-labels'),
-          {
-            type: 'symbol',
-            source: sourceId,
-            filter: ['!=', ['get', 'label'], ''],
-            layout: {
-              'text-field': ['get', 'label'],
-              'text-size': ['get', 'labelSize'],
-              // A label above the mark anchors by its own bottom edge, and so
-              // on round — the anchor is the opposite of where the text goes.
-              'text-anchor': [
-                'match',
-                ['get', 'labelPosition'],
-                'top',
-                'bottom',
-                'bottom',
-                'top',
-                'left',
-                'right',
-                'right',
-                'left',
-                'center',
-              ],
-              'text-offset': [
-                'match',
-                ['get', 'labelPosition'],
-                'top',
-                ['literal', [0, -1.1]],
-                'bottom',
-                ['literal', [0, 1.1]],
-                'left',
-                ['literal', [-1.1, 0]],
-                'right',
-                ['literal', [1.1, 0]],
-                ['literal', [0, 0]],
-              ],
-              'text-optional': true,
-            },
-            paint: {
-              'text-color': labels.text,
-              'text-halo-color': labels.halo,
-              'text-halo-width': labels.haloWidth,
-            },
-          },
-          true,
-        ),
+        ...(needed.labels
+          ? [
+              toLayer(
+                id('-labels'),
+                {
+                  type: 'symbol',
+                  source: sourceId,
+                  filter: ['!=', ['get', 'label'], ''],
+                  layout: {
+                    'text-field': ['get', 'label'],
+                    'text-size': ['get', 'labelSize'],
+                    // A label above the mark anchors by its own bottom edge, and so
+                    // on round — the anchor is the opposite of where the text goes.
+                    'text-anchor': [
+                      'match',
+                      ['get', 'labelPosition'],
+                      'top',
+                      'bottom',
+                      'bottom',
+                      'top',
+                      'left',
+                      'right',
+                      'right',
+                      'left',
+                      'center',
+                    ],
+                    'text-offset': [
+                      'match',
+                      ['get', 'labelPosition'],
+                      'top',
+                      ['literal', [0, -1.1]],
+                      'bottom',
+                      ['literal', [0, 1.1]],
+                      'left',
+                      ['literal', [-1.1, 0]],
+                      'right',
+                      ['literal', [1.1, 0]],
+                      ['literal', [0, 0]],
+                    ],
+                    'text-optional': true,
+                  },
+                  paint: {
+                    'text-color': labels.text,
+                    'text-halo-color': labels.halo,
+                    'text-halo-width': labels.haloWidth,
+                  },
+                },
+                true,
+              ),
+            ]
+          : []),
       ],
     }
-  }
-
-  /**
-   * The data of a GeoJSON source whose spec changed in no other way, or
-   * undefined if the source has to be rebuilt.
-   *
-   * Worth telling apart: rebuilding a source means dropping every layer drawn
-   * from it and adding them all back. That is slow, and it is visible — the
-   * annotation bucket would flash on every mark committed.
-   */
-  function inlineDataChange(
-    previousSpec: string,
-    spec: Record<string, unknown>,
-  ): unknown | undefined {
-    if (spec.type !== 'geojson' || spec.data === undefined) return undefined
-    let previous: Record<string, unknown>
-    try {
-      previous = JSON.parse(previousSpec)
-    } catch {
-      return undefined
-    }
-    if (previous.type !== 'geojson') return undefined
-
-    const withoutData = (source: Record<string, unknown>) =>
-      JSON.stringify(
-        Object.keys(source)
-          .filter(key => key !== 'data')
-          .sort()
-          .map(key => [key, source[key]]),
-      )
-    return withoutData(previous) === withoutData(spec) ? spec.data : undefined
   }
 
   function render() {
     const strategy = mapStore.getMapStrategy()
     if (!strategy) return
 
-    /** Source id → its serialised spec, and the spec itself to hand over. */
-    const nextSources = new Map<string, string>()
+    /** Source id → its signature, and the spec itself to hand over. */
+    const nextSources = new Map<string, SourceSignature>()
     const specs = new Map<string, Record<string, unknown>>()
     /** Layer id → serialised configuration, the key for "has this changed". */
     const nextLayers = new Map<string, string>()
-    const plans: { plan: LayerPlan; visible: boolean }[] = []
+    /**
+     * Kept apart from the configuration: a switch flipping is one call to the
+     * engine, where a changed configuration means taking the layer off and
+     * putting it back — and putting it back moves it to the top of the style.
+     */
+    const nextVisible = new Map<string, boolean>()
+    /** Every layer this pass wants, bottom first — the order it must draw in. */
+    const ordered: { layer: Layer; visible: boolean }[] = []
+    /** Which sources a layer draws from, for "did one of them get rebuilt". */
+    const drawnFrom = new Map<string, string[]>()
 
     function collect(plan: LayerPlan, visible: boolean) {
-      plans.push({ plan, visible })
       for (const [id, spec] of Object.entries(plan.sources)) {
-        nextSources.set(id, JSON.stringify(spec))
+        nextSources.set(id, sourceSignature(spec))
         specs.set(id, spec)
       }
       for (const layer of plan.layers) {
         layer.configuration = withEmissive(
           layer.configuration as Record<string, unknown>,
         ) as typeof layer.configuration
-        nextLayers.set(layer.id, JSON.stringify([layer.configuration, visible]))
+        nextLayers.set(layer.id, JSON.stringify(layer.configuration))
+        nextVisible.set(layer.id, visible)
+        ordered.push({ layer, visible })
       }
+      const sources = Object.keys(plan.sources)
+      for (const layer of plan.layers) drawnFrom.set(layer.id, sources)
     }
 
     for (const canvas of canvases.value) {
@@ -705,6 +781,10 @@ export function useCanvasRendering(
         const plan = planAnnotations(
           strategy,
           canvas,
+          // Named after the mark at the bottom of the run as the stack has
+          // it, not as the run ends up drawn: hiding that mark, or picking
+          // it up to reshape, must not rename the run around it.
+          `annotations:${run[0].annotation.id}`,
           run.filter(entry => entry.visible).map(entry => entry.annotation),
         )
         if (plan.layers.length) collect(plan, true)
@@ -731,31 +811,27 @@ export function useCanvasRendering(
      */
     const updating = new Map<string, unknown>()
     const rebuilding = new Set<string>()
-    for (const [id, spec] of nextSources) {
+    for (const [id, signature] of nextSources) {
       const previous = mountedSources.get(id)
-      if (previous === spec) continue
-      const data =
-        previous === undefined
-          ? undefined
-          : inlineDataChange(previous, specs.get(id)!)
-      if (data === undefined) rebuilding.add(id)
-      else updating.set(id, data)
+      if (previous?.shape === signature.shape) {
+        // Only the features changed, which a live source will take as it is.
+        if (previous.data !== signature.data) {
+          updating.set(id, specs.get(id)!.data)
+        }
+        continue
+      }
+      rebuilding.add(id)
     }
 
-    const onRebuiltSource = new Set(
-      plans
-        .filter(({ plan }) =>
-          Object.keys(plan.sources).some(id => rebuilding.has(id)),
-        )
-        .flatMap(({ plan }) => plan.layers.map(layer => layer.id)),
-    )
+    const onRebuiltSource = (layerId: string) =>
+      (drawnFrom.get(layerId) ?? []).some(id => rebuilding.has(id))
 
     // Nothing may reference a source we are about to drop — the engine
     // refuses outright, and the failed drop used to leave the next addSource
     // colliding with the source it thought it had removed. So layers come off
     // first: the ones going away, and the ones sitting on a rebuilt source.
     for (const id of [...mountedLayers.keys()]) {
-      if (!nextLayers.has(id) || onRebuiltSource.has(id)) {
+      if (!nextLayers.has(id) || onRebuiltSource(id)) {
         strategy.removeLayer(id)
         mountedLayers.delete(id)
       }
@@ -765,25 +841,51 @@ export function useCanvasRendering(
       if (!nextSources.has(id) || rebuilding.has(id)) strategy.removeSource(id)
     }
 
+    for (const [id, spec] of specs) {
+      if (rebuilding.has(id)) strategy.addSource(id, spec)
+    }
+
     for (const [id, data] of updating) strategy.setSourceData(id, data)
 
-    for (const { plan, visible } of plans) {
-      for (const [id, spec] of Object.entries(plan.sources)) {
-        if (rebuilding.has(id)) strategy.addSource(id, spec)
+    /**
+     * Where the style stops matching what the stack now says, and everything
+     * from there up has to be laid down again.
+     *
+     * The engine has no "move this layer": adding one puts it on top. So a
+     * pass keeps the longest run of layers that are already unchanged *and*
+     * already in the right order, and re-adds the rest in order above it.
+     * Skipping unchanged layers wherever they sat is what used to make a
+     * reorder a no-op — nothing about a layer says where it draws, so two
+     * swapped layers both looked untouched and the map never heard about it.
+     */
+    const mounted = [...mountedLayers.keys()]
+    let held = 0
+    let from = ordered.length
+    for (const [index, { layer }] of ordered.entries()) {
+      const unchanged = mountedLayers.get(layer.id) === nextLayers.get(layer.id)
+      if (unchanged && mounted[held] === layer.id) {
+        held++
+        continue
       }
-      for (const mapLayer of plan.layers) {
-        // Re-adding an unchanged layer rebuilds the style for nothing, and
-        // this used to run for every layer on every pass — which is why
-        // moving the pointer rebuilt the whole canvas, sixty times a second.
-        if (mountedLayers.get(mapLayer.id) === nextLayers.get(mapLayer.id)) {
-          continue
+      from = index
+      break
+    }
+
+    for (const [index, { layer, visible }] of ordered.entries()) {
+      if (index < from) {
+        // Untouched and already in the right place; only its switch can have
+        // moved, and that is one call rather than a rebuild.
+        if (mountedVisible.get(layer.id) !== visible) {
+          strategy.toggleLayerVisibility(layer.id, visible)
         }
-        strategy.addLayer(mapLayer, true)
-        strategy.toggleLayerVisibility(mapLayer.id, visible)
+        continue
       }
+      strategy.addLayer(layer, true)
+      strategy.toggleLayerVisibility(layer.id, visible)
     }
 
     mountedLayers = nextLayers
+    mountedVisible = nextVisible
     mountedSources = nextSources
   }
 
@@ -791,8 +893,9 @@ export function useCanvasRendering(
     const strategy = mapStore.getMapStrategy()
     if (!strategy) return
     mountedLayers.forEach((_configuration, id) => strategy.removeLayer(id))
-    mountedSources.forEach((_spec, id) => strategy.removeSource(id))
+    mountedSources.forEach((_signature, id) => strategy.removeSource(id))
     mountedLayers = new Map()
+    mountedVisible = new Map()
     mountedSources = new Map()
   }
 

--- a/web/src/composables/useCanvasRendering.ts
+++ b/web/src/composables/useCanvasRendering.ts
@@ -899,7 +899,11 @@ export function useCanvasRendering(
     mountedSources = new Map()
   }
 
-  watch(canvases, render, { deep: true, immediate: true })
+  // Shallow: a canvas body is replaced rather than changed in place, both in
+  // the editor's working copy and in the store, so the list changes identity
+  // whenever anything in it does. A deep watch would only add a walk of every
+  // feature on the canvas — and a canvas can carry megabytes of them.
+  watch(canvases, render, { immediate: true })
 
   // Turning the map to night changes what a label has to be to stay readable,
   // and nothing else would prompt a redraw for it.

--- a/web/src/composables/useDrawingSurface.test.ts
+++ b/web/src/composables/useDrawingSurface.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { effectScope } from 'vue'
+import { createPinia, setActivePinia } from 'pinia'
+import { useMapStore } from '@/stores/map.store'
+import { useDrawingSurface } from './useDrawingSurface'
+
+/**
+ * The two things here that are more than a forwarding call: turning a
+ * pointer event into a position on the ground, and asking the engine what it
+ * drew around one. Both are measured against the canvas the map draws into,
+ * which is what a bare `clientX` would get wrong the moment the map is not
+ * flush with the window.
+ */
+
+function fakeMap(features: { properties?: Record<string, unknown> }[] = []) {
+  const canvas = document.createElement('canvas')
+  canvas.getBoundingClientRect = () =>
+    ({ left: 100, top: 40 }) as DOMRect
+  return {
+    canvas,
+    getCanvas: () => canvas,
+    project: ([lng, lat]: number[]) => ({ x: lng, y: lat }),
+    unproject: ([x, y]: [number, number]) => ({ lng: x, lat: y }),
+    queryRenderedFeatures: vi.fn(() => features),
+  }
+}
+
+function surface(map: unknown) {
+  const scope = effectScope()
+  return scope.run(() => {
+    useMapStore().setMapStrategy({ mapInstance: map } as never)
+    return useDrawingSurface()
+  })!
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia())
+  localStorage.clear()
+})
+
+describe('useDrawingSurface', () => {
+  it('measures a pointer from the map, not from the window', () => {
+    const api = surface(fakeMap())
+
+    expect(api.positionAt({ clientX: 130, clientY: 60 })).toEqual([30, 20])
+  })
+
+  it('has an answer before the map does', () => {
+    const api = surface(undefined)
+
+    // A canvas can be open before the engine has finished loading.
+    expect(api.positionAt({ clientX: 1, clientY: 1 })).toBeNull()
+    expect(api.screenDistance([0, 0], [3, 4])).toBeNull()
+    expect(api.idsAround([0, 0], 6)).toEqual([])
+    expect(() => api.setPanning(true)).not.toThrow()
+  })
+
+  it('asks the engine for a box around the point, not the point itself', () => {
+    const map = fakeMap([{ properties: { id: 'an-1' } }])
+    const api = surface(map)
+
+    // A hairline is otherwise almost unhittable.
+    expect(api.idsAround([50, 20], 6)).toEqual(['an-1'])
+    expect(map.queryRenderedFeatures).toHaveBeenCalledWith([
+      [44, 14],
+      [56, 26],
+    ])
+  })
+
+  it('keeps only the ids of things that have one', () => {
+    const api = surface(
+      fakeMap([
+        { properties: { id: 'an-1' } },
+        // The basemap's own features come back too, and most carry no id.
+        { properties: {} },
+        { properties: { id: 42 } },
+      ]),
+    )
+
+    expect(api.idsAround([0, 0], 6)).toEqual(['an-1'])
+  })
+
+  it('only clears the cursor it put there', () => {
+    const map = fakeMap()
+    const api = surface(map)
+
+    map.canvas.style.cursor = 'crosshair'
+    api.clearCursor('grab')
+    expect(map.canvas.style.cursor).toBe('crosshair')
+
+    api.setCursor('grab')
+    api.clearCursor('grab')
+    expect(map.canvas.style.cursor).toBe('')
+  })
+})

--- a/web/src/composables/useDrawingSurface.ts
+++ b/web/src/composables/useDrawingSurface.ts
@@ -1,0 +1,158 @@
+/**
+ * The map, as the things you draw on it need it.
+ *
+ * Drawing reaches past the strategies and talks to the engine's own map
+ * instance: it has to unproject a pointer, ask what was drawn under it, and
+ * take away the gestures that use the same inputs a tool does. Neither
+ * engine's type is ours to widen, so every place that needed one of those
+ * used to cast the instance to a one-off shape naming just the parts it
+ * touched — nine of them across the drawing tools, each a slightly different
+ * guess at the same object.
+ *
+ * This is that shape, written once. Every member is optional and every
+ * helper is a no-op before the map exists, because a canvas can be open
+ * before the engine has finished loading.
+ */
+
+import type { Position } from 'geojson'
+import { useMapStore } from '@/stores/map.store'
+
+/** A gesture the engine can be told to stand down. */
+interface Gesture {
+  enable: () => void
+  disable: () => void
+}
+
+export interface DrawingSurface {
+  getCanvas?: () => HTMLCanvasElement
+  project?: (position: Position) => { x: number; y: number }
+  unproject?: (point: [number, number]) => { lng: number; lat: number }
+  queryRenderedFeatures?: (
+    box: [[number, number], [number, number]],
+  ) => { properties?: Record<string, unknown> | null }[]
+  dragPan?: Gesture
+  doubleClickZoom?: Gesture
+  boxZoom?: Gesture
+  on?: (event: string, handler: (event: never) => void) => void
+  off?: (event: string, handler: (event: never) => void) => void
+}
+
+export function useDrawingSurface() {
+  const mapStore = useMapStore()
+
+  /** The engine's map instance, or undefined before there is one. */
+  const map = () =>
+    mapStore.getMapStrategy()?.mapInstance as DrawingSurface | undefined
+
+  /** The element the map draws into — what pointer events are measured from. */
+  const element = () => map()?.getCanvas?.()
+
+  function setCursor(cursor: string) {
+    const canvas = element()
+    if (canvas) canvas.style.cursor = cursor
+  }
+
+  /** The cursor, but only if it is still the one we set. */
+  function clearCursor(ours: string) {
+    const canvas = element()
+    if (canvas?.style.cursor === ours) canvas.style.cursor = ''
+  }
+
+  /** The map's own drag, which has to stand down for the length of a stroke. */
+  function setPanning(enabled: boolean) {
+    const gesture = map()?.dragPan
+    if (enabled) gesture?.enable()
+    else gesture?.disable()
+  }
+
+  /**
+   * The gestures that share a tool's inputs.
+   *
+   * Two vertices placed in quick succession read as a double-click, and the
+   * map zoomed instead of taking the second point; shift starts a box zoom
+   * and swallows the click outright, so holding it to constrain a shape
+   * placed nothing at all.
+   */
+  function setMapGestures(enabled: boolean) {
+    const instance = map()
+    if (!instance) return
+    if (enabled) {
+      instance.doubleClickZoom?.enable()
+      instance.boxZoom?.enable()
+    } else {
+      instance.doubleClickZoom?.disable()
+      instance.boxZoom?.disable()
+    }
+  }
+
+  /** Where a pointer event is, in the canvas's own coordinates. */
+  function pointAt(event: {
+    clientX: number
+    clientY: number
+  }): { x: number; y: number } | null {
+    const canvas = element()
+    if (!canvas) return null
+    const rect = canvas.getBoundingClientRect()
+    return { x: event.clientX - rect.left, y: event.clientY - rect.top }
+  }
+
+  /** Where a pointer event is, on the ground. */
+  function positionAt(event: {
+    clientX: number
+    clientY: number
+  }): Position | null {
+    const instance = map()
+    const point = pointAt(event)
+    if (!instance?.unproject || !point) return null
+    const { lng, lat } = instance.unproject([point.x, point.y])
+    return [lng, lat]
+  }
+
+  /**
+   * How far apart two positions are on screen, or null if the map can't say.
+   *
+   * Judged in pixels rather than metres: two points a metre apart are the
+   * same click at one zoom and far apart at another.
+   */
+  function screenDistance(a: Position, b: Position): number | null {
+    const project = map()?.project
+    if (!project) return null
+    const from = project(a)
+    const to = project(b)
+    return Math.hypot(from.x - to.x, from.y - to.y)
+  }
+
+  /**
+   * The ids of everything the engine drew within `radius` pixels of a point.
+   *
+   * Asking the engine rather than hit-testing the geometry here: a mark is as
+   * thick as its stroke and as big as its label, and only the thing that
+   * painted it knows that. Everything else drawn there comes back too — the
+   * basemap's own features included — so the caller decides which are its.
+   */
+  function idsAround(position: Position, radius: number): string[] {
+    const instance = map()
+    if (!instance?.project || !instance.queryRenderedFeatures) return []
+    const { x, y } = instance.project(position)
+    return instance
+      .queryRenderedFeatures([
+        [x - radius, y - radius],
+        [x + radius, y + radius],
+      ])
+      .map(feature => feature.properties?.id)
+      .filter((id): id is string => typeof id === 'string')
+  }
+
+  return {
+    map,
+    element,
+    setCursor,
+    clearCursor,
+    setPanning,
+    setMapGestures,
+    pointAt,
+    positionAt,
+    screenDistance,
+    idsAround,
+  }
+}

--- a/web/src/composables/useLatestRequest.ts
+++ b/web/src/composables/useLatestRequest.ts
@@ -1,0 +1,66 @@
+/**
+ * One request at a time, where asking again replaces the ask before it.
+ *
+ * The canvas asks the routing engine for a path while its waypoints are
+ * still being placed, and the isochrone engine for a shape while the reach
+ * is still being dragged — so the answer that matters is always the last one
+ * asked for, and everything before it is so much wasted network. Each of
+ * those places used to keep its own AbortController, its own "is one in
+ * flight" flag and its own idea of which errors were worth a console line;
+ * there were four copies of it across the drawing tools.
+ *
+ * A superseded call resolves to `SUPERSEDED` rather than to nothing, because
+ * the two mean opposite things to a caller: a request that failed leaves the
+ * mark with no answer, while one that was replaced has a better answer
+ * already on its way and must leave everything exactly as it is.
+ */
+
+import { onScopeDispose, ref } from 'vue'
+
+/** What a call resolves to when a newer one took its place. */
+export const SUPERSEDED = Symbol('superseded')
+
+/** Cancelled, rather than failed — including our own `RouteSnapAborted`. */
+function isAbort(error: unknown): boolean {
+  return !!(error as Error | undefined)?.name?.includes('Abort')
+}
+
+export function useLatestRequest(label: string) {
+  /**
+   * Follows the newest request only: a superseded one clearing this would
+   * say the engine had finished while its answer was still on the way.
+   */
+  const pending = ref(false)
+  let controller: AbortController | undefined
+
+  async function run<T>(
+    task: (signal: AbortSignal) => Promise<T>,
+  ): Promise<T | undefined | typeof SUPERSEDED> {
+    controller?.abort()
+    const mine = new AbortController()
+    controller = mine
+    pending.value = true
+    try {
+      return await task(mine.signal)
+    } catch (error) {
+      if (isAbort(error)) return SUPERSEDED
+      console.error(`[canvas] ${label}`, error)
+      return undefined
+    } finally {
+      if (controller === mine) {
+        pending.value = false
+        controller = undefined
+      }
+    }
+  }
+
+  function abort() {
+    controller?.abort()
+    controller = undefined
+    pending.value = false
+  }
+
+  onScopeDispose(abort)
+
+  return { pending, run, abort }
+}

--- a/web/src/lib/canvas-annotations.ts
+++ b/web/src/lib/canvas-annotations.ts
@@ -27,6 +27,7 @@ import {
 } from '@/lib/map-marker'
 import {
   ANNOTATION_STYLE_DEFAULTS,
+  newCanvasId,
   type AnnotationLabelPosition,
   type AnnotationTool,
   type CanvasAnnotation,
@@ -507,7 +508,7 @@ export function createAnnotation(
   routed?: CanvasAnnotation['routed'],
 ): CanvasAnnotation {
   const annotation: CanvasAnnotation = {
-    id: `an-${Math.random().toString(36).slice(2, 10)}`,
+    id: newCanvasId('an'),
     tool,
     positions,
     color: DEFAULT_ANNOTATION_COLOR,

--- a/web/src/lib/canvas-draw-style.ts
+++ b/web/src/lib/canvas-draw-style.ts
@@ -70,6 +70,29 @@ export const TOOL_STYLE_OPTIONS: Record<CanvasTool, DrawOption[]> = {
   isochrone: AREA,
 }
 
+/**
+ * The range each numeric setting is offered over, and how it reads.
+ *
+ * A mark can be styled in two places — the tool options bar, for the next
+ * one, and a finished mark's own editor — and they were each carrying their
+ * own idea of how thick a stroke can get. One table, so they cannot drift.
+ *
+ * The opacities are held as percentages, which is what both controls show
+ * and what neither wants to convert twice.
+ */
+export const STYLE_RANGES = {
+  strokeWidth: { min: 1, max: 24, step: 1 },
+  strokeOpacity: { min: 0, max: 100, step: 5 },
+  fillOpacity: { min: 0, max: 100, step: 5 },
+  markerSize: { min: 4, max: 20, step: 0.5 },
+  labelSize: { min: 8, max: 32, step: 1 },
+} as const
+
+/** An opacity as it is shown beside the control that sets it. */
+export function percentLabel(value: number): string {
+  return `${Math.round(value * 100)}%`
+}
+
 /** Whether a tool is styled by this setting at all. */
 export function hasStyleOption(
   tool: CanvasTool,

--- a/web/src/lib/route-snapping.ts
+++ b/web/src/lib/route-snapping.ts
@@ -110,7 +110,13 @@ export function pathFromTrip(trip: any): SnappedPath {
   }
 }
 
-export class RouteSnapAborted extends Error {}
+/**
+ * Named for what the platform calls a cancelled request, so anything asking
+ * "was this abandoned or did it fail" gets one answer for both.
+ */
+export class RouteSnapAborted extends Error {
+  override name = 'AbortError'
+}
 
 /**
  * Route between the given waypoints. Returns null when the engine had nothing

--- a/web/src/types/canvas.types.ts
+++ b/web/src/types/canvas.types.ts
@@ -412,6 +412,19 @@ export interface CreateCanvasParams {
   scheme?: CanvasScheme
 }
 
+/**
+ * A new id for something on a canvas, prefixed by what it is: `cl` a layer,
+ * `cg` a group, `an` a mark.
+ *
+ * The prefix is what makes an id read in a document, in a map layer id or in
+ * a log say what it belongs to — so it is worth there being one place that
+ * mints them rather than the same expression written out wherever something
+ * new is made.
+ */
+export function newCanvasId(kind: 'cl' | 'cg' | 'an'): string {
+  return `${kind}-${Math.random().toString(36).slice(2, 10)}`
+}
+
 /** An empty body, so callers never have to null-check the layer list. */
 export function emptyCanvasBody(): CanvasBody {
   return { layers: [], annotations: [] }

--- a/web/src/views/library/canvases/CanvasEditor.vue
+++ b/web/src/views/library/canvases/CanvasEditor.vue
@@ -68,6 +68,7 @@ import type { ThemeColor } from '@/lib/utils'
 import {
   cloneCanvasBody,
   emptyCanvasBody,
+  newCanvasId,
   type CanvasAnnotation,
   type CanvasBody,
   type CanvasDataLayer,
@@ -161,10 +162,6 @@ const isDirty = computed(() => body.value !== saved.value)
 
 // ── Annotations ──────────────────────────────────────────────────────────────
 
-/**
- * Marks made on the canvas rather than data brought to it. They live in their
- * own bucket, so drawing never asks the user to create a layer first.
- */
 /**
  * The row the panel is pointed at, whichever kind it is. A selected mark also
  * opens into its properties and takes the map's halo; a selected layer just
@@ -423,7 +420,7 @@ function addLayer(layer: CanvasLayer) {
   nextTick(() => fitToLayer(props.id, layer))
 }
 
-async function removeLayer(id: string) {
+function removeLayer(id: string) {
   if (selectedId.value === id) selectedId.value = null
   body.value = removeFromStack(
     { ...body.value, layers: body.value.layers.filter(l => l.id !== id) },
@@ -491,7 +488,7 @@ function patchGroup(id: string, patch: Partial<CanvasGroup>) {
  */
 function addGroup() {
   const group: CanvasGroup = {
-    id: `cg-${Math.random().toString(36).slice(2, 10)}`,
+    id: newCanvasId('cg'),
     name: t('canvases.groups.untitled'),
     visible: true,
     children: [],
@@ -561,16 +558,11 @@ function patchDataLayer(patch: Partial<CanvasDataLayer>) {
   patchLayer(editingDataLayerId.value, patch as Partial<CanvasLayer>)
 }
 
-
 // ── Adding layers ────────────────────────────────────────────────────────────
 
 const sourcesOpen = ref(false)
 const addOpen = ref(false)
 const pickerStep = ref<'library' | 'collection' | 'route' | null>(null)
-
-function newLayerId() {
-  return `cl-${Math.random().toString(36).slice(2, 10)}`
-}
 
 function createStyleLayer() {
   router.push({ name: AppRoute.LAYER_EDITOR_NEW, query: { canvas: props.id } })
@@ -584,7 +576,7 @@ function createStyleLayer() {
 function addLibrarySource(source: DataSourceDefinition) {
   if (source.layer.type === 'style') {
     addLayer({
-      id: newLayerId(),
+      id: newCanvasId('cl'),
       kind: 'style',
       name: source.name,
       visible: true,
@@ -594,7 +586,7 @@ function addLibrarySource(source: DataSourceDefinition) {
   }
 
   addLayer({
-    id: newLayerId(),
+    id: newCanvasId('cl'),
     kind: 'data',
     name: source.name,
     visible: true,
@@ -615,7 +607,7 @@ function addImportedData(result: {
   const collection = result.collection as CanvasDataLayer['data']
   const render = inferRender(countGeometries(collection))
   addLayer({
-    id: newLayerId(),
+    id: newCanvasId('cl'),
     kind: 'data',
     name: result.name,
     visible: true,
@@ -667,7 +659,7 @@ const addMenuItems = computed(() => [
     label: t('canvases.add.options.people.title'),
     icon: UsersIcon,
     onSelect: () =>
-      addLayer({ id: newLayerId(), kind: 'people', visible: true }),
+      addLayer({ id: newCanvasId('cl'), kind: 'people', visible: true }),
   },
   { type: 'separator' as const },
   { type: 'label' as const, label: t('canvases.add.groups.data') },

--- a/web/src/views/library/canvases/CanvasEditor.vue
+++ b/web/src/views/library/canvases/CanvasEditor.vue
@@ -8,7 +8,15 @@
  * Save; leaving with unsaved work asks first, which is also what the sheet's
  * close button ends up doing.
  */
-import { computed, nextTick, onScopeDispose, provide, ref, watch } from 'vue'
+import {
+  computed,
+  nextTick,
+  onScopeDispose,
+  provide,
+  ref,
+  shallowRef,
+  watch,
+} from 'vue'
 import { useHotkeys } from '@/composables/useHotkeys'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
@@ -107,19 +115,28 @@ const { canvases } = storeToRefs(canvasesStore)
 
 const canvas = computed(() => canvases.value.find(c => c.id === props.id))
 
-/** The working copy. Nothing here reaches the server until Save. */
+/** The working copy. Nothing here reaches the server until it is saved. */
 const body = ref<CanvasBody>(emptyCanvasBody())
-const pristine = ref('')
+/**
+ * The body that is on the server, held by identity rather than by a copy of
+ * its text.
+ *
+ * Every edit replaces the body rather than changing it in place, so "has
+ * anything moved" is one comparison — where serialising a canvas that can
+ * carry megabytes of imported GeoJSON was the most expensive thing a
+ * keystroke did. It also means undoing back to what was saved reads as
+ * saved, since the step put the very same body back.
+ */
+const saved = shallowRef<CanvasBody | null>(null)
 const loading = ref(true)
 const saving = ref(false)
 
 function load() {
   body.value = cloneCanvasBody(canvas.value?.body)
-  pristine.value = JSON.stringify(body.value)
+  saved.value = body.value
   // Nothing before the canvas was opened is undoable.
   history.reset()
 }
-
 
 
 // A cold load (opened from a link, or after a reload) has neither the canvas
@@ -140,7 +157,7 @@ function load() {
   }
 })()
 
-const isDirty = computed(() => JSON.stringify(body.value) !== pristine.value)
+const isDirty = computed(() => body.value !== saved.value)
 
 // ── Annotations ──────────────────────────────────────────────────────────────
 
@@ -203,13 +220,12 @@ watch(selectedAnnotationId, id => {
  * half-drawn on it. See `useCanvasHistory` for why they can't be separate.
  */
 const history = useCanvasHistory({
-  snapshot: () => ({
-    body: body.value,
-    drawing: annotations.snapshot(),
-  }),
+  // Flat, and every part replaced rather than changed in place, which is
+  // what lets a step be the values themselves — see `useCanvasHistory`.
+  snapshot: () => ({ body: body.value, ...annotations.snapshot() }),
   restore: snapshot => {
     body.value = snapshot.body
-    annotations.restore(snapshot.drawing)
+    annotations.restore(snapshot)
   },
   busy: annotations.isBusy,
 })
@@ -708,13 +724,13 @@ async function save() {
 
   clearTimeout(saveTimer)
   saveTimer = undefined
-  const attempted = JSON.stringify(body.value)
+  const attempted = body.value
   saving.value = true
   try {
-    const saved = await canvasesService.saveBody(canvas.value, body.value)
-    // `pristine` records what actually reached the server, not what the
-    // working copy holds now — it may have moved on while this was away.
-    if (saved) pristine.value = attempted
+    const written = await canvasesService.saveBody(canvas.value, attempted)
+    // What actually reached the server, not what the working copy holds now
+    // — it may have moved on while this was away.
+    if (written) saved.value = attempted
   } finally {
     saving.value = false
     if (saveAgain) {
@@ -724,15 +740,13 @@ async function save() {
   }
 }
 
-watch(
-  body,
-  () => {
-    if (!canvas.value || !isDirty.value) return
-    clearTimeout(saveTimer)
-    saveTimer = setTimeout(() => void save(), SAVE_DEBOUNCE_MS)
-  },
-  { deep: true },
-)
+// Shallow: every edit replaces the body, so there is nothing a deep watch
+// would catch — only a walk of every feature in it to find that out.
+watch(body, () => {
+  if (!canvas.value || !isDirty.value) return
+  clearTimeout(saveTimer)
+  saveTimer = setTimeout(() => void save(), SAVE_DEBOUNCE_MS)
+})
 
 // Closing the editor shouldn't drop the last second of work.
 onScopeDispose(() => {

--- a/web/src/views/library/layers/LayerEditor.vue
+++ b/web/src/views/library/layers/LayerEditor.vue
@@ -43,7 +43,7 @@ import { Checkbox } from '@/components/ui/checkbox'
 import { IconPicker } from '@/components/ui/icon-picker'
 import { Spinner } from '@/components/ui/spinner'
 import { MapEngine, type Layer } from '@/types/map.types'
-import type { CanvasStyleLayer } from '@/types/canvas.types'
+import { newCanvasId, type CanvasStyleLayer } from '@/types/canvas.types'
 import { DownloadIcon, EyeIcon, EyeOffIcon } from 'lucide-vue-next'
 
 const props = defineProps<{ id?: string }>()
@@ -199,7 +199,7 @@ async function saveToCanvas(fields: ReturnType<typeof draftToLayerFields>) {
   const target = canvas.value
   if (!target) return
   const layer: CanvasStyleLayer = {
-    id: props.id ?? `cl-${Math.random().toString(36).slice(2, 10)}`,
+    id: props.id ?? newCanvasId('cl'),
     kind: 'style',
     name: fields.name,
     icon: fields.icon,


### PR DESCRIPTION
A review pass over the canvas feature — the renderer, the drawing tools, the editor, the store and the API. Three of the things it turned up are bugs; the rest is what a canvas costs to edit.

## Bugs

**Reordering the stack told the map nothing.** A render pass skipped any layer whose configuration was unchanged, and nothing in a configuration records where a layer draws — so two swapped layers both looked untouched and the drag reached the engine as no calls at all. The order only took effect when something else forced a redraw. The same blind spot ran the other way: the engine has no "move this layer", so re-adding a restyled one quietly lifted it above everything it had been under.

A pass now keeps the longest run of layers that are unchanged *and* already in the right place, and lays the rest down again in order above it. Visibility is tracked apart from the configuration, so flipping a switch is one call rather than a rebuild that also reorders.

**Reshaping the mark at the foot of a run tore the run off the map.** Marks that sit together share a source and a set of style layers, named after the mark at the bottom — but the name was taken after the suppressed and hidden marks had been filtered out, so picking that mark up renamed every layer in the run: 8 removals and 8 additions, twice per drag. It takes its name from the stack now, before anything is held out.

**Changing a travel-time area's reach while the engine was thinking lost the mark.** The abandoned request's error handler cleared the origin, and the answer that was still on its way arrived to find nothing to attach itself to. `useLatestRequest` now distinguishes a request that failed from one a newer ask replaced.

## Speed

A canvas can hold 4 MB of imported GeoJSON per layer (`MAX_IMPORT_BYTES`), and every edit was writing the document out three or four times over: once for the dirty check, twice to take an undo step, once more to work out what the map had to be told — plus a deep watch walking every feature to notice the edit at all. Measured on the dev box: 21 ms to serialise a 4 MB body, 60 ms to parse one back, 36 ms to walk one. So roughly 80 ms an edit before anything was saved, and more on the save tick; several times that on a phone.

Nothing is copied to answer any of those now:

- **Dirty** is the body compared to the one that reached the server, by identity — every edit replaces the body rather than changing it in place. Undoing back to what was saved reads as saved, because the step put the very same body back.
- **Undo steps** hold the editor's own values instead of a JSON string, so a hundred of them share everything the edits did not touch. The stack held up to 100 full copies before.
- **Both watchers** see a replacement without walking what is inside it.
- **A source** is compared as two halves, its shape and its data, and the data half is remembered against the object it came from — so an unchanged inline dataset is recognised by identity rather than serialised and parsed on every pass.
- **A run of marks** asks for the layers it uses rather than every layer any mark could need. A run of plain lines is one layer now instead of eight — a fill, four sets of pin layers, a halo and a label layer that could never match a feature.
- **A save** no longer gets the whole document echoed back at it. `PUT /library/canvases/:id` answers without the body; both callers overwrote it with their own copy the moment it arrived.

## Tidying

One place mints an id for something on a canvas, rather than the same expression in five files. One table holds the range each numeric setting is offered over, rather than the tool options bar and a mark's own editor each carrying their own idea of how thick a stroke can get.

Two new composables replace duplicated machinery rather than adding any: `useDrawingSurface` is the shape of the engine's map instance that drawing needs, written once instead of nine one-off casts; `useLatestRequest` is the abort-and-supersede dance that four places were each doing their own way. `useCanvasAnnotations` loses 119 lines and `useAnnotationEditing` 49, net −92 across the two with both helpers included.

## Verified

`vue-tsc` clean, **2129 web tests** (18 new), **3942 server unit** and **73 DB-backed** all pass. The isochrone test fails against the old code; so does each of the reorder tests.

Also driven in a browser against the running preview, since the reconciliation is the sort of thing a unit test can agree with and a build still get wrong:

```
initial       addLayer:cl-a, addLayer:cl-b
reorder       addLayer:cl-b, addLayer:cl-a      (was: nothing at all)
hide cl-a     visibility:cl-a:false             (was: a full rebuild, and a reorder with it)
```

No screenshot: every change here is either invisible in a still frame (draw order, a run that no longer flashes) or a number rather than a picture, and the preview browser is signed out so there is no canvas to photograph. The preview is up if you want to drag a few layers around on a phone.

## Left alone, deliberately

- The shared-link view lists `body.layers` flat, ignoring groups, order and marks — so it disagrees with the owner's panel and with what is drawn. Fixing it means teaching the group and mark rows a read-only mode, which is a UI change rather than a cleanup, so it wants its own PR.
- `GET /library/canvases` returns every body, so opening the Canvases tab fetches, decrypts and localStorage-writes every canvas in full to render names and counts. The bodies of canvases switched on are genuinely needed at boot, so splitting this is a design decision, not a tidy-up.
- `parchment-docs` still has no canvases documentation at all — nothing in `content/` mentions them.