### PR TITLE
Layer selector tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@
 
 ### Changed
 
+* The layer selector now separates map overlays, saved-place collections and canvases into a compact tabbed panel with a clearer base-map picker
 * The desktop sidebar has been rebuilt. Rows sit on an even grid at full contrast, the current one is marked by a single raised chip that slides between them, and collapsing or expanding the rail now glides instead of snapping — with the map resizing in step
 * The sidebar remembers whether it was collapsed, and the collapse toggle has moved to the top of the panel, next to the logo. Collapsed, the strip along the sidebar's edge lights up under the cursor and clicking it expands the panel again — `S` still works from anywhere
 * The expanded sidebar can be dragged to whatever width you want, by its outer edge, and it remembers that too. Drag it well past its narrowest and it collapses to the icon rail; drag back out and it returns

--- a/web/src/components/map/controls/LayerControl.vue
+++ b/web/src/components/map/controls/LayerControl.vue
@@ -12,7 +12,8 @@ import ResponsiveHoverCard from '@/components/responsive/ResponsiveHoverCard.vue
     side="left"
     align="end"
     :side-offset="12"
-    desktop-content-class="w-[360px] max-w-[calc(100vw-3.75rem)] md:max-w-[400px] p-4 shadow-xl"
+    desktop-content-class="w-[380px] max-w-[calc(100vw-3.75rem)] overflow-hidden rounded-md p-0 shadow-xl"
+    mobile-content-class="p-0 pt-8"
     :fit-content="true"
   >
     <template #trigger>

--- a/web/src/components/navigation/LayerSelectorRow.vue
+++ b/web/src/components/navigation/LayerSelectorRow.vue
@@ -47,13 +47,18 @@ function onRowClick() {
 <template>
   <div>
     <div
-      class="flex items-center gap-2 rounded-md py-1.5 pr-1 transition-colors"
+      class="flex min-h-9 items-center gap-2 rounded-md px-2 py-1 outline-hidden transition-colors focus-visible:ring-1 focus-visible:ring-inset focus-visible:ring-ring"
       :class="[
-        hasChildren ? 'cursor-pointer hover:bg-accent/60' : 'cursor-default',
-        depth > 0 ? 'pl-2' : 'pl-1',
+        hasChildren ? 'cursor-pointer hover:bg-muted/70' : 'cursor-default',
+        partiallyOn ? 'bg-primary/[0.06]' : '',
       ]"
-      :style="depth > 0 ? { marginLeft: `${depth * 20}px` } : undefined"
+      :style="depth > 0 ? { marginLeft: `${depth * 16}px` } : undefined"
+      :role="hasChildren ? 'button' : undefined"
+      :tabindex="hasChildren ? 0 : undefined"
+      :aria-expanded="hasChildren ? isExpanded : undefined"
       @click="onRowClick"
+      @keydown.enter.prevent="onRowClick"
+      @keydown.space.prevent="onRowClick"
     >
       <!-- Disclosure. Leaf rows get an equivalent spacer so every icon in the
            list stays on the same vertical line. -->
