### PR TITLE
Clarify integration capability labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changed
+
+* The integrations page no longer offers an "Imagery" capability filter, which no integration provided. The rideshare filter is now named "Rideshare" instead of "Rideshare Estimate"
+
 ## [0.8.3] - 2026-09-02
 
 ### Changed

--- a/server/src/types/integration.enums.ts
+++ b/server/src/types/integration.enums.ts
@@ -41,7 +41,6 @@ export enum IntegrationCapabilityId {
   GEOCODING = 'geocoding',
   PLACE_INFO = 'placeInfo',
   ROUTING = 'routing',
-  IMAGERY = 'imagery',
   MAP_ENGINE = 'mapEngine',
   MAP_LAYER = 'mapLayer',
   STREET_VIEW = 'streetView',

--- a/server/src/types/integration.types.ts
+++ b/server/src/types/integration.types.ts
@@ -245,11 +245,6 @@ export interface BrandCatalogCapability {
   ): Promise<Place[]>
 }
 
-// TODO: Return types
-export interface ImageryCapability {
-  getImagery(lat: number, lng: number, options?: any): Promise<any[]>
-}
-
 export interface MapEngineCapability {} // No methods needed for now
 
 export interface TransitDataCapability {
@@ -635,7 +630,6 @@ export interface IntegrationCapabilities {
   placeInfo?: PlaceInfoCapability
   geocoding?: GeocodingCapability
   routing?: RoutingCapability
-  imagery?: ImageryCapability
   mapEngine?: MapEngineCapability
   transitData?: TransitDataCapability
   weather?: WeatherCapability

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -1830,7 +1830,6 @@
         "routing": "Routing",
         "geocoding": "Geocoding",
         "placeInfo": "Place Info",
-        "imagery": "Imagery",
         "mapEngine": "Map Engine",
         "title": "Capabilities",
         "streetView": "Street View",
@@ -1845,7 +1844,7 @@
         "locationHistory": "Location History",
         "brandCatalog": "Brand Catalog",
         "transitRouting": "Transit Routing",
-        "rideshareEstimate": "Rideshare Estimate"
+        "rideshareEstimate": "Rideshare"
       },
       "descriptions": {
         "google-maps": "Comprehensive mapping and location services",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -1720,7 +1720,7 @@
         "routing": "Rutas",
         "geocoding": "Geocodificación",
         "placeInfo": "Información de Lugares",
-        "imagery": "Imágenes",
+        "mapEngine": "Motor de mapas",
         "title": "Capacidades",
         "streetView": "Vista de calle",
         "transitData": "Datos de Tránsito",
@@ -1734,7 +1734,7 @@
         "locationHistory": "Historial de ubicación",
         "brandCatalog": "Catálogo de marcas",
         "transitRouting": "Rutas de tránsito",
-        "rideshareEstimate": "Estimación de viaje compartido"
+        "rideshareEstimate": "Viajes compartidos"
       },
       "descriptions": {
         "google-maps": "Servicios completos de mapas y ubicación",


### PR DESCRIPTION
## Summary

Audited every entry in `IntegrationCapabilityId` against the `capabilityIds` each integration declares.

- **Removed `imagery`** — the only capability with zero providers anywhere. Drops the enum member, the `ImageryCapability` interface and its slot in `IntegrationCapabilities`, and the `en-US`/`es-ES` labels.
- **Renamed `rideshareEstimate` to "Rideshare"** (es: "Viajes compartidos"), down from "Rideshare Estimate".
- Added the `mapEngine` label to `es-ES.json`, which was the last one still missing there.

Every other capability has at least one integration behind it.

## Note

`rideshareEstimate` is kept because `UberIntegration` and `LyftIntegration` do provide it (`integration-registry.ts:62`). They just aren't listed in `availableIntegrations` (`server/src/services/integration.service.ts:51`), which is what the settings page renders — so the capability currently has no configurable integration behind it even though `rideshare.service.ts` and the trip-planner rideshare legs are fully wired. Tracked separately.

## Rebase note

Rebased onto `main` after #429 landed the `brandCatalog` / `transitRouting` / `rideshareEstimate` labels independently, so those are no longer part of this PR. Git auto-merged the two locale files into duplicate JSON keys — last-wins would have silently reverted the rename — so both `capabilities` blocks were resolved by hand and checked for duplicates.

## Testing

- `vue-tsc --noEmit` on `web` — clean.
- `integrations-filters.test.ts` + `integrations.store.test.ts` — 55 tests pass.
- Both locale files parse and have no duplicate keys in the `capabilities` block.
- No screenshot: the change is a settings dropdown, and no dev server was running to capture it.