### PR TITLE
Compact routing popup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* The routing settings popup no longer overflows off screen — when its options are taller than the window, it caps at the visible height and scrolls inside.
+
 ## [0.9.0] - 2026-09-03
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* The routing settings popup is more compact, and the routing engine picker only appears when there is more than one engine to choose from.
+
 ### Fixed
 
 * The routing settings popup no longer overflows off screen — when its options are taller than the window, it caps at the visible height and scrolls inside.

--- a/web/src/components/responsive/ResponsivePopover.vue
+++ b/web/src/components/responsive/ResponsivePopover.vue
@@ -6,6 +6,7 @@ import {
   type ResponsiveOverlayPositionProps,
 } from '@/composables/useResponsiveOverlay'
 import BottomSheet from '@/components/BottomSheet.vue'
+import { cn } from '@/lib/utils'
 import {
   Popover,
   PopoverContent,
@@ -120,7 +121,12 @@ watch(
       :align="props.align"
       :side="props.side"
       :side-offset="props.sideOffset"
-      :class="props.desktopContentClass"
+      :class="
+        cn(
+          'max-h-[var(--reka-popover-content-available-height)] overflow-y-auto',
+          props.desktopContentClass,
+        )
+      "
     >
       <slot name="content" :close="() => handleDesktopOpenChange(false)" />
     </PopoverContent>

--- a/web/src/views/directions/RoutingPreferences.vue
+++ b/web/src/views/directions/RoutingPreferences.vue
@@ -341,11 +341,13 @@ const customModelError = computed(() => {
 <template>
   <div class="w-full">
     <!-- General Section -->
-    <div class="p-4 space-y-3">
+    <div class="px-4 py-3 space-y-3">
       <h2 class="font-semibold">{{ t('directions.preferences.general') }}</h2>
 
+      <!-- With a single engine there is nothing to choose; it's still applied
+           as the default in onMounted. -->
       <div
-        v-if="routingEngines.length > 0"
+        v-if="routingEngines.length > 1"
         class="flex items-center justify-between"
       >
         <Label for="routing-engine-global" class="text-sm font-normal">{{
@@ -374,7 +376,7 @@ const customModelError = computed(() => {
         </Select>
       </div>
 
-      <div class="space-y-3 pt-3">
+      <div class="space-y-3">
         <div class="flex items-center justify-between">
           <Label for="use-known-vehicle-locations" class="text-sm font-normal">
             {{ t('directions.preferences.useKnownVehicleLocations') }}
@@ -402,7 +404,7 @@ const customModelError = computed(() => {
     <Separator />
 
     <!-- Mode Title -->
-    <div class="p-4">
+    <div class="px-4 pt-3 pb-2">
       <h2 class="font-semibold">{{ currentModeName }}</h2>
     </div>
 
@@ -430,7 +432,7 @@ const customModelError = computed(() => {
       </TabsList>
 
       <!-- ═══════════════════ Walking ═══════════════════ -->
-      <TabsContent value="walking" class="py-4 px-2 space-y-5 mt-0">
+      <TabsContent value="walking" class="py-3 px-2 space-y-4 mt-0">
         <!-- Hills -->
         <PreferenceRow
           pref="hills"
@@ -467,7 +469,7 @@ const customModelError = computed(() => {
       </TabsContent>
 
       <!-- ═══════════════════ Cycling ═══════════════════ -->
-      <TabsContent value="biking" class="py-4 px-2 space-y-5 mt-0">
+      <TabsContent value="biking" class="py-3 px-2 space-y-4 mt-0">
         <!-- Bicycle Type -->
         <div
           v-if="isSupported('bicycleType')"
@@ -531,7 +533,7 @@ const customModelError = computed(() => {
       </TabsContent>
 
       <!-- ═══════════════════ Transit ═══════════════════ -->
-      <TabsContent value="transit" class="py-4 px-2 space-y-5 mt-0">
+      <TabsContent value="transit" class="py-3 px-2 space-y-4 mt-0">
         <div v-if="isSupported('maxWalkDistance')" class="space-y-2">
           <div class="flex items-center justify-between">
             <Label class="text-sm font-normal">Max walking distance</Label>
@@ -548,7 +550,10 @@ const customModelError = computed(() => {
           />
         </div>
 
-        <div v-if="isSupported('maxTransfers')" class="space-y-3">
+        <div
+          v-if="isSupported('maxTransfers')"
+          class="flex items-center justify-between"
+        >
           <Label for="max-transfers" class="text-sm font-normal"
             >Max transfers</Label
           >
@@ -559,6 +564,7 @@ const customModelError = computed(() => {
             min="0"
             max="10"
             step="1"
+            class="h-8 w-20 text-xs"
             @update:model-value="
               val => updatePreference('maxTransfers', Number(val))
             "
@@ -592,7 +598,7 @@ const customModelError = computed(() => {
       </TabsContent>
 
       <!-- ═══════════════════ Driving ═══════════════════ -->
-      <TabsContent value="driving" class="py-4 px-2 space-y-5 mt-0">
+      <TabsContent value="driving" class="py-3 px-2 space-y-4 mt-0">
         <!-- Highways -->
         <PreferenceRow
           pref="highways"
@@ -618,7 +624,7 @@ const customModelError = computed(() => {
       </TabsContent>
 
       <!-- ═══════════════════ Wheelchair ═══════════════════ -->
-      <TabsContent value="wheelchair" class="py-4 px-2 space-y-5 mt-0">
+      <TabsContent value="wheelchair" class="py-3 px-2 space-y-4 mt-0">
         <!-- Hills -->
         <PreferenceRow
           pref="hills"


### PR DESCRIPTION
## Problem

Opening the routing settings popover on directions with a short window pushed most of its content — Transit Options, Advanced, Done — off the bottom of the screen with no way to reach it. The layout was also looser than it needed to be.

## Changes

**Scroll instead of overflow** — the desktop popover in `ResponsivePopover.vue` had no height constraint. It now caps at reka-ui's `--reka-popover-content-available-height` (the space between the trigger and the viewport edge) and scrolls internally. Applies to every popover built on `ResponsivePopover`; the mobile bottom-sheet path already handles its own scrolling and is untouched.

**Compact layout** — the routing engine picker is hidden when only one engine is configured (it's still applied silently as the default); section padding and row spacing are tightened throughout; and Max transfers is a label + narrow input row instead of a full-width field.

## Verification

Checked live in a 1100×660 window: the popover caps at exactly the available height and scrolls cleanly to the Advanced section and Done button, which were unreachable before. With the engine list reduced to one, the Routing Engine row disappears and General Options leads straight into the toggles; content height dropped from 559px to 477px.