### PR TITLE
Station groups and transfer times

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,7 @@
 
 ### Fixed
 
+* Tapping any part of a station on the transit map opens the whole interchange, rather than one line's platforms. Tapping the J at Canal St opened the N/Q station instead — six separate stations share that name and nothing drawn on the map says which one a given marker belongs to, so "just this station" was picking an arbitrary one. The group's list contains every line the specific station runs, so nothing is lost by opening it
 * Turning on the transit layer no longer erases the railway network from the map. The basemap's station labels step aside for the layer's own stops instead, so the rails stay drawn
 * Lines you can walk to are listed separately from lines you can transfer to, instead of sharing one Transfers heading. At Rector St the 1 train is fifty metres away but reaching it means leaving through the turnstiles and paying a second fare, and listing it beside the genuine in-station transfers said otherwise. Walk-to lines now sit under their own heading with the distance beside them
 * Tapping a station label that covers a whole interchange now shows all of its lines beside the station's name. The departures below already covered the whole interchange; the bullets did not, so Brooklyn Bridge–City Hall read "4 5 6" with the J and Z listed as connections — the answer for tapping one station rather than the group

--- a/web/src/services/layers/features/portolan/portolan-ui.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-ui.test.ts
@@ -117,22 +117,45 @@ describe('which place a clicked station is', () => {
   }
 
   test('the OSM object wins, so the transit label and the POI open one page', () => {
-    expect(stopTargetFor(CONEY)).toEqual({ kind: 'osm', type: 'node', id: '1683730419' })
+    expect(stopTargetFor(CONEY)).toEqual({
+      kind: 'osm',
+      type: 'node',
+      id: '1683730419',
+      complex: true,
+    })
   })
 
   test('ways and relations route as themselves', () => {
-    expect(stopTargetFor({ osm: 'way/123' })).toEqual({ kind: 'osm', type: 'way', id: '123' })
-    expect(stopTargetFor({ osm: 'relation/9' })).toEqual({ kind: 'osm', type: 'relation', id: '9' })
+    expect(stopTargetFor({ osm: 'way/123' })).toEqual({
+      kind: 'osm',
+      type: 'way',
+      id: '123',
+      complex: true,
+    })
+    expect(stopTargetFor({ osm: 'relation/9' })).toEqual({
+      kind: 'osm',
+      type: 'relation',
+      id: '9',
+      complex: true,
+    })
   })
 
   test('an unmatched station still opens its feed’s stop', () => {
     const { osm, ...noMatch } = CONEY
-    expect(stopTargetFor(noMatch)).toEqual({ kind: 'transitland', stopKey: 'f-dr5r-nyctsubway:D43' })
+    expect(stopTargetFor(noMatch)).toEqual({
+      kind: 'transitland',
+      stopKey: 'f-dr5r-nyctsubway:D43',
+      complex: true,
+    })
   })
 
   test('a complex opens the first pair, which the tiler ranked first', () => {
     const props = { gtfs_ids: 'f-dr5r-nyctsubway:635;f-dr5r-nyctsubway:418' }
-    expect(stopTargetFor(props)).toEqual({ kind: 'transitland', stopKey: 'f-dr5r-nyctsubway:635' })
+    expect(stopTargetFor(props)).toEqual({
+      kind: 'transitland',
+      stopKey: 'f-dr5r-nyctsubway:635',
+      complex: true,
+    })
   })
 
   test('a station with neither is not a link', () => {
@@ -149,36 +172,39 @@ describe('which place a clicked station is', () => {
 
 describe('opening a merged station', () => {
   /**
-   * One drawn label can stand for a whole interchange: New York has four
-   * separate GTFS stations named "Canal St", and the map merges them. Tapping
-   * that label should open all of them, while tapping one corridor's marker
-   * opens only the station it sits on — Apple's hybrid.
+   * One drawn label can stand for a whole interchange: New York has six
+   * separate GTFS stations named "Canal St", and the map merges them.
+   *
+   * This was Apple's hybrid — label opens the group, marker opens its own
+   * station — until the second half turned out to be unimplementable. A marker
+   * is handed its STATION's osm id, never one of its own, so "the station it
+   * sits on" resolved to whichever of the six portolan had matched: tapping
+   * the J at Canal St opened the N/Q. Everything opens the group now.
    */
-  test('marks the merged label as a complex', () => {
+  test('opens the group for a merged label', () => {
     expect(
       stopTargetFor({ ftype: 'station', nmarkers: 3, osm: 'node/7613354754' })?.complex,
     ).toBe(true)
   })
 
-  test('leaves a single-bundle station alone', () => {
-    expect(
-      stopTargetFor({ ftype: 'station', nmarkers: 1, osm: 'node/1' })?.complex,
-    ).toBeFalsy()
-  })
-
-  test("leaves one corridor's marker alone", () => {
-    // A marker carries the station's ids, not its own — so without this it
-    // would inherit the complex flag and open the whole interchange.
+  test("opens the group for one corridor's marker too", () => {
+    // The case that drove this: the marker knows its station's id and nothing
+    // narrower, so opening "just this station" opens an arbitrary one.
     expect(
       stopTargetFor({ ftype: 'marker', nmarkers: 3, osm: 'node/1' })?.complex,
-    ).toBeFalsy()
+    ).toBe(true)
   })
 
-  test('does not count gtfs_ids, which lists platforms too', () => {
-    // Q01, Q01N and Q01S are one station; counting pairs would call it three.
+  test('costs nothing at a station that is not a group', () => {
+    // One station, so its group is itself.
     expect(
-      stopTargetFor({ ftype: 'station', nmarkers: 1, gtfs_ids: 'f:Q01;f:Q01N;f:Q01S' })
-        ?.complex,
-    ).toBeFalsy()
+      stopTargetFor({ ftype: 'station', nmarkers: 1, osm: 'node/1' })?.complex,
+    ).toBe(true)
+  })
+
+  test('applies to a transitland target as well', () => {
+    expect(
+      stopTargetFor({ ftype: 'marker', gtfs_ids: 'f-dr5r-nyctsubway:M20' })?.complex,
+    ).toBe(true)
   })
 })

--- a/web/src/services/layers/features/portolan/portolan-ui.ts
+++ b/web/src/services/layers/features/portolan/portolan-ui.ts
@@ -119,15 +119,13 @@ export type StopTarget = (
   | { kind: 'transitland'; stopKey: string }
 ) & {
   /**
-   * The symbol stands for a whole complex rather than one station, so the
-   * panel should open all of it.
+   * Open everything at this interchange rather than one station of it.
    *
-   * Read from `nmarkers`, not from `gtfs_ids`: that prop lists every stop
-   * merged into the station — platforms AND parent records — so even a plain
-   * two-platform station carries several pairs and counting them would call
-   * everything a complex. `nmarkers` is one per ribbon bundle the station's
-   * lines snap to, which is what actually makes a drawn label cover more than
-   * one station: Canal St is one symbol over four of them.
+   * Always set. Nothing in the tiles identifies WHICH station a tapped marker
+   * belongs to — portolan matches OSM objects to the station and hands every
+   * marker the same id — so asking for one station means asking for an
+   * arbitrary one. Where the symbol covers a single station this is simply
+   * that station, so the flag costs nothing there.
    */
   complex?: boolean
 }
@@ -153,13 +151,20 @@ export type StopTarget = (
  * be a link.
  */
 export function stopTargetFor(props: any): StopTarget | null {
-  // The merged label is the whole interchange; one corridor's marker is not.
-  // Present only when true, so a plain station's target stays exactly what it
-  // has always been.
-  const complex =
-    props?.ftype === 'station' && Number(props?.nmarkers ?? 0) > 1
-      ? { complex: true as const }
-      : {}
+  // Always the whole interchange.
+  //
+  // This used to be Apple's hybrid: the merged label opened the group, one
+  // corridor's marker opened the station it sat on. That second half cannot
+  // work with what the tiles carry. Portolan matches an OSM object to the
+  // STATION, and a marker is handed its station's `osm` id rather than one of
+  // its own — so tapping the J at Canal St opened whichever of the six
+  // same-named stations portolan had matched, which is the N/Q. There is no
+  // id on a marker that says which sub-station it belongs to, so the choice is
+  // between opening the right group and opening an arbitrary member of it.
+  //
+  // Opening the group is the honest one, and it loses nothing: every line the
+  // specific station runs is in the group's list too.
+  const complex = { complex: true as const }
 
   const osm = String(props?.osm ?? '')
   const slash = osm.indexOf('/')


### PR DESCRIPTION
Two changes to the transit panel.

## Tapping any part of a station opens the whole interchange

Tapping the J at Canal St opened the N/Q station.

#437 built Apple's hybrid: the merged label opens the interchange, one
corridor's marker opens the station it sits on. The second half cannot be
implemented with what the tiles carry. Portolan matches an OSM object to the
**station**, and `stations.go` hands every one of that station's markers the
same `osm` id — nothing on a marker says which sub-station it belongs to. Six
GTFS stations are named "Canal St", so "the station it sits on" resolved to
whichever portolan had matched. Broadway Junction fails the same way, with the
A/C marker opening the L platform's node.

The choice was never "right station or group" — it was "arbitrary station or
group". `stopTargetFor` now always asks for the group. Nothing is lost: every
line the specific station runs is in the group's list too.

## Connections show their departure times

The Transfers section listed 4, 5, 6 and 6X with no times — which is the least
useful half of the answer. It now shows when they actually leave, laid out like
the board above it.

They stay a **separate** list, because those trains leave a different platform:
merging them into the main board would say they depart from where you are
standing, which is the distinction alexwohlbruck/barrelman#100 drew and this
keeps. Walk-to lines under **Nearby** keep their distance instead, since no feed
can say when they leave.

Needs barrelman alexwohlbruck/barrelman#102, which adds `transfers=true` and
returns each connecting station's board marked `stop.via: 'transfer'`. Until
that ships the list is empty and the section falls back to the bullets it shows
today, so this degrades rather than breaks.

`formatCountdown` moved into `lib/transit-departures` — it was private to
`PlaceTransit.vue` and is now wanted in three places.

## Tests

`bun run test` — 2141 pass, 0 fail. `vue-tsc` clean. The four older
exact-equality assertions on `stopTargetFor` now include `complex: true`, since
it is no longer conditional.