### PR TITLE
Precise station links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,8 @@
 
 ### Fixed
 
+* A transfer opens the station it actually names. Tapping "Chambers St" from Brooklyn Bridge–City Hall opened the A/C/E station 428 metres away, because the only way to find it was to search by the name — and three stations are called Chambers St. Each one is now identified exactly, using the match the transit map itself already made
+
 * Tapping any part of a station on the transit map opens the whole interchange, rather than one line's platforms. Tapping the J at Canal St opened the N/Q station instead — six separate stations share that name and nothing drawn on the map says which one a given marker belongs to, so "just this station" was picking an arbitrary one. The group's list contains every line the specific station runs, so nothing is lost by opening it
 * Turning on the transit layer no longer erases the railway network from the map. The basemap's station labels step aside for the layer's own stops instead, so the rails stay drawn
 * Lines you can walk to are listed separately from lines you can transfer to, instead of sharing one Transfers heading. At Rector St the 1 train is fifty metres away but reaching it means leaving through the turnstiles and paying a second fare, and listing it beside the genuine in-station transfers said otherwise. Walk-to lines now sit under their own heading with the distance beside them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Added
 
+* The Transfers section shows when the connections actually leave, not just which lines they are. Changing at Chambers St now tells you the 4 leaves Brooklyn Bridge–City Hall in three minutes, laid out like the departures above it. They stay a separate list, because those trains leave a different platform — merging them would say they depart from where you are standing. Lines you can only walk to keep their distance instead, since no feed can say when they leave
 * Each stop on a route's detail page shows the other lines you can get there, under its name — Union Square on the N listing Q and R and W beside it, and the 4, 5, 6 and L a passageway away. Lines reached by a transfer are dimmed, since they leave from another platform rather than the one you are standing on
 * A station's Transfers section now also lists lines running from stops within walking distance — the bus from the stop outside a subway entrance. No transit feed can describe a connection between two different operators, so these are found by distance alone: they come after the connections the agency does publish, nearest first, and may well cost another fare
 * The MapLibre engine can now draw the map on a globe. The map projection setting applies to both engines, offering flat and globe on MapLibre and the full list on Mapbox

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Added
 
-* The Transfers section shows when the connections actually leave, not just which lines they are. Changing at Chambers St now tells you the 4 leaves Brooklyn Bridge–City Hall in three minutes, laid out like the departures above it. They stay a separate list, because those trains leave a different platform — merging them would say they depart from where you are standing. Lines you can only walk to keep their distance instead, since no feed can say when they leave
+* The Transfers section shows where a connection leaves from and when. Each connecting station gets its own block under its name — tap it to open that station — with its lines and times beneath, laid out like the departures above. Stations sharing a name are one block, since that is the same station drawn twice.
 * Each stop on a route's detail page shows the other lines you can get there, under its name — Union Square on the N listing Q and R and W beside it, and the 4, 5, 6 and L a passageway away. Lines reached by a transfer are dimmed, since they leave from another platform rather than the one you are standing on
 * A station's Transfers section now also lists lines running from stops within walking distance — the bus from the stop outside a subway entrance. No transit feed can describe a connection between two different operators, so these are found by distance alone: they come after the connections the agency does publish, nearest first, and may well cost another fare
 * The MapLibre engine can now draw the map on a globe. The map projection setting applies to both engines, offering flat and globe on MapLibre and the full list on Mapbox

--- a/server/src/controllers/place.controller.ts
+++ b/server/src/controllers/place.controller.ts
@@ -123,12 +123,37 @@ app.get(
           lng: lng!,
         }
 
-        // Use the new method to get place by name and coordinates
+        // Resolve the name and point to a place...
         place = await lookupPlaceByNameAndLocation(name!, coordinates, {
           userId: user?.id,
           radius: Math.round(radius),
           language,
         })
+
+        // ...then look it up again by the id that resolved to, so this route
+        // answers with the same place the id route does.
+        //
+        // The name lookup returns whatever the provider search found, and that
+        // is not an enriched place: no widget descriptors, so no departures,
+        // no OSM tags, no related places. A transit station reached this way
+        // rendered as a name, an address and a phone number, while the very
+        // same node reached by id showed its whole board. Both URLs name one
+        // place and should answer alike.
+        // Its OWN id, not `externalIds[OSM]` — those can point at a different
+        // object entirely. Here the node the name resolved to carried an
+        // external id for the platform WAY beside it, and enriching that
+        // opened "Brooklyn Bridge-City Hall (4,5,6,<6>)" instead of the
+        // station a tap on the map opens.
+        const [idSource, ...idRest] = (place?.id ?? '').split('/')
+        const resolvedOsmId = idSource === SOURCE.OSM ? idRest.join('/') : null
+        if (resolvedOsmId) {
+          place =
+            (await lookupEnrichedPlaceById(SOURCE.OSM, resolvedOsmId, {
+              userId: user?.id,
+              language,
+              premiumData,
+            })) ?? place
+        }
       } else if (isCoordinateLookup) {
         place = await lookupEnrichedPlaceByCoordinates(lat!, lng!, {
           userId: user?.id,

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -364,7 +364,7 @@ interface BarrelmanStopDepartures {
     /** `transfer` marks a connecting station under another name, returned
      *  because `transfers=true` was asked for. Absent means this station. */
     via?: 'station' | 'transfer'
-    osm?: string
+    feedOnestopId?: string
   }
   departures: BarrelmanDeparture[]
   hasMore?: boolean
@@ -522,7 +522,7 @@ async function fetchTransitDepartures(
         stopId: rows[0].stop.stopId,
         lat: rows[0].stop.lat,
         lng: rows[0].stop.lng,
-        osm: rows.find((r) => r.stop.osm)?.stop.osm,
+        feedOnestopId: rows.find((r) => r.stop.feedOnestopId)?.stop.feedOnestopId,
         departures: shapeBoard(asBoard(rows), board).departures,
       }))
       .filter((s) => s.departures.length)

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -364,6 +364,7 @@ interface BarrelmanStopDepartures {
     /** `transfer` marks a connecting station under another name, returned
      *  because `transfers=true` was asked for. Absent means this station. */
     via?: 'station' | 'transfer'
+    osm?: string
   }
   departures: BarrelmanDeparture[]
   hasMore?: boolean
@@ -521,6 +522,7 @@ async function fetchTransitDepartures(
         stopId: rows[0].stop.stopId,
         lat: rows[0].stop.lat,
         lng: rows[0].stop.lng,
+        osm: rows.find((r) => r.stop.osm)?.stop.osm,
         departures: shapeBoard(asBoard(rows), board).departures,
       }))
       .filter((s) => s.departures.length)

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -358,7 +358,13 @@ interface BarrelmanDeparture {
 }
 
 interface BarrelmanStopDepartures {
-  stop: { stopId: string; feedId: string; name: string; code?: string; lat: number; lng: number; timezone: string; distance?: number }
+  stop: {
+    stopId: string; feedId: string; name: string; code?: string
+    lat: number; lng: number; timezone: string; distance?: number
+    /** `transfer` marks a connecting station under another name, returned
+     *  because `transfers=true` was asked for. Absent means this station. */
+    via?: 'station' | 'transfer'
+  }
   departures: BarrelmanDeparture[]
   hasMore?: boolean
 }
