### PR TITLE
Trim unsupported directions modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Removed the wheelchair travel mode from directions. Accessible routing stays available as the "Wheelchair accessible" preference under Walking and Transit, which avoids stairs and prefers accessible stops and entrances.
+
 ### Fixed
 
 ## [0.9.0] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 * Removed the wheelchair travel mode from directions. Accessible routing stays available as the "Wheelchair accessible" preference under Walking and Transit, which avoids stairs and prefers accessible stops and entrances.
+* Hid the rideshare travel mode until there is a working rideshare integration behind it.
 
 ### Fixed
 

--- a/docs/trip-planner-review.md
+++ b/docs/trip-planner-review.md
@@ -7,9 +7,12 @@
 > the rideshare `isAvailable()` typo (C1) is fixed and rideshare+transit variants are
 > now derived from intermodal results; vehicle-access queries gained origin→vehicle
 > walk legs, `useKnownVehicleLocations`/`maxWalkingDistance` handling, and
-> `parkedVehicles` tracking. Line numbers and the two-path architecture described
-> below no longer match the code — read this for the *why* behind the consolidation,
-> not as a map of the current source.
+> `parkedVehicles` tracking; and the wheelchair travel mode was **removed** —
+> `planWheelchairSegment` and the `wheelchair` mode/profile no longer exist (the
+> `wheelchairAccessible` routing preference for walking and transit remains).
+> Line numbers and the two-path architecture described below no longer match the
+> code — read this for the *why* behind the consolidation, not as a map of the
+> current source.
 
 A code-grounded walkthrough of the multimodal trip planner, end to end, followed by a
 critical review. Every claim below is traced to a specific file and line.

--- a/server/docs/trip-planner.md
+++ b/server/docs/trip-planner.md
@@ -4,8 +4,8 @@ Technical reference for the multimodal trip planning system.
 
 ## Overview
 
-The trip planner composes routes across walking, cycling, driving, wheelchair,
-and transit modes. Transit routing uses MOTIS (a C++ RAPTOR engine) for
+The trip planner composes routes across walking, cycling, driving, and transit
+modes. Transit routing uses MOTIS (a C++ RAPTOR engine) for
 stop-to-stop itineraries while all street routing stays in GraphHopper. The
 Parchment server orchestrates access-leg + transit-core + egress-leg composition
 so MOTIS never needs an OSM graph.
@@ -41,7 +41,7 @@ MultimodalTripResponse  (ranked TripCandidate[])
 | Field | Type | Description |
 |-------|------|-------------|
 | `waypoints` | `Waypoint[]` | Min 2. Each has `location`, optional `departAfter`, `arriveBy`, `dwellTime` |
-| `selectedMode` | `SelectedMode` | `multi`, `walking`, `driving`, `biking`, `transit`, `wheelchair` |
+| `selectedMode` | `SelectedMode` | `multi`, `walking`, `driving`, `biking`, `transit` |
 | `sortPreference` | `SortPreference?` | `fastest`, `cheapest`, `fewest_transfers`, `least_walking`, `greenest` |
 | `routingPreferences` | `RoutingPreferences?` | Per-mode tuning (hills, tolls, maxWalkingDistance, etc.) |
 | `availableVehicles` | `Vehicle[]?` | Known vehicle locations for walk-to-vehicle trips |
@@ -58,7 +58,6 @@ MultimodalTripResponse  (ranked TripCandidate[])
 | `walking` | `walking` |
 | `driving` | `walking`, `driving` |
 | `biking` | `walking`, `biking` |
-| `wheelchair` | `wheelchair` |
 | (default) | `walking`, `driving`, `biking` |
 
 ### 3. Transit Composition
@@ -316,7 +315,6 @@ V = vehicle location    S = transit stop
 | 1.1 | O →[W]→ X | Walk |
 | 1.2 | O →[B]→ X | Cycle |
 | 1.3 | O →[D]→ X | Drive |
-| 1.4 | O →[Wc]→ X | Wheelchair |
 
 ### Vehicle-access trips
 

--- a/server/openapi.json
+++ b/server/openapi.json
@@ -1267,10 +1267,6 @@
                         "type": "string"
                       },
                       {
-                        "const": "wheelchair",
-                        "type": "string"
-                      },
-                      {
                         "const": "rideshare",
                         "type": "string"
                       }
@@ -1445,10 +1441,6 @@
                             },
                             {
                               "const": "e-scooter",
-                              "type": "string"
-                            },
-                            {
-                              "const": "wheelchair",
                               "type": "string"
                             },
                             {
@@ -1648,10 +1640,6 @@
                         "type": "string"
                       },
                       {
-                        "const": "wheelchair",
-                        "type": "string"
-                      },
-                      {
                         "const": "rideshare",
                         "type": "string"
                       }
@@ -1826,10 +1814,6 @@
                             },
                             {
                               "const": "e-scooter",
-                              "type": "string"
-                            },
-                            {
-                              "const": "wheelchair",
                               "type": "string"
                             },
                             {
@@ -2029,10 +2013,6 @@
                         "type": "string"
                       },
                       {
-                        "const": "wheelchair",
-                        "type": "string"
-                      },
-                      {
                         "const": "rideshare",
                         "type": "string"
                       }
@@ -2207,10 +2187,6 @@
                             },
                             {
                               "const": "e-scooter",
-                              "type": "string"
-                            },
-                            {
-                              "const": "wheelchair",
                               "type": "string"
                             },
                             {
@@ -2442,10 +2418,6 @@
                         "type": "string"
                       },
                       {
-                        "const": "wheelchair",
-                        "type": "string"
-                      },
-                      {
                         "const": "rideshare",
                         "type": "string"
                       }
@@ -2620,10 +2592,6 @@
                             },
                             {
                               "const": "e-scooter",
-                              "type": "string"
-                            },
-                            {
-                              "const": "wheelchair",
                               "type": "string"
                             },
                             {
@@ -2823,10 +2791,6 @@
                         "type": "string"
                       },
                       {
-                        "const": "wheelchair",
-                        "type": "string"
-                      },
-                      {
                         "const": "rideshare",
                         "type": "string"
                       }
@@ -3001,10 +2965,6 @@
                             },
                             {
                               "const": "e-scooter",
-                              "type": "string"
-                            },
-                            {
-                              "const": "wheelchair",
                               "type": "string"
                             },
                             {
@@ -3204,10 +3164,6 @@
                         "type": "string"
                       },
                       {
-                        "const": "wheelchair",
-                        "type": "string"
-                      },
-                      {
                         "const": "rideshare",
                         "type": "string"
                       }
