### PR TITLE
Keep rails under transit layer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@
 
 ### Fixed
 
+* Turning on the transit layer no longer erases the railway network from the map. The basemap's station labels step aside for the layer's own stops instead, so the rails stay drawn
 * Tapping a station label that covers a whole interchange now opens all of it. New York draws four separate stations named "Canal St" as one symbol, and tapping it opened whichever of the four the label happened to sit on — so the panel showed two lines where the map had drawn six. Tapping a single line's marker still opens just that station
 * The map keeps up with the sidebar as it is dragged or collapsed, resizing frame by frame rather than snapping once the panel has settled
 * Centring on a place, or fitting a route, no longer aims too far to the right when a panel is open over the map. The gutter the map was told to leave on the left included the sidebar's width a second time, even though the map never extended under it — worse the wider the sidebar

--- a/web/src/lib/map-style/build.ts
+++ b/web/src/lib/map-style/build.ts
@@ -11,6 +11,7 @@ import {
   BUILDING_3D_TILES,
 } from './detail-layers'
 import { buildingColor, BUILDING_TINT } from './building-color.mjs'
+import { TRANSIT_POI_CLASSES } from './transit-poi.mjs'
 import { barrelmanBuildingsReady } from './barrelman-buildings'
 import lightTokens from './tokens.light.json'
 import darkTokens from './tokens.dark.json'
@@ -283,12 +284,37 @@ function idsWhere(pred: (l: any) => boolean): string[] {
   return specLayers.filter(pred).map(l => l.id)
 }
 
+/** Every `class` value a layer's filter tests for, however deeply nested. */
+function filterClasses(filter: any, found = new Set<string>()): Set<string> {
+  if (!Array.isArray(filter)) return found
+  const [op, subject, values] = filter
+  if (op === 'match' && Array.isArray(subject) && subject[0] === 'get' && subject[1] === 'class' && Array.isArray(values)) {
+    for (const v of values) found.add(v)
+  }
+  for (const part of filter) filterClasses(part, found)
+  return found
+}
+
+/** A POI layer that draws transit stops and nothing else. */
+function isTransitStopLayer(l: any): boolean {
+  if (l.type !== 'symbol' || l['source-layer'] !== 'poi') return false
+  const classes = filterClasses(l.filter)
+  return classes.size > 0 && [...classes].every(c => TRANSIT_POI_CLASSES.includes(c))
+}
+
 export const layerGroups = {
   poi: idsWhere(
     l => l.type === 'symbol' && ['poi', 'housenumber', 'aerodrome_label', 'mountain_peak'].includes(l['source-layer']),
   ),
   roadLabels: idsWhere(l => l.type === 'symbol' && l['source-layer'] === 'transportation_name'),
-  transit: idsWhere(l => /rail|transit|subway|tram|funicular/i.test(l.id)),
+  /**
+   * Transit stop labels, not the rails under them. The transit overlay redraws
+   * these stops itself, so the basemap's copies hide while it is on — but the
+   * railway network is basemap cartography and stays either way. Matching on
+   * layer *id* instead caught only the `Railway` / `rail` line layers, so
+   * turning transit on erased the rails and left every stop label doubled.
+   */
+  transit: idsWhere(isTransitStopLayer),
   placeLabels: idsWhere(l => l.type === 'symbol' && l['source-layer'] === 'place'),
   building3d: specLayers.find(l => l.type === 'fill-extrusion')?.id ?? 'Building 3D',
 }

--- a/web/src/lib/map-style/map-style.test.ts
+++ b/web/src/lib/map-style/map-style.test.ts
@@ -1055,6 +1055,23 @@ describe('assembled styles', () => {
     }
     expect(ids).toContain(layerGroups.building3d)
   })
+
+  /**
+   * The transit toggle hides stop labels the overlay is about to redraw. It
+   * once matched on layer id, which caught the railway line layers instead —
+   * so turning transit on wiped the rail network off the basemap.
+   */
+  test('the transit group is stop labels, never the rails themselves', () => {
+    const toggled = layerGroups.transit.map(id => layers.find(l => l.id === id)!)
+    expect(toggled.length).toBeGreaterThan(0)
+    for (const layer of toggled) {
+      expect(layer.type, layer.id).toBe('symbol')
+      expect((layer as any)['source-layer'], layer.id).toBe('poi')
+    }
+    for (const layer of layers) {
+      if (layer.type === 'line') expect(layerGroups.transit).not.toContain(layer.id)
+    }
+  })
 })
 
 describe('assets the spec depends on', () => {


### PR DESCRIPTION
Turning on a transit layer erased the railway network from the basemap.

## Cause

`setTransitLabels(false)` fires whenever a transit layer becomes visible, to stop the basemap's own stop labels doubling up under the overlay's stops. On MapLibre that hides `layerGroups.transit`, which was derived by matching layer **ids**:

```ts
transit: idsWhere(l => /rail|transit|subway|tram|funicular/i.test(l.id)),
```

In the current spec the only ids containing those words are the six railway *line* layers — `Major rail`, `Minor rail`, `Railway tunnel` and their hatchings. So the toggle hid exactly the wrong thing:

* it erased the rail network geometry, and
* it hid **zero** labels, so the basemap's stop labels stayed doubled under the overlay — the thing it exists to prevent, and the behaviour `transit-poi.mjs` documents.

Mapbox was unaffected; its strategy delegates to the `showTransitLabels` basemap config, which already does the right thing. MapLibre-only.

This also explains the **Transit labels** setting in Appearance behaving oddly — it was toggling rail geometry rather than labels — and the same setting now carried per-canvas.

## Fix

Derive the group from what the layers actually draw rather than what they're called: POI symbol layers whose `class` filter is entirely transit classes. That resolves to `Station` (bus/railway stops).

Kept derived from the spec rather than hand-listing `'Station'`, matching the existing intent of `idsWhere` — "so a regenerated spec cannot silently drop one out of a toggle".

Ferry and harbour stops live in the mixed `Transport` layer alongside parking and fuel, so they can't be hidden by layer visibility without taking unrelated POIs with them. Left alone rather than widening the change.

## Testing

* New regression test: the transit group is only POI symbol layers, and never a line layer.
* `map-style.test.ts` — 155 passing.
* `src/services/layers` — 148 passing.
* `vue-tsc` clean.

No screenshot: the headless browser can't capture this app since the WebGL globe landed — snapshots fail and the tab hangs. Worth confirming by eye on the preview.