@@ -416,6 +422,8 @@ async function fetchTransitDepartures(
   options?: { limit?: number; windowMinutes?: number },
 ): Promise<{
   departures: TransitDeparture[]
+  /** Runs leaving the stations a rider can transfer to, on their own board. */
+  transferDepartures: TransitDeparture[]
   stopInfo?: { name?: string; code?: string; feedId?: string; stopId?: string; timezone?: string }
   routes?: TransitStopInfo['routes']
   hasMore: boolean
@@ -427,7 +435,7 @@ async function fetchTransitDepartures(
   const config = resolveBarrelmanConfig()
   if (!config?.host) {
     logger.debug('[Widget/Transit] Barrelman not configured')
-    return { departures: [], hasMore: false, sources: [] }
+    return { departures: [], transferDepartures: [], hasMore: false, sources: [] }
   }
 
   const headers: Record<string, string> = {}
@@ -446,6 +454,9 @@ async function fetchTransitDepartures(
     if (params.name) queryParams.set('name', params.name)
     // One board per station in the interchange, for a tap on a merged label.
     if (params.complex) queryParams.set('complex', 'true')
+    // Connections are worth their times, not just their names — a rider
+    // changing here wants to know when the 4 leaves, not that it exists.
+    queryParams.set('transfers', 'true')
     if (windowMinutes) queryParams.set('windowMinutes', String(windowMinutes))
 
     const response = await fetch(`${config!.host}/transit/departures?${queryParams}`, { headers })
@@ -459,7 +470,7 @@ async function fetchTransitDepartures(
   try {
     logger.debug(`[Widget/Transit] Fetching departures from Barrelman at (${params.lat}, ${params.lng})`)
     let stopResults = await requestStops(limit, board.windowMinutes)
-    if (!stopResults) return { departures: [], hasMore: false, sources: [] }
+    if (!stopResults) return { departures: [], transferDepartures: [], hasMore: false, sources: [] }
 
     // Nothing at all in the window — the stop is shut for the night, or the
     // service is seasonal. Reach past the window rather than render an empty
@@ -471,16 +482,24 @@ async function fetchTransitDepartures(
       if (beyond?.some((s) => s.departures.length)) stopResults = beyond
     }
 
+    // A connecting station's runs are a different answer from this station's,
+    // so they are shaped into their own board. Merging them would put a train
+    // leaving Brooklyn Bridge–City Hall under Chambers St's departures and
+    // claim it departs from here, which is the whole distinction.
+    const ownStops = stopResults.filter((s) => s.stop.via !== 'transfer')
+    const transferStops = stopResults.filter((s) => s.stop.via === 'transfer')
+
     // Merge every nearby stop into one board — soonest first, capped per
     // route + direction so a frequent line can't crowd out an hourly one.
-    const primaryStop = stopResults[0]?.stop
-    const { departures: allDepartures, hasMore } = shapeBoard(
-      stopResults.map((stopResult) => ({
+    const primaryStop = ownStops[0]?.stop ?? stopResults[0]?.stop
+    const asBoard = (rows: BarrelmanStopDepartures[]) =>
+      rows.map((stopResult) => ({
         hasMore: stopResult.hasMore,
         departures: stopResult.departures.map((dep) => adaptDeparture(dep, stopResult.stop.timezone)),
-      })),
-      board,
-    )
+      }))
+
+    const { departures: allDepartures, hasMore } = shapeBoard(asBoard(ownStops), board)
+    const { departures: transferDepartures } = shapeBoard(asBoard(transferStops), board)
 
     logger.debug(`[Widget/Transit] Got ${allDepartures.length} departures from ${stopResults.length} stop(s)`)
 
@@ -542,6 +561,7 @@ async function fetchTransitDepartures(
 
     return {
       departures: allDepartures,
+      transferDepartures,
       stopInfo: primaryStop ? {
         name: primaryStop.name,
         code: primaryStop.code,
@@ -555,7 +575,7 @@ async function fetchTransitDepartures(
     }
   } catch (error) {
     logError('[Widget/Transit] Barrelman departure fetch failed', error)
-    return { departures: [], hasMore: false, sources: [] }
+    return { departures: [], transferDepartures: [], hasMore: false, sources: [] }
   }
 }
 
@@ -653,7 +673,8 @@ export async function fetchWidgetData(
         throw new Error('Missing lat/lng parameters for transit widget')
       }
 
-      const { departures, stopInfo, routes, hasMore, sources } = await fetchTransitDepartures(
+      const { departures, transferDepartures, stopInfo, routes, hasMore, sources } =
+        await fetchTransitDepartures(
         {
           lat,
           lng,
@@ -668,6 +689,7 @@ export async function fetchWidgetData(
 
       const transitInfo: TransitStopInfo = {
         departures,
+        transferDepartures,
         routes,
         hasMore,
         windowMinutes: resolveBoardWindow(windowMinutes).windowMinutes,

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -1,4 +1,4 @@
-import type { Place, TransitDeparture, TransitStopInfo, WidgetDescriptor, WidgetResponse, SourceReference, RelatedPlacesData, RelatedPlacesStrategy, RelatedParent, DisplayChip, BikeshareStatus } from '../types/place.types'
+import type { Place, TransitDeparture, TransitStopInfo, TransitTransferStation, WidgetDescriptor, WidgetResponse, SourceReference, RelatedPlacesData, RelatedPlacesStrategy, RelatedParent, DisplayChip, BikeshareStatus } from '../types/place.types'
 import { WidgetType, WidgetDataType } from '../types/place.types'
 
 import { SOURCE } from '../lib/constants'
@@ -422,8 +422,8 @@ async function fetchTransitDepartures(
   options?: { limit?: number; windowMinutes?: number },
 ): Promise<{
   departures: TransitDeparture[]
-  /** Runs leaving the stations a rider can transfer to, on their own board. */
-  transferDepartures: TransitDeparture[]
+  /** The stations a rider can transfer to, each with its own board. */
+  transferStations: TransitTransferStation[]
   stopInfo?: { name?: string; code?: string; feedId?: string; stopId?: string; timezone?: string }
   routes?: TransitStopInfo['routes']
   hasMore: boolean
@@ -435,7 +435,7 @@ async function fetchTransitDepartures(
   const config = resolveBarrelmanConfig()
   if (!config?.host) {
     logger.debug('[Widget/Transit] Barrelman not configured')
-    return { departures: [], transferDepartures: [], hasMore: false, sources: [] }
+    return { departures: [], transferStations: [], hasMore: false, sources: [] }
   }
 
   const headers: Record<string, string> = {}
@@ -470,7 +470,7 @@ async function fetchTransitDepartures(
   try {
     logger.debug(`[Widget/Transit] Fetching departures from Barrelman at (${params.lat}, ${params.lng})`)
     let stopResults = await requestStops(limit, board.windowMinutes)
-    if (!stopResults) return { departures: [], transferDepartures: [], hasMore: false, sources: [] }
+    if (!stopResults) return { departures: [], transferStations: [], hasMore: false, sources: [] }
 
     // Nothing at all in the window — the stop is shut for the night, or the
     // service is seasonal. Reach past the window rather than render an empty
@@ -499,7 +499,31 @@ async function fetchTransitDepartures(
       }))
 
     const { departures: allDepartures, hasMore } = shapeBoard(asBoard(ownStops), board)
-    const { departures: transferDepartures } = shapeBoard(asBoard(transferStops), board)
+
+    // One entry per connecting station, not one flat list: a connection is a
+    // place, and "the R leaves in 6 minutes" only helps once you know it
+    // leaves from Court St. Stations sharing a name are the same station drawn
+    // twice — Barrelman returns a board per platform group — so they merge, on
+    // the same case-and-punctuation fold it groups by.
+    const foldName = (n: string) =>
+      n.toLowerCase().replace(/[^a-z0-9]+/g, ' ').trim()
+
+    const byName = new Map<string, BarrelmanStopDepartures[]>()
+    for (const row of transferStops) {
+      const key = foldName(row.stop.name)
+      byName.set(key, [...(byName.get(key) ?? []), row])
+    }
+
+    const transferStations: TransitTransferStation[] = [...byName.values()]
+      .map((rows) => ({
+        name: rows[0].stop.name,
+        feedId: rows[0].stop.feedId,
+        stopId: rows[0].stop.stopId,
+        lat: rows[0].stop.lat,
+        lng: rows[0].stop.lng,
+        departures: shapeBoard(asBoard(rows), board).departures,
+      }))
+      .filter((s) => s.departures.length)
 
     logger.debug(`[Widget/Transit] Got ${allDepartures.length} departures from ${stopResults.length} stop(s)`)
 
@@ -561,7 +585,7 @@ async function fetchTransitDepartures(
 
     return {
       departures: allDepartures,
-      transferDepartures,
+      transferStations,
       stopInfo: primaryStop ? {
         name: primaryStop.name,
         code: primaryStop.code,
@@ -575,7 +599,7 @@ async function fetchTransitDepartures(
     }
   } catch (error) {
     logError('[Widget/Transit] Barrelman departure fetch failed', error)
-    return { departures: [], transferDepartures: [], hasMore: false, sources: [] }
+    return { departures: [], transferStations: [], hasMore: false, sources: [] }
   }
 }
 
@@ -673,7 +697,7 @@ export async function fetchWidgetData(
         throw new Error('Missing lat/lng parameters for transit widget')
       }
 
-      const { departures, transferDepartures, stopInfo, routes, hasMore, sources } =
+      const { departures, transferStations, stopInfo, routes, hasMore, sources } =
         await fetchTransitDepartures(
         {
           lat,
@@ -689,7 +713,7 @@ export async function fetchWidgetData(
 
       const transitInfo: TransitStopInfo = {
         departures,
-        transferDepartures,
+        transferStations,
         routes,
         hasMore,
         windowMinutes: resolveBoardWindow(windowMinutes).windowMinutes,

--- a/server/src/types/place.types.ts
+++ b/server/src/types/place.types.ts
@@ -155,10 +155,11 @@ export interface TransitTransferStation {
   stopId?: string
   lat?: number
   lng?: number
-  /** The OSM object this station is, as "node/123", when Barrelman could
-   *  identify one. Opening it beats searching by name, which cannot tell
-   *  three stations called "Chambers St" apart. */
-  osm?: string
+  /** The feed's transit.land onestop id. Portolan keys its station index by
+   *  `<onestop>:<stop_id>`, so this plus `stopId` is what resolves this
+   *  station to the OSM object the map opens — a name cannot, since three
+   *  stations are called "Chambers St". */
+  feedOnestopId?: string
   departures: TransitDeparture[]
 }
 

--- a/server/src/types/place.types.ts
+++ b/server/src/types/place.types.ts
@@ -155,6 +155,10 @@ export interface TransitTransferStation {
   stopId?: string
   lat?: number
   lng?: number
+  /** The OSM object this station is, as "node/123", when Barrelman could
+   *  identify one. Opening it beats searching by name, which cannot tell
+   *  three stations called "Chambers St" apart. */
+  osm?: string
   departures: TransitDeparture[]
 }
 

--- a/server/src/types/place.types.ts
+++ b/server/src/types/place.types.ts
@@ -148,6 +148,16 @@ export interface TransitDeparture {
   }
 }
 
+/** A station reachable on foot from this one, with what leaves from it. */
+export interface TransitTransferStation {
+  name: string
+  feedId?: string
+  stopId?: string
+  lat?: number
+  lng?: number
+  departures: TransitDeparture[]
+}
+
 export interface TransitStopInfo {
   /** @deprecated Use stopId/feedId or coordinates instead */
   onestopId?: string
@@ -166,10 +176,13 @@ export interface TransitStopInfo {
   timezone?: string
   wheelchairBoarding?: number
   departures?: TransitDeparture[]
-  /** Runs leaving the stations a rider can transfer to from here — a
-   *  different promise from `departures`, which is what leaves this platform,
-   *  so they are kept apart rather than merged. */
-  transferDepartures?: TransitDeparture[]
+  /** The stations a rider can transfer to, each with its own board.
+   *
+   *  Kept per-station rather than merged into one list: a connection is a
+   *  place, and "the R leaves in 6 minutes" is only useful once you know it
+   *  leaves from Court St. Stations sharing a name are one entry, since that
+   *  is the same station drawn twice. */
+  transferStations?: TransitTransferStation[]
   /** How far ahead `departures` reaches, in minutes. */
   windowMinutes?: number
   /** More runs exist past the window — the board can offer to load them. */

--- a/server/src/types/place.types.ts
+++ b/server/src/types/place.types.ts
@@ -166,6 +166,10 @@ export interface TransitStopInfo {
   timezone?: string
   wheelchairBoarding?: number
   departures?: TransitDeparture[]
+  /** Runs leaving the stations a rider can transfer to from here — a
+   *  different promise from `departures`, which is what leaves this platform,
+   *  so they are kept apart rather than merged. */
+  transferDepartures?: TransitDeparture[]
   /** How far ahead `departures` reaches, in minutes. */
   windowMinutes?: number
   /** More runs exist past the window — the board can offer to load them. */

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -114,6 +114,7 @@ const transferStations = computed(() =>
     name: station.name,
     lat: station.lat,
     lng: station.lng,
+    osm: station.osm,
     groups: groupDepartures(station.departures, currentTime.value, {
       unknownDirectionLabel: t('place.transit.unknownDirection'),
       limit: 2,
@@ -136,7 +137,24 @@ const transferStations = computed(() =>
  * name names an interchange, not one platform group, and without it the page
  * answers for whichever member the point resolved to.
  */
-function openTransferStation(station: { name: string; lat?: number; lng?: number }) {
+function openTransferStation(station: {
+  name: string
+  lat?: number
+  lng?: number
+  osm?: string
+}) {
+  // The OSM object when Barrelman identified one: it opens the station the map
+  // opens, and it is the only way to tell three stations called "Chambers St"
+  // apart — a name search ranks by importance and picked the A/C/E one 428m
+  // from the J/Z platform the rider was standing on.
+  const [type, id] = (station.osm ?? '').split('/')
+  if (type && id) {
+    router.push({ name: AppRoute.PLACE, params: { type, id }, query: { complex: '1' } })
+    return
+  }
+
+  // Otherwise the name and the point, which resolves to the same node wherever
+  // the name is unambiguous.
   if (station.lat == null || station.lng == null) return
   router.push({
     name: AppRoute.PLACE_LOCATION,

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -125,13 +125,23 @@ const transferStations = computed(() =>
   })).filter((s) => s.groups.length),
 )
 
-/** Open a connecting station's own page — by name and point, which is how the
- *  app addresses a place it has no OSM id for. */
+/**
+ * Open a connecting station's own page.
+ *
+ * By name and point, which is how the app addresses a place it holds no OSM id
+ * for — the server resolves that pair back to the same OSM node a tap on the
+ * map would have opened.
+ *
+ * `complex` rides along for the same reason every station tap carries it: the
+ * name names an interchange, not one platform group, and without it the page
+ * answers for whichever member the point resolved to.
+ */
 function openTransferStation(station: { name: string; lat?: number; lng?: number }) {
   if (station.lat == null || station.lng == null) return
   router.push({
     name: AppRoute.PLACE_LOCATION,
     params: { name: station.name, lat: String(station.lat), lng: String(station.lng) },
+    query: { complex: '1' },
   })
 }
 

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -100,6 +100,23 @@ watch(
 const styleOfRoute = (route: { id: string; type?: number }) =>
   bulletFor(route.id, transitInfo.value?.lat, transitInfo.value?.lng, route.type)
 
+/**
+ * The connecting stations' own board, grouped exactly like this station's.
+ *
+ * Kept separate all the way from Barrelman: these runs leave another platform,
+ * and merging them into the board above would say they depart from here.
+ */
+const transferGroups = computed(() =>
+  groupDepartures(transitInfo.value?.transferDepartures || [], currentTime.value, {
+    unknownDirectionLabel: t('place.transit.unknownDirection'),
+    limit: 2,
+    dayLabels: {
+      tonight: t('place.transit.tonight'),
+      tomorrow: t('place.transit.tomorrow'),
+    },
+  }),
+)
+
 const routeGroups = computed(() =>
   groupDepartures(departures.value, currentTime.value, {
     unknownDirectionLabel: t('place.transit.unknownDirection'),
@@ -258,11 +275,14 @@ function openRoute(routeId?: string) {
       </div>
 
       <StationTransfers
+        :groups="transferGroups"
+        :now="currentTime"
         :lines="transferLines"
         :lat="transitInfo?.lat"
         :lng="transitInfo?.lng"
         :feed-id="transitInfo?.feedId"
         @open="(line: StationLine) => openRoute(line.id)"
+        @open-route="(routeId: string) => openRoute(routeId)"
       />
 
       <!-- Agency attribution -->

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -16,6 +16,10 @@ import { ChevronRightIcon } from 'lucide-vue-next'
 import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
 import RouteBullet from '@/components/transit/RouteBullet.vue'
 import { bulletFor, ensureBulletsAt } from '@/services/layers/features/portolan/portolan-bullets'
+import {
+  ensureStopIndexAt,
+  osmForStop,
+} from '@/services/layers/features/portolan/portolan-stops'
 import { usePlaceTabs } from '@/composables/usePlaceTabs'
 import { useTransitClock } from '@/composables/useTransitClock'
 import {
@@ -94,7 +98,10 @@ watch(
  *  colour and label, resolved against the stop's own coordinates. */
 watch(
   () => [transitInfo.value?.lat, transitInfo.value?.lng],
-  () => void ensureBulletsAt(transitInfo.value?.lat, transitInfo.value?.lng),
+  () => {
+    void ensureBulletsAt(transitInfo.value?.lat, transitInfo.value?.lng)
+    void ensureStopIndexAt(transitInfo.value?.lat, transitInfo.value?.lng)
+  },
   { immediate: true },
 )
 const styleOfRoute = (route: { id: string; type?: number }) =>
@@ -114,7 +121,10 @@ const transferStations = computed(() =>
     name: station.name,
     lat: station.lat,
     lng: station.lng,
-    osm: station.osm,
+    // Portolan's own join, which is the only exact one.
+    osm:
+      osmForStop(station.feedOnestopId, station.stopId, station.lat, station.lng) ??
+      undefined,
     groups: groupDepartures(station.departures, currentTime.value, {
       unknownDirectionLabel: t('place.transit.unknownDirection'),
       limit: 2,
@@ -143,10 +153,10 @@ function openTransferStation(station: {
   lng?: number
   osm?: string
 }) {
-  // The OSM object when Barrelman identified one: it opens the station the map
-  // opens, and it is the only way to tell three stations called "Chambers St"
-  // apart — a name search ranks by importance and picked the A/C/E one 428m
-  // from the J/Z platform the rider was standing on.
+  // Portolan's OSM object when it has one: it opens the station the map opens,
+  // and it is the only way to tell three stations called "Chambers St" apart —
+  // a name search ranks by importance and picked the A/C/E one 428m from the
+  // J/Z platform the rider was standing on.
   const [type, id] = (station.osm ?? '').split('/')
   if (type && id) {
     router.push({ name: AppRoute.PLACE, params: { type, id }, query: { complex: '1' } })

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -101,21 +101,39 @@ const styleOfRoute = (route: { id: string; type?: number }) =>
   bulletFor(route.id, transitInfo.value?.lat, transitInfo.value?.lng, route.type)
 
 /**
- * The connecting stations' own board, grouped exactly like this station's.
+ * The connecting stations, each with its own grouped board.
  *
- * Kept separate all the way from Barrelman: these runs leave another platform,
- * and merging them into the board above would say they depart from here.
+ * Kept per-station all the way from Barrelman: these runs leave another
+ * platform, and merging them into the board above would say they depart from
+ * here. The name rides along because a connection is a place — "the R in 6
+ * minutes" only helps once you know it leaves Court St — and it is what a
+ * rider taps to go and look at it.
  */
-const transferGroups = computed(() =>
-  groupDepartures(transitInfo.value?.transferDepartures || [], currentTime.value, {
-    unknownDirectionLabel: t('place.transit.unknownDirection'),
-    limit: 2,
-    dayLabels: {
-      tonight: t('place.transit.tonight'),
-      tomorrow: t('place.transit.tomorrow'),
-    },
-  }),
+const transferStations = computed(() =>
+  (transitInfo.value?.transferStations || []).map((station) => ({
+    name: station.name,
+    lat: station.lat,
+    lng: station.lng,
+    groups: groupDepartures(station.departures, currentTime.value, {
+      unknownDirectionLabel: t('place.transit.unknownDirection'),
+      limit: 2,
+      dayLabels: {
+        tonight: t('place.transit.tonight'),
+        tomorrow: t('place.transit.tomorrow'),
+      },
+    }),
+  })).filter((s) => s.groups.length),
 )
+
+/** Open a connecting station's own page — by name and point, which is how the
+ *  app addresses a place it has no OSM id for. */
+function openTransferStation(station: { name: string; lat?: number; lng?: number }) {
+  if (station.lat == null || station.lng == null) return
+  router.push({
+    name: AppRoute.PLACE_LOCATION,
+    params: { name: station.name, lat: String(station.lat), lng: String(station.lng) },
+  })
+}
 
 const routeGroups = computed(() =>
   groupDepartures(departures.value, currentTime.value, {
@@ -275,7 +293,7 @@ function openRoute(routeId?: string) {
       </div>
 
       <StationTransfers
-        :groups="transferGroups"
+        :stations="transferStations"
         :now="currentTime"
         :lines="transferLines"
         :lat="transitInfo?.lat"
@@ -283,6 +301,7 @@ function openRoute(routeId?: string) {
         :feed-id="transitInfo?.feedId"
         @open="(line: StationLine) => openRoute(line.id)"
         @open-route="(routeId: string) => openRoute(routeId)"
+        @open-station="openTransferStation"
       />
 
       <!-- Agency attribution -->

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -79,6 +79,23 @@ function openRoute(routeId?: string) {
   router.push({ name: AppRoute.TRANSIT_ROUTE, params: { feedId, routeId } })
 }
 
+/**
+ * The connecting stations' own board, grouped exactly like this station's.
+ *
+ * Kept separate all the way from Barrelman: these runs leave another platform,
+ * and merging them into the board above would say they depart from here.
+ */
+const transferGroups = computed(() =>
+  groupDepartures(props.transitInfo?.transferDepartures || [], currentTime.value, {
+    unknownDirectionLabel: t('place.transit.unknownDirection'),
+    limit: 2,
+    dayLabels: {
+      tonight: t('place.transit.tonight'),
+      tomorrow: t('place.transit.tomorrow'),
+    },
+  }),
+)
+
 const routeGroups = computed(() =>
   groupDepartures(departures.value, currentTime.value, {
     unknownDirectionLabel: t('place.transit.unknownDirection'),
@@ -281,12 +298,15 @@ function openTransitlandLink() {
     </div>
 
     <StationTransfers
+      :groups="transferGroups"
+      :now="currentTime"
       :lines="transferLines"
       :lat="transitInfo?.lat"
       :lng="transitInfo?.lng"
       :feed-id="transitInfo?.feedId"
       class="mt-6"
       @open="(line: StationLine) => openRoute(line.id)"
+      @open-route="(routeId: string) => openRoute(routeId)"
     />
 
     <!-- Footer -->

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -104,13 +104,23 @@ const transferStations = computed(() =>
   })).filter((s) => s.groups.length),
 )
 
-/** Open a connecting station's own page — by name and point, which is how the
- *  app addresses a place it has no OSM id for. */
+/**
+ * Open a connecting station's own page.
+ *
+ * By name and point, which is how the app addresses a place it holds no OSM id
+ * for — the server resolves that pair back to the same OSM node a tap on the
+ * map would have opened.
+ *
+ * `complex` rides along for the same reason every station tap carries it: the
+ * name names an interchange, not one platform group, and without it the page
+ * answers for whichever member the point resolved to.
+ */
 function openTransferStation(station: { name: string; lat?: number; lng?: number }) {
   if (station.lat == null || station.lng == null) return
   router.push({
     name: AppRoute.PLACE_LOCATION,
     params: { name: station.name, lat: String(station.lat), lng: String(station.lng) },
+    query: { complex: '1' },
   })
 }
 

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -93,6 +93,7 @@ const transferStations = computed(() =>
     name: station.name,
     lat: station.lat,
     lng: station.lng,
+    osm: station.osm,
     groups: groupDepartures(station.departures, currentTime.value, {
       unknownDirectionLabel: t('place.transit.unknownDirection'),
       limit: 2,
@@ -115,7 +116,24 @@ const transferStations = computed(() =>
  * name names an interchange, not one platform group, and without it the page
  * answers for whichever member the point resolved to.
  */
-function openTransferStation(station: { name: string; lat?: number; lng?: number }) {
+function openTransferStation(station: {
+  name: string
+  lat?: number
+  lng?: number
+  osm?: string
+}) {
+  // The OSM object when Barrelman identified one: it opens the station the map
+  // opens, and it is the only way to tell three stations called "Chambers St"
+  // apart — a name search ranks by importance and picked the A/C/E one 428m
+  // from the J/Z platform the rider was standing on.
+  const [type, id] = (station.osm ?? '').split('/')
+  if (type && id) {
+    router.push({ name: AppRoute.PLACE, params: { type, id }, query: { complex: '1' } })
+    return
+  }
+
+  // Otherwise the name and the point, which resolves to the same node wherever
+  // the name is unambiguous.
   if (station.lat == null || station.lng == null) return
   router.push({
     name: AppRoute.PLACE_LOCATION,

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -7,6 +7,10 @@ import { ClockIcon, ExternalLinkIcon } from 'lucide-vue-next'
 import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
 import RouteBullet from '@/components/transit/RouteBullet.vue'
 import { bulletFor, ensureBulletsAt } from '@/services/layers/features/portolan/portolan-bullets'
+import {
+  ensureStopIndexAt,
+  osmForStop,
+} from '@/services/layers/features/portolan/portolan-stops'
 import ServiceAlerts from '@/components/transit/ServiceAlerts.vue'
 import ServiceAlertBadge from '@/components/transit/ServiceAlertBadge.vue'
 import { useTransitAlerts } from '@/composables/useTransitAlerts'
@@ -63,7 +67,10 @@ const departures = computed((): TransitDeparture[] => {
 /** Same curated bullets as the card this page expands. */
 watch(
   () => [props.transitInfo?.lat, props.transitInfo?.lng],
-  () => void ensureBulletsAt(props.transitInfo?.lat, props.transitInfo?.lng),
+  () => {
+    void ensureBulletsAt(props.transitInfo?.lat, props.transitInfo?.lng)
+    void ensureStopIndexAt(props.transitInfo?.lat, props.transitInfo?.lng)
+  },
   { immediate: true },
 )
 const styleOfRoute = (route: { id: string; type?: number }) =>
@@ -93,7 +100,10 @@ const transferStations = computed(() =>
     name: station.name,
     lat: station.lat,
     lng: station.lng,
-    osm: station.osm,
+    // Portolan's own join, which is the only exact one.
+    osm:
+      osmForStop(station.feedOnestopId, station.stopId, station.lat, station.lng) ??
+      undefined,
     groups: groupDepartures(station.departures, currentTime.value, {
       unknownDirectionLabel: t('place.transit.unknownDirection'),
       limit: 2,
@@ -122,10 +132,10 @@ function openTransferStation(station: {
   lng?: number
   osm?: string
 }) {
-  // The OSM object when Barrelman identified one: it opens the station the map
-  // opens, and it is the only way to tell three stations called "Chambers St"
-  // apart — a name search ranks by importance and picked the A/C/E one 428m
-  // from the J/Z platform the rider was standing on.
+  // Portolan's OSM object when it has one: it opens the station the map opens,
+  // and it is the only way to tell three stations called "Chambers St" apart —
+  // a name search ranks by importance and picked the A/C/E one 428m from the
+  // J/Z platform the rider was standing on.
   const [type, id] = (station.osm ?? '').split('/')
   if (type && id) {
     router.push({ name: AppRoute.PLACE, params: { type, id }, query: { complex: '1' } })

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -80,21 +80,39 @@ function openRoute(routeId?: string) {
 }
 
 /**
- * The connecting stations' own board, grouped exactly like this station's.
+ * The connecting stations, each with its own grouped board.
  *
- * Kept separate all the way from Barrelman: these runs leave another platform,
- * and merging them into the board above would say they depart from here.
+ * Kept per-station all the way from Barrelman: these runs leave another
+ * platform, and merging them into the board above would say they depart from
+ * here. The name rides along because a connection is a place — "the R in 6
+ * minutes" only helps once you know it leaves Court St — and it is what a
+ * rider taps to go and look at it.
  */
-const transferGroups = computed(() =>
-  groupDepartures(props.transitInfo?.transferDepartures || [], currentTime.value, {
-    unknownDirectionLabel: t('place.transit.unknownDirection'),
-    limit: 2,
-    dayLabels: {
-      tonight: t('place.transit.tonight'),
-      tomorrow: t('place.transit.tomorrow'),
-    },
-  }),
+const transferStations = computed(() =>
+  (props.transitInfo?.transferStations || []).map((station) => ({
+    name: station.name,
+    lat: station.lat,
+    lng: station.lng,
+    groups: groupDepartures(station.departures, currentTime.value, {
+      unknownDirectionLabel: t('place.transit.unknownDirection'),
+      limit: 2,
+      dayLabels: {
+        tonight: t('place.transit.tonight'),
+        tomorrow: t('place.transit.tomorrow'),
+      },
+    }),
+  })).filter((s) => s.groups.length),
 )
+
+/** Open a connecting station's own page — by name and point, which is how the
+ *  app addresses a place it has no OSM id for. */
+function openTransferStation(station: { name: string; lat?: number; lng?: number }) {
+  if (station.lat == null || station.lng == null) return
+  router.push({
+    name: AppRoute.PLACE_LOCATION,
+    params: { name: station.name, lat: String(station.lat), lng: String(station.lng) },
+  })
+}
 
 const routeGroups = computed(() =>
   groupDepartures(departures.value, currentTime.value, {
@@ -298,7 +316,7 @@ function openTransitlandLink() {
     </div>
 
     <StationTransfers
-      :groups="transferGroups"
+      :stations="transferStations"
       :now="currentTime"
       :lines="transferLines"
       :lat="transitInfo?.lat"
@@ -307,6 +325,7 @@ function openTransitlandLink() {
       class="mt-6"
       @open="(line: StationLine) => openRoute(line.id)"
       @open-route="(routeId: string) => openRoute(routeId)"
+        @open-station="openTransferStation"
     />
 
     <!-- Footer -->

--- a/web/src/components/transit/StationTransfers.vue
+++ b/web/src/components/transit/StationTransfers.vue
@@ -39,6 +39,7 @@ const props = defineProps<{
     name: string
     lat?: number
     lng?: number
+    osm?: string
     groups: RouteGroup[]
   }>
   /** Clock the countdowns are measured against. */
@@ -48,7 +49,12 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'open', line: StationLine): void
   (e: 'openRoute', routeId: string): void
-  (e: 'openStation', station: { name: string; lat?: number; lng?: number }): void
+  (e: 'openStation', station: {
+    name: string
+    lat?: number
+    lng?: number
+    osm?: string
+  }): void
 }>()
 
 const { t } = useI18n()
@@ -93,8 +99,13 @@ const hasTransfers = computed(
 const countdown = (dep: any) => (props.now ? formatCountdown(dep, props.now) : '')
 
 /** A station is only a link when we know where it is. */
-function openStation(station: { name: string; lat?: number; lng?: number }) {
-  if (station.lat == null || station.lng == null) return
+function openStation(station: {
+  name: string
+  lat?: number
+  lng?: number
+  osm?: string
+}) {
+  if (!station.osm && (station.lat == null || station.lng == null)) return
   emit('openStation', station)
 }
 </script>
@@ -112,9 +123,9 @@ function openStation(station: { name: string; lat?: number; lng?: number }) {
         <!-- One block per connecting station: its name, then what leaves it -->
         <div v-for="station in stations ?? []" :key="station.name">
           <component
-            :is="station.lat != null && station.lng != null ? 'button' : 'div'"
+            :is="station.osm || (station.lat != null && station.lng != null) ? 'button' : 'div'"
             class="flex items-center gap-1 mb-1.5 text-left group/station"
-            :class="station.lat != null && station.lng != null && 'cursor-pointer'"
+            :class="(station.osm || station.lat != null) && 'cursor-pointer'"
             @click="openStation(station)"
           >
             <span
@@ -123,7 +134,7 @@ function openStation(station: { name: string; lat?: number; lng?: number }) {
               {{ station.name }}
             </span>
             <ChevronRightIcon
-              v-if="station.lat != null && station.lng != null"
+              v-if="station.osm || (station.lat != null && station.lng != null)"
               class="h-3 w-3 text-muted-foreground/60 group-hover/station:text-foreground transition-colors"
             />
           </component>

--- a/web/src/components/transit/StationTransfers.vue
+++ b/web/src/components/transit/StationTransfers.vue
@@ -21,6 +21,7 @@ import { getRouteBulletLabel } from '@/lib/transit'
 import type { StationLine } from '@/composables/usePlaceTransitLines'
 import type { Dayjs } from 'dayjs'
 import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
+import { ChevronRightIcon } from 'lucide-vue-next'
 import { formatCountdown, type RouteGroup } from '@/lib/transit-departures'
 
 const props = defineProps<{
@@ -31,10 +32,15 @@ const props = defineProps<{
   lng?: number
   /** Absent when the board never named its feed; a bullet is then inert. */
   feedId?: string
-  /** Departures leaving the connecting stations, grouped by route. When these
-   *  are present the Transfers list shows times instead of bare bullets — a
-   *  connection is worth more with them than without. */
-  groups?: RouteGroup[]
+  /** The connecting stations, each with its name and its own grouped board.
+   *  A connection is a place: "the R in 6 minutes" only helps once you know it
+   *  leaves from Court St, and the name is also what you tap to go there. */
+  stations?: Array<{
+    name: string
+    lat?: number
+    lng?: number
+    groups: RouteGroup[]
+  }>
   /** Clock the countdowns are measured against. */
   now?: Date | Dayjs
 }>()
@@ -42,6 +48,7 @@ const props = defineProps<{
 const emit = defineEmits<{
   (e: 'open', line: StationLine): void
   (e: 'openRoute', routeId: string): void
+  (e: 'openStation', station: { name: string; lat?: number; lng?: number }): void
 }>()
 
 const { t } = useI18n()
@@ -69,7 +76,9 @@ const bulletForRoute = (route: RouteGroup['route']) =>
 /** Transfer lines still needing a bullet row: the ones no board covers. When
  *  a connection has departures, its times say everything the bullet did. */
 const uncoveredTransfers = computed(() => {
-  const withTimes = new Set((props.groups ?? []).map((g) => g.route.id))
+  const withTimes = new Set(
+    (props.stations ?? []).flatMap((st) => st.groups.map((g) => g.route.id)),
+  )
   return props.lines.filter((l) => l.via === 'transfer' && !withTimes.has(l.id))
 })
 
@@ -78,10 +87,16 @@ const uncoveredTransfers = computed(() => {
 const nearbyLines = computed(() => props.lines.filter((l) => l.via === 'nearby'))
 
 const hasTransfers = computed(
-  () => (props.groups?.length ?? 0) > 0 || uncoveredTransfers.value.length > 0,
+  () => (props.stations?.length ?? 0) > 0 || uncoveredTransfers.value.length > 0,
 )
 
 const countdown = (dep: any) => (props.now ? formatCountdown(dep, props.now) : '')
+
+/** A station is only a link when we know where it is. */
+function openStation(station: { name: string; lat?: number; lng?: number }) {
+  if (station.lat == null || station.lng == null) return
+  emit('openStation', station)
+}
 </script>
 
 <template>
@@ -93,44 +108,66 @@ const countdown = (dep: any) => (props.now ? formatCountdown(dep, props.now) : '
     <div v-if="hasTransfers">
       <h3 class="text-sm font-medium mb-2">{{ t('place.transit.transfers') }}</h3>
 
-      <div class="space-y-3">
-        <div v-for="group in groups ?? []" :key="group.routeKey">
-          <button
-            class="flex items-center gap-2 mb-1.5 group/route cursor-pointer text-left"
-            @click="emit('openRoute', group.route.id)"
+      <div class="space-y-4">
+        <!-- One block per connecting station: its name, then what leaves it -->
+        <div v-for="station in stations ?? []" :key="station.name">
+          <component
+            :is="station.lat != null && station.lng != null ? 'button' : 'div'"
+            class="flex items-center gap-1 mb-1.5 text-left group/station"
+            :class="station.lat != null && station.lng != null && 'cursor-pointer'"
+            @click="openStation(station)"
           >
-            <RouteBullet
-              :label="bulletForRoute(group.route)?.label || group.route.shortName || ''"
-              :color="bulletForRoute(group.route)?.color || group.route.color"
-              :shape="bulletForRoute(group.route)?.shape"
-              :text-color="bulletForRoute(group.route)?.color ? null : group.route.textColor"
-              class="group-hover/route:ring-2 ring-offset-1 ring-foreground/20 transition-shadow"
-            />
             <span
-              class="text-sm text-muted-foreground truncate group-hover/route:text-foreground transition-colors"
+              class="text-xs font-medium text-muted-foreground group-hover/station:text-foreground transition-colors"
             >
-              {{ group.route.longName || group.route.shortName }}
+              {{ station.name }}
             </span>
-          </button>
+            <ChevronRightIcon
+              v-if="station.lat != null && station.lng != null"
+              class="h-3 w-3 text-muted-foreground/60 group-hover/station:text-foreground transition-colors"
+            />
+          </component>
 
-          <div class="space-y-1.5 ml-1">
-            <div
-              v-for="dir in group.directions"
-              :key="dir.headsign"
-              class="flex items-center justify-between gap-3"
-            >
-              <span class="text-sm truncate min-w-0">{{ dir.headsign }}</span>
-              <div class="flex items-center gap-0.5 shrink-0">
-                <template v-for="(dep, i) in dir.departures" :key="i">
-                  <span v-if="i > 0" class="text-muted-foreground text-xs">,</span>
-                  <span class="text-sm tabular-nums">{{ countdown(dep) }}</span>
-                  <RealtimeIndicator
-                    v-if="dep.realTime"
-                    :real-time="true"
-                    :delay="dep.delay"
-                    class="shrink-0"
-                  />
-                </template>
+          <div class="space-y-3">
+            <div v-for="group in station.groups" :key="group.routeKey">
+              <button
+                class="flex items-center gap-2 mb-1.5 group/route cursor-pointer text-left"
+                @click="emit('openRoute', group.route.id)"
+              >
+                <RouteBullet
+                  :label="bulletForRoute(group.route)?.label || group.route.shortName || ''"
+                  :color="bulletForRoute(group.route)?.color || group.route.color"
+                  :shape="bulletForRoute(group.route)?.shape"
+                  :text-color="bulletForRoute(group.route)?.color ? null : group.route.textColor"
+                  class="group-hover/route:ring-2 ring-offset-1 ring-foreground/20 transition-shadow"
+                />
+                <span
+                  class="text-sm text-muted-foreground truncate group-hover/route:text-foreground transition-colors"
+                >
+                  {{ group.route.longName || group.route.shortName }}
+                </span>
+              </button>
+
+              <div class="space-y-1.5 ml-1">
+                <div
+                  v-for="dir in group.directions"
+                  :key="dir.headsign"
+                  class="flex items-center justify-between gap-3"
+                >
+                  <span class="text-sm truncate min-w-0">{{ dir.headsign }}</span>
+                  <div class="flex items-center gap-0.5 shrink-0">
+                    <template v-for="(dep, i) in dir.departures" :key="i">
+                      <span v-if="i > 0" class="text-muted-foreground text-xs">,</span>
+                      <span class="text-sm tabular-nums">{{ countdown(dep) }}</span>
+                      <RealtimeIndicator
+                        v-if="dep.realTime"
+                        :real-time="true"
+                        :delay="dep.delay"
+                        class="shrink-0"
+                      />
+                    </template>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/web/src/components/transit/StationTransfers.vue
+++ b/web/src/components/transit/StationTransfers.vue
@@ -19,6 +19,9 @@ import RouteBullet from '@/components/transit/RouteBullet.vue'
 import { bulletFor } from '@/services/layers/features/portolan/portolan-bullets'
 import { getRouteBulletLabel } from '@/lib/transit'
 import type { StationLine } from '@/composables/usePlaceTransitLines'
+import type { Dayjs } from 'dayjs'
+import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
+import { formatCountdown, type RouteGroup } from '@/lib/transit-departures'
 
 const props = defineProps<{
   lines: StationLine[]
@@ -28,13 +31,27 @@ const props = defineProps<{
   lng?: number
   /** Absent when the board never named its feed; a bullet is then inert. */
   feedId?: string
+  /** Departures leaving the connecting stations, grouped by route. When these
+   *  are present the Transfers list shows times instead of bare bullets — a
+   *  connection is worth more with them than without. */
+  groups?: RouteGroup[]
+  /** Clock the countdowns are measured against. */
+  now?: Date | Dayjs
 }>()
 
-const emit = defineEmits<{ (e: 'open', line: StationLine): void }>()
+const emit = defineEmits<{
+  (e: 'open', line: StationLine): void
+  (e: 'openRoute', routeId: string): void
+}>()
 
 const { t } = useI18n()
 
 const styleOf = (line: StationLine) => bulletFor(line.id, props.lat, props.lng, line.type)
+
+/** The same lookup for a departure group's route, which carries `type`
+ *  under a different name than a StationLine does. */
+const bulletForRoute = (route: RouteGroup['route']) =>
+  bulletFor(route.id, props.lat, props.lng, route.type)
 
 /**
  * Two lists, because they are two different promises.
@@ -49,49 +66,136 @@ const styleOf = (line: StationLine) => bulletFor(line.id, props.lat, props.lng, 
  * The distance is shown rather than described, which is the honest signal: a
  * row that says "50 m" is plainly somewhere you walk to.
  */
-const groups = computed(() =>
-  [
-    { key: 'transfers', label: t('place.transit.transfers'), lines: props.lines.filter((l) => l.via === 'transfer') },
-    { key: 'nearby', label: t('place.transit.nearby'), lines: props.lines.filter((l) => l.via === 'nearby') },
-  ].filter((g) => g.lines.length),
+/** Transfer lines still needing a bullet row: the ones no board covers. When
+ *  a connection has departures, its times say everything the bullet did. */
+const uncoveredTransfers = computed(() => {
+  const withTimes = new Set((props.groups ?? []).map((g) => g.route.id))
+  return props.lines.filter((l) => l.via === 'transfer' && !withTimes.has(l.id))
+})
+
+/** Walk-to lines. Never timed: the board that would answer when they leave is
+ *  the other stop's, and no feed connects it to this one. */
+const nearbyLines = computed(() => props.lines.filter((l) => l.via === 'nearby'))
+
+const hasTransfers = computed(
+  () => (props.groups?.length ?? 0) > 0 || uncoveredTransfers.value.length > 0,
 )
+
+const countdown = (dep: any) => (props.now ? formatCountdown(dep, props.now) : '')
 </script>
 
 <template>
-  <section v-if="groups.length" class="mt-3 pt-3 border-t space-y-4">
-    <div v-for="group in groups" :key="group.key">
-    <h3 class="text-sm font-medium mb-2">{{ group.label }}</h3>
+  <section
+    v-if="hasTransfers || nearbyLines.length"
+    class="mt-3 pt-3 border-t space-y-4"
+  >
+    <!-- Transfers: a connecting station's own board, so these carry times -->
+    <div v-if="hasTransfers">
+      <h3 class="text-sm font-medium mb-2">{{ t('place.transit.transfers') }}</h3>
 
-    <ul class="space-y-1.5">
-      <li v-for="line in group.lines" :key="line.id">
-        <component
-          :is="feedId ? 'button' : 'div'"
-          class="flex items-center gap-2 w-full text-left"
-          :class="feedId && 'group/transfer cursor-pointer'"
-          @click="feedId && emit('open', line)"
-        >
-          <RouteBullet
-            :label="styleOf(line)?.label || getRouteBulletLabel(line, t)"
-            :color="styleOf(line)?.color || line.color"
-            :shape="styleOf(line)?.shape"
-            :text-color="styleOf(line)?.color ? null : line.textColor"
-            class="group-hover/transfer:ring-2 ring-offset-1 ring-foreground/20 transition-shadow"
-          />
-          <span
-            class="text-sm text-muted-foreground truncate group-hover/transfer:text-foreground transition-colors"
+      <div class="space-y-3">
+        <div v-for="group in groups ?? []" :key="group.routeKey">
+          <button
+            class="flex items-center gap-2 mb-1.5 group/route cursor-pointer text-left"
+            @click="emit('openRoute', group.route.id)"
           >
-            {{ line.longName || line.shortName }}
-          </span>
-          <!-- How far the walk is. Only nearby rows carry one. -->
-          <span
-            v-if="line.distanceM != null"
-            class="text-xs text-muted-foreground/70 shrink-0 ml-auto tabular-nums"
+            <RouteBullet
+              :label="bulletForRoute(group.route)?.label || group.route.shortName || ''"
+              :color="bulletForRoute(group.route)?.color || group.route.color"
+              :shape="bulletForRoute(group.route)?.shape"
+              :text-color="bulletForRoute(group.route)?.color ? null : group.route.textColor"
+              class="group-hover/route:ring-2 ring-offset-1 ring-foreground/20 transition-shadow"
+            />
+            <span
+              class="text-sm text-muted-foreground truncate group-hover/route:text-foreground transition-colors"
+            >
+              {{ group.route.longName || group.route.shortName }}
+            </span>
+          </button>
+
+          <div class="space-y-1.5 ml-1">
+            <div
+              v-for="dir in group.directions"
+              :key="dir.headsign"
+              class="flex items-center justify-between gap-3"
+            >
+              <span class="text-sm truncate min-w-0">{{ dir.headsign }}</span>
+              <div class="flex items-center gap-0.5 shrink-0">
+                <template v-for="(dep, i) in dir.departures" :key="i">
+                  <span v-if="i > 0" class="text-muted-foreground text-xs">,</span>
+                  <span class="text-sm tabular-nums">{{ countdown(dep) }}</span>
+                  <RealtimeIndicator
+                    v-if="dep.realTime"
+                    :real-time="true"
+                    :delay="dep.delay"
+                    class="shrink-0"
+                  />
+                </template>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- A transfer no board covered: still worth saying it exists. -->
+        <ul v-if="uncoveredTransfers.length" class="space-y-1.5">
+          <li v-for="line in uncoveredTransfers" :key="line.id">
+            <component
+              :is="feedId ? 'button' : 'div'"
+              class="flex items-center gap-2 w-full text-left"
+              :class="feedId && 'group/transfer cursor-pointer'"
+              @click="feedId && emit('open', line)"
+            >
+              <RouteBullet
+                :label="styleOf(line)?.label || getRouteBulletLabel(line, t)"
+                :color="styleOf(line)?.color || line.color"
+                :shape="styleOf(line)?.shape"
+                :text-color="styleOf(line)?.color ? null : line.textColor"
+                class="group-hover/transfer:ring-2 ring-offset-1 ring-foreground/20 transition-shadow"
+              />
+              <span
+                class="text-sm text-muted-foreground truncate group-hover/transfer:text-foreground transition-colors"
+              >
+                {{ line.longName || line.shortName }}
+              </span>
+            </component>
+          </li>
+        </ul>
+      </div>
+    </div>
+
+    <!-- Nearby: a walk to another operator's stop, so distance, not times -->
+    <div v-if="nearbyLines.length">
+      <h3 class="text-sm font-medium mb-2">{{ t('place.transit.nearby') }}</h3>
+
+      <ul class="space-y-1.5">
+        <li v-for="line in nearbyLines" :key="line.id">
+          <component
+            :is="feedId ? 'button' : 'div'"
+            class="flex items-center gap-2 w-full text-left"
+            :class="feedId && 'group/transfer cursor-pointer'"
+            @click="feedId && emit('open', line)"
           >
-            {{ line.distanceM }} m
-          </span>
-        </component>
-      </li>
-    </ul>
+            <RouteBullet
+              :label="styleOf(line)?.label || getRouteBulletLabel(line, t)"
+              :color="styleOf(line)?.color || line.color"
+              :shape="styleOf(line)?.shape"
+              :text-color="styleOf(line)?.color ? null : line.textColor"
+              class="group-hover/transfer:ring-2 ring-offset-1 ring-foreground/20 transition-shadow"
+            />
+            <span
+              class="text-sm text-muted-foreground truncate group-hover/transfer:text-foreground transition-colors"
+            >
+              {{ line.longName || line.shortName }}
+            </span>
+            <span
+              v-if="line.distanceM != null"
+              class="text-xs text-muted-foreground/70 shrink-0 ml-auto tabular-nums"
+            >
+              {{ line.distanceM }} m
+            </span>
+          </component>
+        </li>
+      </ul>
     </div>
   </section>
 </template>

--- a/web/src/lib/transit-departures.ts
+++ b/web/src/lib/transit-departures.ts
@@ -1,7 +1,7 @@
 import type dayjs from 'dayjs'
 import type { TransitDeparture } from '@/types/place.types'
 import { orderBullets } from './transit-bullets'
-import { getMinutesUntil } from '@/lib/transit'
+import { getMinutesUntil, formatDepartureTime } from '@/lib/transit'
 
 /**
  * Grouping a stop's departure board into route → direction → next few runs.
@@ -226,4 +226,29 @@ export function groupDepartures(
       }
     }),
   }))
+}
+
+/** Past this many minutes a countdown stops being useful and the clock time
+ *  is what a rider wants. */
+export const COUNTDOWN_MAX_MINUTES = 120
+
+/**
+ * How long until a run leaves, phrased the way a rider reads it.
+ *
+ * A countdown is only useful while it is short. Past an hour or so the clock
+ * time is what is wanted, and past today the day as well — "6:00 AM" alone
+ * reads as this morning when the tramway has been shut since 2am.
+ */
+export function formatCountdown(dep: BoardDeparture, now: Date | dayjs.Dayjs): string {
+  const mins = getMinutesUntil(dep, now)
+  if (mins === null) return ''
+  if (dep.dayLabel) return `${dep.dayLabel} ${formatDepartureTime(dep)}`
+  if (mins <= 0) return 'Now'
+  if (mins < 60) return `${mins} min`
+  if (mins < COUNTDOWN_MAX_MINUTES) {
+    const h = Math.floor(mins / 60)
+    const m = mins % 60
+    return m > 0 ? `${h}h ${m}m` : `${h}h`
+  }
+  return formatDepartureTime(dep)
 }

--- a/web/src/services/layers/features/portolan/portolan-stops.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-stops.test.ts
@@ -1,0 +1,46 @@
+/**
+ * Which OSM object a GTFS stop is.
+ *
+ * The reason this index exists at all: a name cannot tell three stations
+ * called "Chambers St" apart, and distance is worse — the nearest mapped node
+ * to the J/Z platform belongs to Brooklyn Bridge–City Hall, across the
+ * passageway. Only portolan's own join is exact.
+ */
+import { describe, test, expect, beforeEach } from 'vitest'
+import { osmForStop, resetPortolanStops, setPortolanStopIndex } from './portolan-stops'
+import { resetPortolanBullets } from './portolan-bullets'
+
+const NYC = { feed: 'nyc-subway', bounds: [-74.3, 40.5, -73.6, 40.95], maxzoom: 16 }
+
+describe('osmForStop', () => {
+  beforeEach(() => {
+    resetPortolanStops()
+    resetPortolanBullets([NYC])
+    setPortolanStopIndex('nyc-subway', {
+      'f-dr5r-nyctsubway:M21': 'node/2052618392',
+      'f-dr5r-nyctsubway:A36': 'node/7218038804',
+      'f-dr5r-nyctsubway:640': 'node/8410411844',
+    })
+  })
+
+  test('tells two stations of the same name apart', () => {
+    // Both are "Chambers St"; only the stop id separates them.
+    expect(osmForStop('f-dr5r-nyctsubway', 'M21', 40.7132, -74.0034)).toBe('node/2052618392')
+    expect(osmForStop('f-dr5r-nyctsubway', 'A36', 40.7141, -74.0086)).toBe('node/7218038804')
+  })
+
+  test('is null for a stop the pyramid never matched', () => {
+    expect(osmForStop('f-rioc~nyc', '2437315', 40.76, -73.95)).toBeNull()
+  })
+
+  test('is null without both halves of the key', () => {
+    expect(osmForStop(undefined, 'M21', 40.71, -74)).toBeNull()
+    expect(osmForStop('f-dr5r-nyctsubway', undefined, 40.71, -74)).toBeNull()
+  })
+
+  test('a feed with no published index resolves nothing rather than throwing', () => {
+    setPortolanStopIndex('nyc-subway', null)
+
+    expect(osmForStop('f-dr5r-nyctsubway', 'M21', 40.7132, -74.0034)).toBeNull()
+  })
+})

--- a/web/src/services/layers/features/portolan/portolan-stops.ts
+++ b/web/src/services/layers/features/portolan/portolan-stops.ts
@@ -1,0 +1,96 @@
+/**
+ * Which OSM object a GTFS stop is.
+ *
+ * Portolan matches every drawn station to the OSM object that is really the
+ * same place — one-to-one on name, mode class and distance — and publishes the
+ * result as `<feed>/stops.json`, keyed by the `<feed-onestop>:<stop_id>` pair
+ * its tiles already carry.
+ *
+ * Nothing else can answer this. A name cannot: New York has three stations
+ * called "Chambers St", and searching from the J/Z platform opened the A/C/E
+ * one 428 m away. Distance cannot either, and fails more quietly — the nearest
+ * mapped node to that platform is Brooklyn Bridge–City Hall, 33 m through the
+ * passageway. Only the join portolan already computed is exact.
+ *
+ * Same shape as the bullet index beside it: fetched once per feed per session,
+ * degrading to null everywhere — no barrelman, no pyramid, a feed built before
+ * the index existed. A miss means the caller falls back to whatever it did
+ * before, which is a worse link rather than none.
+ */
+import { reactive } from 'vue'
+import { api } from '@/lib/api'
+import { feedsAt } from './portolan-bullets'
+
+/** `<feed-onestop>:<stop_id>` → `"node/123"`. */
+type StopIndex = Record<string, string>
+
+const proxyBase = () => `${api.defaults.baseURL}/proxy/portolan`
+
+/** Loaded stop indexes, per feed. `null` marks a feed that publishes none. */
+const indexes = reactive<Record<string, StopIndex | null>>({})
+const pending = new Map<string, Promise<void>>()
+/** Bumped when a fetch lands, so a consumer computed re-runs. */
+const state = reactive({ generation: 0 })
+
+function ensureIndex(feed: string): Promise<void> {
+  const inFlight = pending.get(feed)
+  if (inFlight) return inFlight
+  if (feed in indexes) return Promise.resolve()
+  const p = fetch(`${proxyBase()}/${encodeURIComponent(feed)}/stops.json`)
+    .then(r => (r.ok ? r.json() : null))
+    .catch(() => null)
+    .then(idx => {
+      indexes[feed] = idx && typeof idx === 'object' ? (idx as StopIndex) : null
+      pending.delete(feed)
+      state.generation++
+    })
+  pending.set(feed, p)
+  return p
+}
+
+/**
+ * Load what is needed to resolve stops near a point. Safe to call on every
+ * render: one fetch per feed per session.
+ */
+export async function ensureStopIndexAt(lat?: number, lng?: number): Promise<void> {
+  if (lat === undefined || lng === undefined) return
+  await Promise.all(feedsAt(lat, lng).map(ensureIndex))
+}
+
+/**
+ * The OSM object a stop is, as `"node/123"`, or null.
+ *
+ * `feedOnestopId` comes from Barrelman, whose own feed ids are local to its
+ * database; the onestop id is the identity the stop has outside it, and what
+ * portolan keyed by.
+ */
+export function osmForStop(
+  feedOnestopId?: string,
+  stopId?: string,
+  lat?: number,
+  lng?: number,
+): string | null {
+  // touch the generation so Vue re-evaluates when a fetch lands
+  void state.generation
+  if (!feedOnestopId || !stopId) return null
+  const key = `${feedOnestopId}:${stopId}`
+  const feeds = lat !== undefined && lng !== undefined ? feedsAt(lat, lng) : Object.keys(indexes)
+  for (const feed of feeds) {
+    const hit = indexes[feed]?.[key]
+    if (hit) return hit
+  }
+  return null
+}
+
+/** Test seam: forget everything fetched. */
+export function resetPortolanStops(): void {
+  for (const k of Object.keys(indexes)) delete indexes[k]
+  pending.clear()
+  state.generation++
+}
+
+/** Test seam: install one feed's index without a fetch. */
+export function setPortolanStopIndex(feed: string, idx: StopIndex | null): void {
+  indexes[feed] = idx
+  state.generation++
+}


### PR DESCRIPTION
Tapping the **Chambers St** transfer from Brooklyn Bridge–City Hall opened the
**A/C/E** Chambers St, 428 m away.

The client had only a name and a point, and neither identifies a station. A name
search ranks by importance, not distance, and three NYC stations are called
"Chambers St". Proximity is worse, and fails more quietly: the nearest mapped
node to the J/Z platform is Brooklyn Bridge–City Hall, 33 m through the
passageway.

Portolan already computes the exact join — `osmstops.go` pairs each drawn
station with the OSM object that is really the same place — and now publishes it
as `<feed>/stops.json` (alexwohlbruck/portolan#29). This reads it, the same way
`portolan-bullets` already reads `routes.json` through the same proxy: one fetch
per feed per session, degrading to null everywhere.

The key is `<feed-onestop>:<stop_id>`. Barrelman's feed ids are local to its own
database, so it now reports the onestop id alongside
(alexwohlbruck/barrelman#107) — that is the bridge between the two.

## Also here

This branch carries four commits that were pushed to #445 after it had already
been merged, so they never reached `dev`:

* transfer departure times, kept on their own board
* a named, linked block per connecting station, stations of one name merged
* `complex=1` on a station link, so it opens the interchange
* name-and-point lookups answered with the enriched place — that route returned
  no widget descriptors at all, so a station reached by name showed an address
  and a phone number where the same node by id showed its whole board

## Degrading

`stops.json` appears on the next pyramid build. Until then the lookup misses and
the link falls back to name and point, which is today's behaviour: right
wherever a station name is unambiguous, wrong at Chambers St. No worse than now,
and exact the moment the index lands.

`bun run test` — 2145 pass. `vue-tsc` clean.