@@ -3382,10 +3338,6 @@
                             },
                             {
                               "const": "e-scooter",
-                              "type": "string"
-                            },
-                            {
-                              "const": "wheelchair",
                               "type": "string"
                             },
                             {
@@ -12520,6 +12472,150 @@
           "Subscriptions"
         ],
         "summary": "Get billing configuration and product info",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/subscriptions/webhook": {
+      "post": {
+        "operationId": "postSubscriptionsWebhook",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Handle Polar webhook events",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/subscriptions/checkout": {
+      "post": {
+        "parameters": [],
+        "operationId": "postSubscriptionsCheckout",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Create a Polar checkout session for subscription upgrade",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tier": {
+                    "anyOf": [
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "premium",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "successUrl": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "multipart/form-data": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tier": {
+                    "anyOf": [
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "premium",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "successUrl": {
+                    "type": "string"
+                  }
+                }
+              }
+            },
+            "text/plain": {
+              "schema": {
+                "type": "object",
+                "properties": {
+                  "tier": {
+                    "anyOf": [
+                      {
+                        "const": "basic",
+                        "type": "string"
+                      },
+                      {
+                        "const": "premium",
+                        "type": "string"
+                      }
+                    ]
+                  },
+                  "successUrl": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/subscriptions/portal": {
+      "get": {
+        "operationId": "getSubscriptionsPortal",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Get Polar customer portal URL",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/subscriptions/status": {
+      "get": {
+        "operationId": "getSubscriptionsStatus",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Get current subscription status",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/subscriptions/details": {
+      "get": {
+        "operationId": "getSubscriptionsDetails",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Get rich subscription details from Polar",
+        "responses": {
+          "200": {}
+        }
+      }
+    },
+    "/subscriptions/verify": {
+      "post": {
+        "operationId": "postSubscriptionsVerify",
+        "tags": [
+          "Subscriptions"
+        ],
+        "summary": "Verify subscription status directly with Polar",
         "responses": {
           "200": {}
         }

--- a/server/src/controllers/directions.controller.test.ts
+++ b/server/src/controllers/directions.controller.test.ts
@@ -271,7 +271,7 @@ describe('GET /directions/vehicle-types and /status', () => {
     expect(res.status).toBe(200)
     const types = res.body.vehicleTypes.map((v: any) => v.type)
     expect(types).toContain('car')
-    expect(types).toContain('wheelchair')
+    expect(types).toContain('truck')
   })
 
   test('declares energy types per vehicle', async () => {

--- a/server/src/controllers/directions.controller.ts
+++ b/server/src/controllers/directions.controller.ts
@@ -44,7 +44,6 @@ const VehicleSchema = t.Object({
     t.Literal('scooter'),
     t.Literal('e-bike'),
     t.Literal('e-scooter'),
-    t.Literal('wheelchair'),
     t.Literal('moped'),
     t.Literal('truck'),
   ]),
@@ -118,7 +117,6 @@ const SelectedModeSchema = t.Union([
   t.Literal('driving'),
   t.Literal('biking'),
   t.Literal('transit'),
-  t.Literal('wheelchair'),
   t.Literal('rideshare'),
 ] as const)
 
@@ -264,12 +262,6 @@ app.get(
           type: 'e-scooter',
           name: 'Electric Scooter',
           description: 'Electric scooter',
-          supportedEnergyTypes: ['electric'],
-        },
-        {
-          type: 'wheelchair',
-          name: 'Wheelchair',
-          description: 'Mobility device',
           supportedEnergyTypes: ['electric'],
         },
         {
@@ -424,7 +416,6 @@ app.get(
           'biking',
           'transit',
           'rideshare',
-          'wheelchair',
           'paratransit',
           'mixed',
         ],
@@ -434,7 +425,6 @@ app.get(
           'scooter',
           'e-bike',
           'e-scooter',
-          'wheelchair',
           'moped',
           'truck',
         ],

--- a/server/src/lib/graphhopper-custom-model.ts
+++ b/server/src/lib/graphhopper-custom-model.ts
@@ -61,7 +61,6 @@ export function getSnapPreventions(mode: TravelMode): string[] | undefined {
     case TravelMode.CYCLING:
       return ['motorway', 'trunk', 'ferry', 'tunnel', 'bridge']
     case TravelMode.WALKING:
-    case TravelMode.WHEELCHAIR:
       return ['motorway', 'trunk', 'ferry', 'tunnel', 'bridge', 'ford']
     default:
       return undefined
@@ -79,7 +78,7 @@ export function getSnapPreventions(mode: TravelMode): string[] | undefined {
  * caller should omit `custom_model` entirely and let GraphHopper use the
  * profile's built-in defaults.
  *
- * @param mode   The travel mode (DRIVING, CYCLING, WALKING, WHEELCHAIR, etc.)
+ * @param mode   The travel mode (DRIVING, CYCLING, WALKING, etc.)
  * @param prefs  The routing preferences from the user
  */
 // A custom model is a pure function of (mode, prefs), and every consumer only
@@ -392,37 +391,6 @@ function computeGraphHopperCustomModel(
         speed.push({ if: 'true', multiply_by: factor })
       }
     }
-  }
-
-  // ── Wheelchair preferences ────────────────────────────────────
-  if (mode === TravelMode.WHEELCHAIR) {
-    priority.push({ if: 'road_class == STEPS', multiply_by: 0 })
-    priority.push({
-      if: 'average_slope >= 10 || average_slope <= -10',
-      multiply_by: 0.01,
-    })
-    priority.push({
-      if: 'average_slope >= 6 || average_slope <= -6',
-      multiply_by: 0.2,
-    })
-    speed.push({
-      if: 'average_slope >= 4 || average_slope <= -4',
-      multiply_by: 0.6,
-    })
-    priority.push({
-      if: 'surface == GRAVEL || surface == DIRT || surface == SAND',
-      multiply_by: 0.1,
-    })
-    priority.push({
-      if: 'smoothness == BAD || smoothness == VERY_BAD || smoothness == HORRIBLE',
-      multiply_by: 0.05,
-    })
-    priority.push({
-      if: 'track_type == GRADE3 || track_type == GRADE4 || track_type == GRADE5',
-      multiply_by: 0.05,
-    })
-    priority.push({ if: 'road_class == TRACK', multiply_by: 0.15 })
-    speed.push({ if: 'true', limit_to: prefs.walkingSpeed || 4 })
   }
 
   // ── Assemble ──────────────────────────────────────────────────

--- a/server/src/lib/vehicle-mode-mapping.ts
+++ b/server/src/lib/vehicle-mode-mapping.ts
@@ -12,7 +12,6 @@ export const VEHICLE_ROUTING_MODE: Record<VehicleType, 'driving' | 'biking'> = {
   'e-bike': 'biking',
   scooter: 'biking',
   'e-scooter': 'biking',
-  wheelchair: 'driving', // Uses road routing
 }
 
 /**

--- a/server/src/services/integrations/adapters/dawarich-adapter.ts
+++ b/server/src/services/integrations/adapters/dawarich-adapter.ts
@@ -435,8 +435,6 @@ export class DawarichAdapter {
         return TravelMode.MOTORCYCLE
       case 'truck':
         return TravelMode.TRUCK
-      case 'wheelchair':
-        return TravelMode.WHEELCHAIR
       case 'driving':
       case 'automotive':
       case 'car':

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -289,7 +289,7 @@ export class BarrelmanIntegration
           // Boolean preferences
           shortest: 'boolean',
           preferHOV: false,             // GH has no HOV data
-          wheelchairAccessible: false,  // Use dedicated wheelchair mode instead
+          wheelchairAccessible: false,  // No accessibility routing data
 
           // Numeric/enum preferences
           cyclingSpeed: 'range',
@@ -300,7 +300,7 @@ export class BarrelmanIntegration
           maxWalkDistance: 'range',
           maxTransfers: 'range',
         },
-        supportedModes: ['driving', 'walking', 'cycling', 'motorcycle', 'truck', 'wheelchair'],
+        supportedModes: ['driving', 'walking', 'cycling', 'motorcycle', 'truck'],
         supportedOptimizations: ['time', 'distance'],
         features: {
           alternatives: true,
@@ -1147,8 +1147,6 @@ export class BarrelmanIntegration
         return 'car' // GraphHopper doesn't have a separate motorcycle profile
       case TravelMode.TRUCK:
         return 'car' // Use car with custom_model constraints for truck
-      case TravelMode.WHEELCHAIR:
-        return 'foot' // Use foot profile with custom_model to avoid stairs, curbs, etc.
       default:
         throw new Error(`Unsupported travel mode: ${mode}`)
     }

--- a/server/src/services/integrations/graphhopper-integration.test.ts
+++ b/server/src/services/integrations/graphhopper-integration.test.ts
@@ -151,7 +151,6 @@ describe('routing metadata', () => {
       'cycling',
       'motorcycle',
       'truck',
-      'wheelchair',
     ])
   })
 
@@ -295,7 +294,6 @@ describe('request assembly', () => {
       [TravelMode.WALKING, 'foot'],
       [TravelMode.MOTORCYCLE, 'motorcycle'],
       [TravelMode.TRUCK, 'truck'],
-      [TravelMode.WHEELCHAIR, 'foot'],
     ] as const) {
       calls = []
       await getRoute(configured())(routeRequest({ mode }) as any)

--- a/server/src/services/integrations/graphhopper-integration.ts
+++ b/server/src/services/integrations/graphhopper-integration.ts
@@ -99,7 +99,6 @@ export class GraphHopperIntegration implements Integration<GraphHopperConfig> {
           'cycling',
           'motorcycle',
           'truck',
-          'wheelchair',
         ],
         supportedOptimizations: ['time', 'distance', 'balanced'], // distance/balanced require paid/self-hosted
         features: {
@@ -365,8 +364,6 @@ export class GraphHopperIntegration implements Integration<GraphHopperConfig> {
         return 'motorcycle'
       case TravelMode.TRUCK:
         return 'truck'
-      case TravelMode.WHEELCHAIR:
-        return 'foot' // Use foot profile with custom_model constraints
       default:
         throw new Error(`Unsupported travel mode for GraphHopper: ${mode}`)
     }

--- a/server/src/services/integrations/valhalla-integration.test.ts
+++ b/server/src/services/integrations/valhalla-integration.test.ts
@@ -163,7 +163,6 @@ describe('routing metadata', () => {
       'cycling',
       'motorcycle',
       'truck',
-      'wheelchair',
     ])
   })
 
@@ -509,7 +508,7 @@ describe('walking costing options', () => {
     )
   })
 
-  test('switches the pedestrian type for wheelchair routing', async () => {
+  test('switches the pedestrian type for accessible routing', async () => {
     expect(await walk({ wheelchairAccessible: true })).toMatchObject({
       type: 'wheelchair',
     })

--- a/server/src/services/integrations/valhalla-integration.ts
+++ b/server/src/services/integrations/valhalla-integration.ts
@@ -71,7 +71,7 @@ export class ValhallaIntegration implements Integration<ValhallaConfig> {
           maxWalkDistance: 'full',
           maxTransfers: false,
         },
-        supportedModes: ['driving', 'walking', 'cycling', 'motorcycle', 'truck', 'wheelchair'],
+        supportedModes: ['driving', 'walking', 'cycling', 'motorcycle', 'truck'],
         supportedOptimizations: ['time', 'distance'],
         features: {
           alternatives: true, // alternates parameter
@@ -439,7 +439,7 @@ export class ValhallaIntegration implements Integration<ValhallaConfig> {
       else if (preferences?.providerOptions?.walkingSpeed)
         pedestrian.walking_speed = preferences.providerOptions.walkingSpeed
 
-      // Wheelchair mode
+      // Accessible pedestrian routing
       if (preferences?.wheelchairAccessible)
         pedestrian.type = 'wheelchair'
 

--- a/server/src/services/routing.service.test.ts
+++ b/server/src/services/routing.service.test.ts
@@ -206,7 +206,6 @@ describe('getRoute — costing to travel mode', () => {
     ['motorcycle', TravelMode.MOTORCYCLE],
     ['truck', TravelMode.TRUCK],
     ['transit', TravelMode.TRANSIT],
-    ['wheelchair', TravelMode.WHEELCHAIR],
   ]
 
   for (const [costing, expected] of cases) {

--- a/server/src/services/routing.service.ts
+++ b/server/src/services/routing.service.ts
@@ -163,8 +163,6 @@ export class RoutingService {
         return TravelMode.TRUCK
       case 'transit':
         return TravelMode.TRANSIT
-      case 'wheelchair':
-        return TravelMode.WHEELCHAIR
       default:
         return TravelMode.DRIVING
     }

--- a/server/src/services/trip.service.test.ts
+++ b/server/src/services/trip.service.test.ts
@@ -2797,64 +2797,6 @@ describe('TripService — segment planners', () => {
     })
   })
 
-  describe('planWheelchairSegment', () => {
-    test('returns segment with mode wheelchair', async () => {
-      mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(500, 480))
-
-      const result = await (tripService as any).planWheelchairSegment(
-        CHARLOTTE_ORIGIN,
-        CHARLOTTE_DEST,
-        baseState,
-        {},
-      )
-      expect(result).not.toBeNull()
-      expect(result.segment.mode).toBe('wheelchair')
-      expect(result.state.currentMode).toBe('wheelchair')
-    })
-
-    test('skips segments under 60s', async () => {
-      mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(20, 30))
-
-      const result = await (tripService as any).planWheelchairSegment(
-        CHARLOTTE_ORIGIN,
-        CHARLOTTE_DEST,
-        baseState,
-        {},
-      )
-      expect(result).toBeNull()
-    })
-
-    test('returns null on routing error', async () => {
-      mockGetRoute.mockImplementation(async () => {
-        throw new Error('GraphHopper error')
-      })
-
-      const result = await (tripService as any).planWheelchairSegment(
-        CHARLOTTE_ORIGIN,
-        CHARLOTTE_DEST,
-        baseState,
-        {},
-      )
-      expect(result).toBeNull()
-    })
-
-    test('passes wheelchair profile to routing service', async () => {
-      mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(500, 480))
-
-      await (tripService as any).planWheelchairSegment(
-        CHARLOTTE_ORIGIN,
-        CHARLOTTE_DEST,
-        baseState,
-        {},
-      )
-      expect(mockGetRoute).toHaveBeenCalledWith(
-        expect.any(Array),
-        'wheelchair',
-        expect.anything(),
-      )
-    })
-  })
-
   describe('planDirectBike', () => {
     test('returns biking segment with co2: 0', async () => {
       mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(3000, 900))
@@ -3153,26 +3095,6 @@ describe('TripService — mode generation edge cases', () => {
     expect(modes).toContain('walking')
     expect(modes).not.toContain('biking')
     expect(modes).not.toContain('transit')
-  })
-
-  test('wheelchair mode generates only wheelchair', () => {
-    const modes = (tripService as any).getModesToGenerate('wheelchair')
-    expect(modes).toEqual(['wheelchair'])
-  })
-
-  test('wheelchair planTrip returns wheelchair segment', async () => {
-    mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(500, 480))
-
-    const response = await tripService.planTrip({
-      waypoints: [CHARLOTTE_ORIGIN, CHARLOTTE_DEST],
-      selectedMode: 'wheelchair',
-      preferredDepartureTime: '2026-01-15T08:00:00Z',
-    })
-
-    const wheelchair = response.trips.find((t) =>
-      t.trip.segments.some((s) => s.mode === 'wheelchair'),
-    )
-    expect(wheelchair).toBeDefined()
   })
 })
 

--- a/server/src/services/trip.service.ts
+++ b/server/src/services/trip.service.ts
@@ -49,7 +49,7 @@ export class TripService {
     // When useKnownParkingLocations is on, vehicle modes (driving/biking)
     // are replaced by their parking-aware variants — you can't just teleport
     // to the destination, you need to park first. Non-vehicle modes (walking,
-    // transit, wheelchair) are unaffected.
+    // transit) are unaffected.
     const useParking = request.routingPreferences?.useKnownParkingLocations
     const parkingVehicleModes: Set<Mode> = useParking
       ? new Set(['driving', 'biking'] as Mode[])
@@ -192,8 +192,6 @@ export class TripService {
         return ['walking', 'biking']
       case 'transit':
         return ['transit']
-      case 'wheelchair':
-        return ['wheelchair']
       case 'rideshare':
         return hasRideshare ? ['rideshare'] : []
       default:
@@ -523,8 +521,6 @@ export class TripService {
           availableVehicles,
           preferences,
         )
-      case 'wheelchair':
-        return this.planWheelchairSegment(from, to, state, preferences)
       default:
         // Transit/rideshare are planned at the trip level (planTrip), not per-segment.
         return null
@@ -592,66 +588,6 @@ export class TripService {
       }
     } catch (error) {
       logError('Walking route failed', error)
-      return null
-    }
-  }
-
-  /**
-   * Plan wheelchair segment — uses foot profile with accessibility custom_model
-   */
-  private async planWheelchairSegment(
-    from: Waypoint,
-    to: Waypoint,
-    state: SegmentState,
-    preferences: any,
-  ): Promise<{ segment: TripSegment; state: SegmentState } | null> {
-    try {
-      const route = await routingService.getRoute(
-        [
-          { type: 'coordinates', value: [from.location.lat, from.location.lng] },
-          { type: 'coordinates', value: [to.location.lat, to.location.lng] },
-        ],
-        'wheelchair',
-        preferences,
-      )
-
-      if (!route.routes.length) return null
-
-      const leg = route.routes[0].legs[0]
-      if (leg.duration < 60) return null
-
-      const segment: TripSegment = {
-        segmentIndex: 0,
-        mode: 'wheelchair',
-        start: from,
-        end: to,
-        startTime: state.currentTime,
-        endTime: new Date(
-          new Date(state.currentTime).getTime() + leg.duration * 1000,
-        ).toISOString(),
-        duration: leg.duration,
-        distance: leg.distance,
-        geometry: leg.geometry,
-        instructions: leg.instructions,
-        co2: 0,
-        totalElevationGain: leg.totalElevationGain,
-        totalElevationLoss: leg.totalElevationLoss,
-        maxElevation: leg.maxElevation,
-        minElevation: leg.minElevation,
-        edgeSegments: leg.edgeSegments,
-      }
-
-      return {
-        segment,
-        state: {
-          currentTime: segment.endTime,
-          currentLocation: to.location,
-          currentMode: 'wheelchair',
-          parkedVehicles: state.parkedVehicles,
-        },
-      }
-    } catch (error) {
-      logError('Wheelchair route failed', error)
       return null
     }
   }
@@ -3724,7 +3660,6 @@ export class TripService {
     biking: 0,
     transit: 0.00005, // ~50g/km = 0.05 kg/km
     driving: 0.00024, // ~240g/km = 0.24 kg/km
-    wheelchair: 0,
   }
 
   /** Fuel cost per meter for driving (based on ~$3.50/gal, ~25 MPG → ~$0.087/km) */
@@ -3966,7 +3901,6 @@ export class TripService {
     walking: 0.7,
     biking: 0.5,
     driving: 0.6,
-    wheelchair: 0.6,
     transit: 1.0,
   }
 

--- a/server/src/types/routing-adapters.types.ts
+++ b/server/src/types/routing-adapters.types.ts
@@ -382,7 +382,6 @@ export interface OpenRouteServiceRequest {
     | 'cycling-electric'
     | 'foot-walking'
     | 'foot-hiking'
-    | 'wheelchair'
   preference?: 'fastest' | 'shortest' | 'recommended'
   format?: 'json' | 'geojson' | 'gpx'
   units?: 'km' | 'mi' | 'm'

--- a/server/src/types/trip.types.ts
+++ b/server/src/types/trip.types.ts
@@ -15,7 +15,6 @@ export type VehicleType =
   | 'scooter'
   | 'e-bike'
   | 'e-scooter'
-  | 'wheelchair'
   | 'moped'
   | 'truck'
 
@@ -25,7 +24,6 @@ export type Mode =
   | 'biking'
   | 'transit'
   | 'rideshare'
-  | 'wheelchair'
   | 'paratransit'
   | 'mixed'
 
@@ -36,7 +34,6 @@ export type SelectedMode =
   | 'driving'
   | 'biking'
   | 'transit'
-  | 'wheelchair'
   | 'rideshare'
 
 export type WaypointType = 'origin' | 'destination' | 'via'

--- a/server/src/types/unified-routing.types.ts
+++ b/server/src/types/unified-routing.types.ts
@@ -15,7 +15,6 @@ export enum TravelMode {
   TRANSIT = 'transit',
   MOTORCYCLE = 'motorcycle',
   TRUCK = 'truck',
-  WHEELCHAIR = 'wheelchair',
 }
 
 // Waypoint types for different use cases

--- a/web/src/components/directions/timeline/SegmentDetails.vue
+++ b/web/src/components/directions/timeline/SegmentDetails.vue
@@ -57,9 +57,7 @@ function showSegmentChart(segment: any): boolean {
     (segment.totalElevationGain ||
       segment.totalElevationLoss ||
       segment.edgeSegments?.length) &&
-    (segment.mode === 'walking' ||
-      segment.mode === 'cycling' ||
-      segment.mode === 'wheelchair')
+    (segment.mode === 'walking' || segment.mode === 'cycling')
   )
 }
 

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -717,7 +717,6 @@
       "walking": "Walking",
       "cycling": "Cycling",
       "driving": "Driving",
-      "wheelchair": "Wheelchair",
       "rideshare": "Rideshare",
       "transit": "Transit",
       "transitWalking": "Transit & Walking",
@@ -742,7 +741,6 @@
       "cycling": "Cycling",
       "transit": "Transit",
       "driving": "Driving",
-      "wheelchair": "Wheelchair",
       "rideshare": "Rideshare"
     },
     "preferences": {
@@ -751,7 +749,6 @@
       "cycling": "Cycling Options",
       "transit": "Transit Options",
       "driving": "Driving Options",
-      "wheelchair": "Wheelchair Options",
       "routingEngine": "Routing Engine",
       "useKnownVehicleLocations": "Use known vehicle locations",
       "useKnownParkingLocations": "Use known parking locations"
@@ -1918,8 +1915,7 @@
         "bike": "Bike",
         "e-bike": "E-bike",
         "scooter": "Scooter",
-        "e-scooter": "E-scooter",
-        "wheelchair": "Wheelchair"
+        "e-scooter": "E-scooter"
       },
       "energyTypes": {
         "gas": "Gas",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -698,7 +698,6 @@
       "walking": "A pie",
       "cycling": "Bicicleta",
       "driving": "Coche",
-      "wheelchair": "Silla de ruedas",
       "rideshare": "VTC",
       "transit": "Transporte público",
       "transitWalking": "Transporte y a pie",
@@ -1831,8 +1830,7 @@
         "bike": "Bicicleta",
         "e-bike": "Bicicleta eléctrica",
         "scooter": "Patinete",
-        "e-scooter": "Patinete eléctrico",
-        "wheelchair": "Silla de ruedas"
+        "e-scooter": "Patinete eléctrico"
       },
       "energyTypes": {
         "gas": "Gasolina",

--- a/web/src/lib/route-profile-colors.ts
+++ b/web/src/lib/route-profile-colors.ts
@@ -36,8 +36,8 @@ export interface ProfileTabDef {
  */
 export const PROFILE_TABS: ProfileTabDef[] = [
   { id: 'stress',  label: 'Bike friendly', modes: ['cycling'] as TravelMode[] },
-  { id: 'surface', label: 'Surface',       modes: ['cycling', 'walking', 'driving', 'wheelchair'] as TravelMode[] },
-  { id: 'incline', label: 'Incline',       modes: ['cycling', 'walking', 'wheelchair'] as TravelMode[] },
+  { id: 'surface', label: 'Surface',       modes: ['cycling', 'walking', 'driving'] as TravelMode[] },
+  { id: 'incline', label: 'Incline',       modes: ['cycling', 'walking'] as TravelMode[] },
 ]
 
 // ── Surface categories ──────────────────────────────────────────────

--- a/web/src/lib/travel-mode-icons.ts
+++ b/web/src/lib/travel-mode-icons.ts
@@ -9,7 +9,6 @@ import {
   BikeIcon,
   CarFrontIcon,
   TruckIcon,
-  AccessibilityIcon,
   TrainFrontTunnelIcon,
   type LucideIcon,
 } from 'lucide-vue-next'
@@ -43,7 +42,6 @@ const modeIcons: Record<string, LucideIcon> = {
   transit: TrainFrontIcon,
   motorcycle: CarFrontIcon,
   truck: TruckIcon,
-  wheelchair: AccessibilityIcon,
   rideshare: CarTaxiFrontIcon,
 }
 
@@ -62,7 +60,6 @@ const vehicleTypeIcons: Record<string, LucideIcon> = {
   'e-bike': BikeIcon,
   scooter: BikeIcon,
   'e-scooter': BikeIcon,
-  wheelchair: AccessibilityIcon,
 }
 
 /**

--- a/web/src/lib/trip-signature.ts
+++ b/web/src/lib/trip-signature.ts
@@ -30,8 +30,6 @@ export function tripSignature(segments: SignatureSegment[] | undefined): string 
       tokens.push('drive')
     } else if (seg.mode === 'cycling' || seg.mode === 'biking') {
       tokens.push('bike')
-    } else if (seg.mode === 'wheelchair') {
-      tokens.push('wheel')
     }
     // walking legs are connective tissue — every trip has them
   }

--- a/web/src/lib/vehicle-mode-mapping.ts
+++ b/web/src/lib/vehicle-mode-mapping.ts
@@ -12,7 +12,6 @@ export const VEHICLE_ROUTING_MODE: Record<VehicleType, 'driving' | 'biking'> = {
   'e-bike': 'biking',
   scooter: 'biking',
   'e-scooter': 'biking',
-  wheelchair: 'driving',
 }
 
 /**
@@ -33,7 +32,6 @@ export const VEHICLE_TYPE_LABELS: Record<VehicleType, string> = {
   'e-bike': 'E-bike',
   scooter: 'Scooter',
   'e-scooter': 'E-scooter',
-  wheelchair: 'Wheelchair',
 }
 
 /**
@@ -47,5 +45,4 @@ export const VEHICLE_TYPE_ICONS: Record<VehicleType, string> = {
   'e-bike': 'zap',
   scooter: 'bike',
   'e-scooter': 'zap',
-  wheelchair: 'accessibility',
 }

--- a/web/src/stores/directions.store.test.ts
+++ b/web/src/stores/directions.store.test.ts
@@ -60,11 +60,19 @@ describe('useDirectionsStore', () => {
     })
 
     test('loads mode from localStorage if available', () => {
-      localStorageMock.setItem('selectedMode', 'car')
-      
+      localStorageMock.setItem('selectedMode', 'driving')
+
       const store = useDirectionsStore()
-      
-      expect(store.selectedMode).toBe('car')
+
+      expect(store.selectedMode).toBe('driving')
+    })
+
+    test('falls back to multi when the stored mode is not selectable', () => {
+      localStorageMock.setItem('selectedMode', 'wheelchair')
+
+      const store = useDirectionsStore()
+
+      expect(store.selectedMode).toBe('multi')
     })
 
     test('starts with default routing preferences for biking (default mode)', () => {
@@ -82,9 +90,7 @@ describe('useDirectionsStore', () => {
 
       expect(store.modePreferences.walking.hills).toBe(0.5)
       expect(store.modePreferences.biking.hills).toBe(0.5)
-      expect(store.modePreferences.wheelchair.hills).toBe(0)
       expect(store.modePreferences.biking.surfaceQuality).toBe(0.25)
-      expect(store.modePreferences.wheelchair.surfaceQuality).toBe(0.75)
       expect(store.modePreferences.driving.highways).toBe(0.5)
       expect(store.modePreferences.transit.maxWalkingDistance).toBe(1000)
     })
@@ -96,9 +102,8 @@ describe('useDirectionsStore', () => {
       expect(store.routingPreferences.hills).toBe(0.5)
       expect(store.routingPreferences.ferries).toBe(0.5)
 
-      store.selectedMode = 'wheelchair'
-      expect(store.routingPreferences.hills).toBe(0)
-      expect(store.routingPreferences.surfaceQuality).toBe(0.75)
+      store.selectedMode = 'biking'
+      expect(store.routingPreferences.surfaceQuality).toBe(0.25)
 
       store.selectedMode = 'driving'
       expect(store.routingPreferences.highways).toBe(0.5)

--- a/web/src/stores/directions.store.test.ts
+++ b/web/src/stores/directions.store.test.ts
@@ -75,6 +75,16 @@ describe('useDirectionsStore', () => {
       expect(store.selectedMode).toBe('multi')
     })
 
+    test('falls back to multi when the stored mode is hidden', () => {
+      // Rideshare is hidden while no integration exists, so a previously
+      // selected rideshare must not be restored.
+      localStorageMock.setItem('selectedMode', 'rideshare')
+
+      const store = useDirectionsStore()
+
+      expect(store.selectedMode).toBe('multi')
+    })
+
     test('starts with default routing preferences for biking (default mode)', () => {
       const store = useDirectionsStore()
 

--- a/web/src/stores/directions.store.ts
+++ b/web/src/stores/directions.store.ts
@@ -5,6 +5,22 @@ import { Waypoint } from '@/types/map.types'
 import { RoutingPreferences, SelectedMode, SortPreference } from '@/types/multimodal.types'
 import { getTimezoneWarning, type TimezoneWarning } from '@/lib/timezone.utils'
 
+// Rideshare has no working integration yet, so the mode is hidden everywhere it
+// could be picked. Flip this to true to bring it back.
+export const RIDESHARE_ENABLED = false
+
+// Modes a user can actually select. A stored value outside this list — a mode
+// since removed, or one currently hidden — falls back to 'multi' rather than
+// being sent to the API, which rejects unknown modes.
+export const SELECTABLE_MODES: readonly SelectedMode[] = [
+  'multi',
+  'walking',
+  'driving',
+  'biking',
+  'transit',
+  ...(RIDESHARE_ENABLED ? (['rideshare'] as const) : []),
+]
+
 // Mode-scoped preference storage
 export type ModeKey = 'walking' | 'biking' | 'driving' | 'transit'
 
@@ -118,18 +134,6 @@ export const useDirectionsStore = defineStore('directions', () => {
       lngLat: null,
     },
   ]) // List of locations to get directions for
-
-  // Load selected mode from localStorage, default to 'multi'. Unknown values —
-  // e.g. a mode that has since been removed — fall back rather than being sent
-  // to the API, which rejects them.
-  const SELECTABLE_MODES: readonly SelectedMode[] = [
-    'multi',
-    'walking',
-    'driving',
-    'biking',
-    'transit',
-    'rideshare',
-  ]
 
   const loadSelectedMode = (): SelectedMode => {
     const stored = localStorage.getItem('selectedMode') as SelectedMode | null

--- a/web/src/stores/directions.store.ts
+++ b/web/src/stores/directions.store.ts
@@ -6,7 +6,7 @@ import { RoutingPreferences, SelectedMode, SortPreference } from '@/types/multim
 import { getTimezoneWarning, type TimezoneWarning } from '@/lib/timezone.utils'
 
 // Mode-scoped preference storage
-export type ModeKey = 'walking' | 'biking' | 'driving' | 'transit' | 'wheelchair'
+export type ModeKey = 'walking' | 'biking' | 'driving' | 'transit'
 
 // Keys that are shared across all modes — everything else is per-mode
 const GENERAL_KEYS: ReadonlyArray<keyof RoutingPreferences> = [
@@ -49,12 +49,6 @@ const defaultModePreferences: Record<ModeKey, Partial<RoutingPreferences>> = {
     maxTransfers: 3,
     transitBufferMinutes: 2,
     wheelchairAccessible: false,
-  },
-  wheelchair: {
-    hills: 0,
-    surfaceQuality: 0.75,
-    walkingSpeed: undefined,
-    wheelchairAccessible: true,
   },
 }
 
@@ -125,17 +119,21 @@ export const useDirectionsStore = defineStore('directions', () => {
     },
   ]) // List of locations to get directions for
 
-  // Load selected mode from localStorage, default to 'multi'
+  // Load selected mode from localStorage, default to 'multi'. Unknown values —
+  // e.g. a mode that has since been removed — fall back rather than being sent
+  // to the API, which rejects them.
+  const SELECTABLE_MODES: readonly SelectedMode[] = [
+    'multi',
+    'walking',
+    'driving',
+    'biking',
+    'transit',
+    'rideshare',
+  ]
+
   const loadSelectedMode = (): SelectedMode => {
-    const stored = localStorage.getItem('selectedMode')
-    if (stored) {
-      try {
-        return stored as SelectedMode
-      } catch {
-        return 'multi'
-      }
-    }
-    return 'multi'
+    const stored = localStorage.getItem('selectedMode') as SelectedMode | null
+    return stored && SELECTABLE_MODES.includes(stored) ? stored : 'multi'
   }
 
   const selectedMode = ref<SelectedMode>(loadSelectedMode())

--- a/web/src/types/multimodal.types.ts
+++ b/web/src/types/multimodal.types.ts
@@ -9,7 +9,6 @@ export type VehicleType =
   | 'scooter'
   | 'e-bike'
   | 'e-scooter'
-  | 'wheelchair'
   | 'moped'
   | 'truck'
 
@@ -19,7 +18,6 @@ export type Mode =
   | 'biking'
   | 'transit'
   | 'rideshare'
-  | 'wheelchair'
   | 'paratransit'
   | 'mixed'
 
@@ -30,7 +28,6 @@ export type SelectedMode =
   | 'driving'
   | 'biking'
   | 'transit'
-  | 'wheelchair'
   | 'rideshare'
 
 export type SortPreference =

--- a/web/src/views/directions/Directions.vue
+++ b/web/src/views/directions/Directions.vue
@@ -18,7 +18,7 @@ import {
   TrainIcon,
   XIcon,
 } from 'lucide-vue-next'
-import { useDirectionsStore } from '@/stores/directions.store'
+import { useDirectionsStore, RIDESHARE_ENABLED } from '@/stores/directions.store'
 import { storeToRefs } from 'pinia'
 import WaypointInput from './WaypointInput.vue'
 import TripsList from './TripsList.vue'
@@ -141,7 +141,7 @@ onUnmounted(() => {
   directionsStore.unsetTrips()
 })
 
-const modes: Array<{ type: SelectedMode; icon: any; label: string }> = [
+const allModes: Array<{ type: SelectedMode; icon: any; label: string }> = [
   {
     type: 'multi',
     icon: ShuffleIcon,
@@ -173,6 +173,10 @@ const modes: Array<{ type: SelectedMode; icon: any; label: string }> = [
     label: 'Rideshare',
   },
 ]
+
+const modes = allModes.filter(
+  m => m.type !== 'rideshare' || RIDESHARE_ENABLED,
+)
 
 // Override default click behavior to add waypoints instead of navigating
 useMapListener(

--- a/web/src/views/directions/Directions.vue
+++ b/web/src/views/directions/Directions.vue
@@ -6,7 +6,6 @@ import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { useDirectionsService } from '@/services/directions.service'
 import { useMapListener } from '@/composables/useMapListener'
 import {
-  AccessibilityIcon,
   BikeIcon,
   BusFrontIcon,
   CarFrontIcon,
@@ -172,11 +171,6 @@ const modes: Array<{ type: SelectedMode; icon: any; label: string }> = [
     type: 'rideshare',
     icon: CarTaxiFrontIcon,
     label: 'Rideshare',
-  },
-  {
-    type: 'wheelchair',
-    icon: AccessibilityIcon,
-    label: 'Wheelchair',
   },
 ]
 

--- a/web/src/views/directions/RoutingPreferences.vue
+++ b/web/src/views/directions/RoutingPreferences.vue
@@ -18,7 +18,6 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import {
-  AccessibilityIcon,
   CarFrontIcon,
   BikeIcon,
   TrainIcon,
@@ -264,8 +263,6 @@ const currentModeName = computed(() => {
       return t('directions.preferences.transit')
     case 'driving':
       return t('directions.preferences.driving')
-    case 'wheelchair':
-      return t('directions.preferences.wheelchair', 'Wheelchair')
     default:
       return ''
   }
@@ -277,7 +274,6 @@ const modeToTab: Record<string, string> = {
   biking: 'biking',
   transit: 'transit',
   driving: 'driving',
-  wheelchair: 'wheelchair',
   multi: 'walking',
 }
 
@@ -411,7 +407,7 @@ const customModelError = computed(() => {
       @update:model-value="handleTabChange"
       class="w-full px-2"
     >
-      <TabsList class="w-full grid grid-cols-5">
+      <TabsList class="w-full grid grid-cols-4">
         <TabsTrigger value="walking" class="text-xs" title="Walking">
           <FootprintsIcon class="size-5" />
         </TabsTrigger>
@@ -423,9 +419,6 @@ const customModelError = computed(() => {
         </TabsTrigger>
         <TabsTrigger value="driving" class="text-xs" title="Driving">
           <CarFrontIcon class="size-5" />
-        </TabsTrigger>
-        <TabsTrigger value="wheelchair" class="text-xs" title="Wheelchair">
-          <AccessibilityIcon class="size-5" />
         </TabsTrigger>
       </TabsList>
 
@@ -462,7 +455,7 @@ const customModelError = computed(() => {
           :step="0.5"
         />
 
-        <!-- Wheelchair -->
+        <!-- Accessibility -->
         <PreferenceToggle pref="wheelchairAccessible" label="Wheelchair accessible" />
       </TabsContent>
 
@@ -615,40 +608,6 @@ const customModelError = computed(() => {
 
         <!-- HOV -->
         <PreferenceToggle pref="preferHOV" label="Prefer HOV lanes" />
-      </TabsContent>
-
-      <!-- ═══════════════════ Wheelchair ═══════════════════ -->
-      <TabsContent value="wheelchair" class="py-4 px-2 space-y-5 mt-0">
-        <!-- Hills -->
-        <PreferenceRow
-          pref="hills"
-          label="Hills"
-          toggle-label="Avoid hills"
-          :on="0"
-          :off="0.5"
-          toggle-when="below"
-        />
-
-        <!-- Surface Quality -->
-        <PreferenceRow
-          pref="surfaceQuality"
-          label="Surface quality"
-          toggle-label="Prefer paved paths"
-          :on="1"
-          :off="0.25"
-          :fallback="0.25"
-        />
-
-        <!-- Walking Speed -->
-        <PreferenceValueSlider
-          v-model="walkingSpeedDisplay"
-          pref="walkingSpeed"
-          label="Walking speed"
-          :hint="`${walkingSpeedDisplay} ${speedUnit}`"
-          :min="walkingSpeedMin"
-          :max="walkingSpeedMax"
-          :step="0.5"
-        />
       </TabsContent>
     </Tabs>
 

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -846,7 +846,6 @@ const modeColors = {
   biking: 'bg-forest-500',
   transit: 'bg-parchment-500',
   truck: 'bg-compass-500',
-  wheelchair: 'bg-teal-500',
 } as const
 
 const modeTextColors: Record<string, string> = {
@@ -856,7 +855,6 @@ const modeTextColors: Record<string, string> = {
   biking: 'text-forest-500',
   transit: 'text-parchment-600',
   truck: 'text-compass-500',
-  wheelchair: 'text-teal-500',
 }
 
 watch(
@@ -1168,9 +1166,7 @@ function showSegmentChart(segment: any): boolean {
     (segment.totalElevationGain ||
       segment.totalElevationLoss ||
       segment.edgeSegments?.length) &&
-    (segment.mode === 'walking' ||
-      segment.mode === 'cycling' ||
-      segment.mode === 'wheelchair')
+    (segment.mode === 'walking' || segment.mode === 'cycling')
   )
 }
 

--- a/web/src/views/directions/TripItem.vue
+++ b/web/src/views/directions/TripItem.vue
@@ -59,7 +59,6 @@ const tripType = computed<{ key: string; iconMode: string }>(() => {
     if (has('rideshare')) return { key: 'rideshare', iconMode: 'rideshare' }
     if (has('driving')) return { key: 'driving', iconMode: 'driving' }
     if (has('cycling')) return { key: 'cycling', iconMode: 'cycling' }
-    if (has('wheelchair')) return { key: 'wheelchair', iconMode: 'wheelchair' }
     return { key: 'walking', iconMode: 'walking' }
   }
 

--- a/web/src/views/timeline/components/TimelineSegmentRow.vue
+++ b/web/src/views/timeline/components/TimelineSegmentRow.vue
@@ -5,7 +5,6 @@ import {
   FootprintsIcon,
   BikeIcon,
   TrainIcon,
-  AccessibilityIcon,
 } from 'lucide-vue-next'
 import { TravelMode } from '@server/types/unified-routing.types'
 import { getTravelModeColor } from '@/lib/travel-mode-colors'
@@ -25,8 +24,6 @@ const modeIcon = computed(() => {
       return BikeIcon
     case TravelMode.TRANSIT:
       return TrainIcon
-    case TravelMode.WHEELCHAIR:
-      return AccessibilityIcon
     case TravelMode.WALKING:
     default:
       return FootprintsIcon
@@ -45,8 +42,6 @@ const modeVerb = computed(() => {
       return 'Cycled'
     case TravelMode.TRANSIT:
       return 'Transit'
-    case TravelMode.WHEELCHAIR:
-      return 'Traveled'
     case TravelMode.WALKING:
     default:
       return 'Walked'


### PR DESCRIPTION
Removes the **wheelchair travel mode** — the selectable mode/profile — from directions and the router.

## Scope

**Server** — `TravelMode.WHEELCHAIR`; `'wheelchair'` from `VehicleType` / `Mode` / `SelectedMode`; `planWheelchairSegment()` and its `getModesToGenerate` case; the mode's CO2 and safety-score entries; the ORS `wheelchair` profile literal; provider `supportedModes` and profile mappings (GraphHopper, Valhalla, Barrelman, Dawarich); the GraphHopper wheelchair custom-model rules; the API schema literals and the `/directions/vehicle-types` entry.

**Web** — the mode's type unions; the wheelchair preferences tab (tab grid 5→4) and its store defaults; mode icons; trip-signature token; vehicle-mode mapping; route-profile tabs; segment/trip colour and chart-eligibility checks; the Directions mode selector entry; en-US/es-ES strings. Unused `AccessibilityIcon` imports went with them.

**Docs** — `server/docs/trip-planner.md` updated. `docs/trip-planner-review.md` is a marked historical snapshot, so this adds to its existing "since then" banner rather than rewriting the record.

## Kept deliberately

Three things share the word but are not the mode:

- **`wheelchairAccessible`** — the routing *preference* under Walking and Transit (avoids stairs, prefers accessible entrances). Independent of the mode; still drives Valhalla's pedestrian type and station-entrance snapping in `trip.service.ts`.
- **Station/stop accessibility** — `wheelchairBoarding`, entrance `wheelchair` flags from GTFS/Barrelman.
- **OSM place tags** — `wheelchair=yes` chips, place details, tag labels/icons.

## Notes

- One web test asserted that `localStorage` round-trips `selectedMode: 'car'` — never a valid mode. Since a persisted `'wheelchair'` would now be sent to an API that rejects it, `loadSelectedMode()` gained a validation whitelist, and that test was replaced with a valid-mode case plus a fallback case.
- `bun run openapi` also picked up six stale `/subscriptions/*` paths missing from the committed spec. The file is fully generated, so they are kept rather than hand-trimmed out of the diff.

## Verification

- Server: 3935 tests pass, 0 failures. Typecheck adds no new errors (the baseline is noisy; this diff only removes errors).
- Web: 2146 tests pass, 0 failures. `vue-tsc` clean apart from one pre-existing unrelated error (`@tmcw/togeojson` missing).