@@ -90,13 +95,17 @@ function onRowClick() {
       <Switch
         :model-value="node.visible"
         :aria-label="node.name"
+        class="origin-right scale-[0.82]"
         :class="{ 'opacity-70': partiallyOn }"
         @click.stop
         @update:model-value="node.onToggle"
       />
     </div>
 
-    <div v-if="hasChildren && isExpanded">
+    <div
+      v-if="hasChildren && isExpanded"
+      class="ml-[17px] border-l border-border/70 pl-0.5"
+    >
       <LayerSelectorRow
         v-for="child in node.children"
         :key="child.id"

--- a/web/src/components/navigation/LayersSelector.vue
+++ b/web/src/components/navigation/LayersSelector.vue
@@ -11,6 +11,11 @@ import { storeToRefs } from 'pinia'
 import { toRaw } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { ScrollArea } from '@/components/ui/scroll-area'
+import { Switch } from '@/components/ui/switch'
+import { EmptyState } from '@/components/ui/empty-state'
+import ItemIcon from '@/components/ui/item-icon/ItemIcon.vue'
 import { useMapStore } from '@/stores/map.store'
 import { useLayersStore } from '@/stores/layers.store'
 import { useLayersService } from '@/services/layers/layers.service'
@@ -18,8 +23,11 @@ import { useMapService } from '@/services/map.service'
 import { basemaps } from '../map/map.data'
 import { Basemap } from '@/types/map.types'
 import type { Layer, LayerGroup } from '@/types/map.types'
-import { isVirtualLayerId } from '@/lib/saved-places-layers'
-import { canvasIdFromLayerId } from '@/lib/canvas-layers'
+import {
+  isVirtualLayerId,
+  SAVED_PLACES_GROUP_ID,
+} from '@/lib/saved-places-layers'
+import { canvasIdFromLayerId, CANVASES_GROUP_ID } from '@/lib/canvas-layers'
 import { useCanvasesStore } from '@/stores/library/canvases.store'
 import { usePortolanTransitStore } from '@/stores/portolan.store'
 import {
@@ -31,6 +39,7 @@ import {
 import LayerSelectorRow from './LayerSelectorRow.vue'
 import TransitServiceTimeControl from './TransitServiceTimeControl.vue'
 import type { SelectorNode } from './layer-selector.types'
+import { BookmarkIcon, Paintbrush2Icon } from 'lucide-vue-next'
 
 const layersStore = useLayersStore()
 const layersService = useLayersService()
@@ -118,7 +127,8 @@ async function setGroupVisible(group: LayerGroup, visible: boolean) {
 // ---------------------------------------------------------------------------
 
 function layerNode(layer: Layer): SelectorNode {
-  const meta = savedPlacesMeta.value.get(layer.id) ?? canvasesMeta.value.get(layer.id)
+  const meta =
+    savedPlacesMeta.value.get(layer.id) ?? canvasesMeta.value.get(layer.id)
   return {
     id: layer.id,
     name: layer.name,
@@ -162,7 +172,9 @@ function groupNode(node: any): SelectorNode {
       .filter((l: Layer) => l.showInLayerSelector)
       .map((l: Layer) => ({ ...layerNode(l), order: l.order })),
     ...(node.children ?? []).map(g => ({ ...groupNode(g), order: g.order })),
-  ].sort((a, b) => (a.order ?? 0) - (b.order ?? 0) || a.name.localeCompare(b.name))
+  ].sort(
+    (a, b) => (a.order ?? 0) - (b.order ?? 0) || a.name.localeCompare(b.name),
+  )
 
   // The Transit group's primary children are the portolan class toggles.
   if (node.id === TRANSIT_GROUP_ID) {
@@ -184,13 +196,16 @@ function groupNode(node: any): SelectorNode {
  * Groups and ungrouped layers, in the user's own order. Empty groups are
  * dropped — an expandable row with nothing inside is just a dead end.
  */
-const nodes = computed<SelectorNode[]>(() => {
+const mapLayerNodes = computed<SelectorNode[]>(() => {
   const result: SelectorNode[] = []
 
   for (const item of mainReorderableItems.value) {
     const isGroup = !('groupId' in item)
 
     if (isGroup) {
+      if (item.id === SAVED_PLACES_GROUP_ID || item.id === CANVASES_GROUP_ID) {
+        continue
+      }
       const treeNode = findGroupNode(item.id, groupTree.value)
       if (!treeNode || !treeNode.showInLayerSelector) continue
       if (layersStore.getGroupTotalLayerCount(item.id) === 0) continue
@@ -206,6 +221,24 @@ const nodes = computed<SelectorNode[]>(() => {
   return result
 })
 
+function selectorGroup(id: string): SelectorNode | null {
+  const treeNode = findGroupNode(id, groupTree.value)
+  if (!treeNode?.showInLayerSelector) return null
+  return groupNode(treeNode)
+}
+
+const collectionsNode = computed(() => selectorGroup(SAVED_PLACES_GROUP_ID))
+const collectionNodes = computed(() => collectionsNode.value?.children ?? [])
+const collectionPlaceCount = computed(() =>
+  collectionNodes.value.reduce((total, node) => total + (node.count ?? 0), 0),
+)
+
+const canvasesNode = computed(() => selectorGroup(CANVASES_GROUP_ID))
+const canvasNodes = computed(() => canvasesNode.value?.children ?? [])
+const canvasItemCount = computed(() =>
+  canvasNodes.value.reduce((total, node) => total + (node.count ?? 0), 0),
+)
+
 function findGroupNode(id: string, tree: any[]): any {
   for (const node of tree) {
     if (node.id === id) return node
@@ -219,61 +252,194 @@ function findGroupNode(id: string, tree: any[]): any {
 </script>
 
 <template>
-  <div class="space-y-5 min-w-0">
-    <!-- Base map -->
-    <div class="space-y-2">
-      <p class="text-xs font-medium text-muted-foreground">Base map</p>
-      <div class="grid grid-cols-2 gap-2">
-        <ToggleGroup
-          type="single"
-          :default-value="mapStore.settings.basemap"
-          @update:model-value="
-            basemap => mapStore.setBasemap(basemap as Basemap)
-          "
-          class="contents"
-        >
-          <ToggleGroupItem
-            v-for="[basemapId, basemap] in Object.entries(basemaps)"
-            :key="basemapId"
-            :value="basemapId"
-            :aria-label="`Switch to ${basemap.name}`"
-            variant="outline"
-            class="flex flex-col items-center gap-2 p-3 h-16 justify-center text-center transition-all duration-200 hover:bg-muted data-[state=on]:bg-primary data-[state=on]:text-primary-foreground data-[state=on]:shadow-sm"
+  <div class="flex min-w-0 flex-col overflow-hidden">
+    <Tabs default-value="map" class="min-h-0">
+      <div class="flex items-end border-b px-3 pt-2.5">
+        <TabsList variant="linear" class="w-full gap-2 border-b-0 sm:gap-5">
+          <TabsTrigger value="map" variant="linear" class="flex-1">
+            {{ t('layers.selector.tabs.map') }}
+          </TabsTrigger>
+          <TabsTrigger
+            value="collections"
+            variant="linear"
+            :count="collectionNodes.length || null"
+            class="flex-1"
           >
-            <component :is="basemap.icon" class="size-4 shrink-0" />
-            <span class="font-medium text-xs leading-tight">{{
-              basemap.name
-            }}</span>
-          </ToggleGroupItem>
-        </ToggleGroup>
+            {{ t('layers.selector.tabs.collections') }}
+          </TabsTrigger>
+          <TabsTrigger
+            value="canvases"
+            variant="linear"
+            :count="canvasNodes.length || null"
+            class="flex-1"
+          >
+            {{ t('layers.selector.tabs.canvases') }}
+          </TabsTrigger>
+        </TabsList>
       </div>
-    </div>
 
-    <!-- Layers -->
-    <div class="space-y-1">
-      <p class="text-xs font-medium text-muted-foreground">
-        {{ $t('layers.title') }}
-      </p>
+      <ScrollArea class="h-[min(460px,calc(100vh-10rem))] min-h-[260px]">
+        <TabsContent value="map" class="m-0 space-y-3 p-3 focus-visible:ring-0">
+          <section class="space-y-2">
+            <p class="px-0.5 text-xs font-medium text-muted-foreground">
+              {{ t('layers.selector.baseMap') }}
+            </p>
 
-      <div class="-mx-1">
-        <template v-for="node in nodes" :key="node.id">
-          <LayerSelectorRow
-            :node="node"
-            :expanded="expanded"
-            @toggle-expanded="toggleExpanded"
+            <ToggleGroup
+              type="single"
+              :model-value="mapStore.settings.basemap"
+              class="grid grid-cols-3 gap-2"
+              @update:model-value="
+                basemap => mapStore.setBasemap(basemap as Basemap)
+              "
+            >
+              <ToggleGroupItem
+                v-for="[basemapId, basemap] in Object.entries(basemaps)"
+                :key="basemapId"
+                :value="basemapId"
+                :aria-label="
+                  t('layers.selector.switchBasemap', { name: basemap.name })
+                "
+                variant="outline"
+                class="h-16 flex-col gap-1.5 rounded-md border bg-card px-2 text-xs transition-colors hover:bg-muted/70 data-[state=on]:border-primary/50 data-[state=on]:bg-primary/10 data-[state=on]:text-foreground data-[state=on]:shadow-none"
+              >
+                <component :is="basemap.icon" class="size-4 shrink-0" />
+                <span class="font-medium leading-none">{{ basemap.name }}</span>
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </section>
+
+          <section class="space-y-2">
+            <p class="px-0.5 text-xs font-medium text-muted-foreground">
+              {{ t('layers.selector.overlays') }}
+            </p>
+            <div class="space-y-0.5 rounded-md border bg-card/70 p-1">
+              <template v-for="node in mapLayerNodes" :key="node.id">
+                <LayerSelectorRow
+                  :node="node"
+                  :expanded="expanded"
+                  @toggle-expanded="toggleExpanded"
+                />
+                <!-- The service-time control belongs to the Transit group: it
+                     filters the portolan map to what actually runs at an instant. -->
+                <TransitServiceTimeControl
+                  v-if="
+                    node.id === TRANSIT_GROUP_ID &&
+                    node.visible &&
+                    expanded.has(node.id)
+                  "
+                />
+              </template>
+            </div>
+          </section>
+        </TabsContent>
+
+        <TabsContent
+          value="collections"
+          class="m-0 space-y-3 p-3 focus-visible:ring-0"
+        >
+          <template v-if="collectionsNode && collectionNodes.length">
+            <div
+              class="flex items-center gap-3 rounded-md border bg-primary/[0.04] p-2"
+            >
+              <ItemIcon
+                icon="Bookmark"
+                color="parchment"
+                variant="ghost"
+                size="xs"
+              />
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-medium">
+                  {{ t('layers.selector.savedPlaces') }}
+                </p>
+                <p class="text-xs text-muted-foreground">
+                  {{
+                    t('layers.selector.placeCount', {
+                      count: collectionPlaceCount,
+                    })
+                  }}
+                </p>
+              </div>
+              <Switch
+                :model-value="collectionsNode.visible"
+                :aria-label="t('layers.selector.savedPlaces')"
+                @update:model-value="collectionsNode.onToggle"
+              />
+            </div>
+
+            <div class="space-y-0.5 rounded-md border bg-card/70 p-1">
+              <LayerSelectorRow
+                v-for="node in collectionNodes"
+                :key="node.id"
+                :node="node"
+                :expanded="expanded"
+                @toggle-expanded="toggleExpanded"
+              />
+            </div>
+          </template>
+
+          <EmptyState
+            v-else
+            :icon="BookmarkIcon"
+            :title="t('layers.selector.emptyCollections.title')"
+            :description="t('layers.selector.emptyCollections.description')"
+            variant="inline"
           />
-          <!-- The service-time control belongs to the Transit group: it
-               filters the portolan map to what actually runs at an instant,
-               so it appears under the expanded, enabled group. -->
-          <TransitServiceTimeControl
-            v-if="
-              node.id === TRANSIT_GROUP_ID &&
-              node.visible &&
-              expanded.has(node.id)
-            "
+        </TabsContent>
+
+        <TabsContent
+          value="canvases"
+          class="m-0 space-y-3 p-3 focus-visible:ring-0"
+        >
+          <template v-if="canvasesNode && canvasNodes.length">
+            <div
+              class="flex items-center gap-3 rounded-md border bg-primary/[0.04] p-2"
+            >
+              <ItemIcon
+                icon="Shapes"
+                color="parchment"
+                variant="ghost"
+                size="xs"
+              />
+              <div class="min-w-0 flex-1">
+                <p class="text-sm font-medium">
+                  {{ t('layers.selector.showCanvases') }}
+                </p>
+                <p class="text-xs text-muted-foreground">
+                  {{
+                    t('layers.selector.canvasItemCount', {
+                      count: canvasItemCount,
+                    })
+                  }}
+                </p>
+              </div>
+              <Switch
+                :model-value="canvasesNode.visible"
+                :aria-label="t('layers.selector.showCanvases')"
+                @update:model-value="canvasesNode.onToggle"
+              />
+            </div>
+
+            <div class="space-y-0.5 rounded-md border bg-card/70 p-1">
+              <LayerSelectorRow
+                v-for="node in canvasNodes"
+                :key="node.id"
+                :node="node"
+                :expanded="expanded"
+                @toggle-expanded="toggleExpanded"
+              />
+            </div>
+          </template>
+
+          <EmptyState
+            v-else
+            :icon="Paintbrush2Icon"
+            :title="t('canvases.empty.title')"
+            :description="t('canvases.empty.description')"
+            variant="inline"
           />
-        </template>
-      </div>
-    </div>
+        </TabsContent>
+      </ScrollArea>
+    </Tabs>
   </div>
 </template>

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -438,6 +438,24 @@
   },
   "layers": {
     "title": "Layers",
+    "selector": {
+      "tabs": {
+        "map": "Map",
+        "collections": "Collections",
+        "canvases": "Canvases"
+      },
+      "baseMap": "Base map",
+      "overlays": "Overlays",
+      "savedPlaces": "Show saved places",
+      "showCanvases": "Show canvases",
+      "placeCount": "{count} places",
+      "canvasItemCount": "{count} items",
+      "switchBasemap": "Switch to {name}",
+      "emptyCollections": {
+        "title": "No saved places yet",
+        "description": "Collections with saved places will appear here."
+      }
+    },
     "transit": {
       "rail": "Rail",
       "bus": "Bus",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -432,6 +432,24 @@
   },
   "layers": {
     "title": "Capas",
+    "selector": {
+      "tabs": {
+        "map": "Mapa",
+        "collections": "Colecciones",
+        "canvases": "Lienzos"
+      },
+      "baseMap": "Mapa base",
+      "overlays": "Superposiciones",
+      "savedPlaces": "Mostrar lugares guardados",
+      "showCanvases": "Mostrar lienzos",
+      "placeCount": "{count} lugares",
+      "canvasItemCount": "{count} elementos",
+      "switchBasemap": "Cambiar a {name}",
+      "emptyCollections": {
+        "title": "Aún no hay lugares guardados",
+        "description": "Las colecciones con lugares guardados aparecerán aquí."
+      }
+    },
     "transit": {
       "rail": "Tren",
       "bus": "Autobús",


### PR DESCRIPTION
## Summary

- separate map overlays, saved-place collections, and canvases with the app’s existing linear tabs
- tighten layer rows and base-map cards with the standard app radius
- preserve real collection and canvas controls, including group visibility and empty states
- add mobile sheet clearance so tabs do not collide with the close control

## Validation

- ./node_modules/.bin/vue-tsc --noEmit
- ./node_modules/.bin/vitest run src/lib/saved-places-layers.test.ts src/lib/canvas-layers.test.ts (32 tests)

## Preview

https://vega5.tailc47d6.ts.net:8402