### PR TITLE
Mobile canvas toolbar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* A minimized bottom sheet stays put when you tap the map behind it, instead of springing back to half height — most visible when drawing on a canvas from a phone.
 * Drawing on a canvas from a phone no longer pops the panel open after every mark, and the minimized panel shrinks to just the canvas's title bar.
 * On a phone, the canvas toolbar no longer floats on top of the expanded panel — the panel now slides over it. When the toolbar is too wide for the screen, it breaks into a fixed pair of rows: drawing tools above, erase and undo/redo below, stepping down a size on the narrowest phones so no tool is cut off.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* Drawing on a canvas from a phone no longer pops the panel open after every mark, and the minimized panel shrinks to just the canvas's title bar.
 * On a phone, the canvas toolbar no longer floats on top of the expanded panel — the panel now slides over it. When the toolbar is too wide for the screen, it breaks into a fixed pair of rows: drawing tools above, erase and undo/redo below.
 
 ## [0.9.0] - 2026-09-03

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Drawing on a canvas from a phone no longer pops the panel open after every mark, and the minimized panel shrinks to just the canvas's title bar.
-* On a phone, the canvas toolbar no longer floats on top of the expanded panel — the panel now slides over it. When the toolbar is too wide for the screen, it breaks into a fixed pair of rows: drawing tools above, erase and undo/redo below.
+* On a phone, the canvas toolbar no longer floats on top of the expanded panel — the panel now slides over it. When the toolbar is too wide for the screen, it breaks into a fixed pair of rows: drawing tools above, erase and undo/redo below, stepping down a size on the narrowest phones so no tool is cut off.
 
 ## [0.9.0] - 2026-09-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* On a phone, the canvas toolbar no longer floats on top of the expanded panel — the panel now slides over it. When the toolbar is too wide for the screen, it breaks into a fixed pair of rows: drawing tools above, erase and undo/redo below.
+
 ## [0.9.0] - 2026-09-03
 
 ### Added

--- a/web/src/components/BottomSheet.vue
+++ b/web/src/components/BottomSheet.vue
@@ -627,7 +627,12 @@ function handleAnimationEnd(open: boolean) {
   isAnimating.value = false
   stopLiveTracking()
 
-  if (!open) {
+  // Only a sheet that really closed goes back to its default detent. Vaul
+  // also reports an animation end for an outside interaction that was
+  // dismissed without closing anything — a tap on the map behind a
+  // non-dismissable sheet — and resetting then yanked a minimized sheet back
+  // up, mid-draw, on every tap.
+  if (!open && !props.open) {
     setTimeout(() => {
       activeSnapPoint.value =
         snapPoints.value[props.defaultSnapPointIndex] ?? null

--- a/web/src/components/layouts/DetailPanelLayout.vue
+++ b/web/src/components/layouts/DetailPanelLayout.vue
@@ -1,25 +1,40 @@
 <script setup lang="ts">
+import { ref, watchEffect } from 'vue'
 import { Button } from '@/components/ui/button'
 import { ArrowLeftIcon } from 'lucide-vue-next'
+import { useSheetPeek } from '@/composables/useSheetPeek'
 
 /**
  * Sheet layout with a sticky header containing back button, title, and optional actions.
  * Use this for detail views that need navigation.
  */
-defineProps<{
+const props = defineProps<{
   title?: string
   showBackButton?: boolean
+  /**
+   * Size the host sheet's collapsed (peek) detent to this header, so a
+   * minimized sheet shows exactly the title bar and nothing of the body.
+   * No-op outside a dynamic-peek bottom sheet.
+   */
+  peekHeader?: boolean
 }>()
 
 const emit = defineEmits<{
   back: []
 }>()
+
+const headerEl = ref<HTMLElement | null>(null)
+const { peekRef } = useSheetPeek()
+watchEffect(() => {
+  peekRef.value = props.peekHeader ? headerEl.value : null
+})
 </script>
 
 <template>
   <div class="h-full flex flex-col">
     <!-- Header -->
     <div
+      ref="headerEl"
       class="sticky top-0 z-10 bg-background/80 backdrop-blur-xl border-b border-border/50"
     >
       <div class="flex items-center gap-3 px-4 py-3">

--- a/web/src/components/library/canvas/CanvasAnnotationRow.vue
+++ b/web/src/components/library/canvas/CanvasAnnotationRow.vue
@@ -12,6 +12,7 @@ import { useI18n } from 'vue-i18n'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { useInlineRename } from '@/composables/useInlineRename'
+import { useResponsive } from '@/lib/utils'
 import { Switch } from '@/components/ui/switch'
 import { IconPicker } from '@/components/ui/icon-picker'
 import {
@@ -136,16 +137,24 @@ const metrics = computed(() =>
 const label = ref(props.annotation.label ?? '')
 const labelInput = ref<InstanceType<typeof Input> | null>(null)
 
+const { isMobileScreen } = useResponsive()
+
 /**
  * A mark that has just been made is almost always about to be named, so the
  * field takes focus the moment its row opens — the same reflex Felt has when
  * it drops a pin. Selecting existing text means a rename is one keystroke.
+ *
+ * Not on a phone, though: there the focus rides in with the keyboard and
+ * drags the bottom sheet open over the map after every single mark, which
+ * turns a run of pins into a fight with the sheet. Drawing is the activity;
+ * naming waits for a tap on the field.
  */
 watch(
   () => props.expanded,
   async expanded => {
     if (!expanded) return
     label.value = props.annotation.label ?? ''
+    if (isMobileScreen.value) return
     await nextTick()
     const el = (labelInput.value?.$el ?? labelInput.value) as
       | HTMLInputElement

--- a/web/src/components/library/canvas/CanvasToolbar.vue
+++ b/web/src/components/library/canvas/CanvasToolbar.vue
@@ -69,12 +69,14 @@ const { t } = useI18n()
  * what the tool can do beyond clicking — held keys and the like — where it
  * can be found without taking up room on the bar.
  */
-const TOOLS: {
+type ToolItem = {
   id: CanvasTool
   icon: typeof MapPinIcon
   key: string
   hint?: string
-}[] = [
+}
+
+const DRAW_TOOLS: ToolItem[] = [
   { id: 'pin', icon: MapPinIcon, key: 'P' },
   { id: 'line', icon: MinusIcon, key: 'L', hint: 'straight' },
   { id: 'route', icon: WaypointsIcon, key: 'R' },
@@ -83,15 +85,24 @@ const TOOLS: {
   { id: 'circle', icon: CircleIcon, key: 'I', hint: 'radius' },
   { id: 'isochrone', icon: TimerIcon, key: 'T', hint: 'isochrone' },
   { id: 'doodle', icon: PencilIcon, key: 'D', hint: 'doodle' },
-  { id: 'erase', icon: EraserIcon, key: 'X', hint: 'erase' },
 ]
 
-function isDisabled(item: (typeof TOOLS)[number]) {
+// With the edit actions, not the draw tools: erase takes marks away, like
+// undo, and keeping it there means the phone-width wrap (draw tools on one
+// row, everything that acts on what's drawn below them) is a real grouping.
+const ERASE_TOOL: ToolItem = {
+  id: 'erase',
+  icon: EraserIcon,
+  key: 'X',
+  hint: 'erase',
+}
+
+function isDisabled(item: ToolItem) {
   // Both lean on the routing engine; neither works without one.
   return (item.id === 'route' || item.id === 'isochrone') && !props.canRoute
 }
 
-function toolTitle(item: (typeof TOOLS)[number]) {
+function toolTitle(item: ToolItem) {
   const name = `${t(`canvases.toolbar.tools.${item.id}`)} (${item.key})`
   if (isDisabled(item)) return t('canvases.toolbar.hints.routingUnavailable')
   return item.hint
@@ -150,112 +161,135 @@ const destinationItems = computed(() => [
     class="pointer-events-auto rounded-xl border bg-background/95 backdrop-blur-sm shadow-lg overflow-hidden"
   >
     <!-- Wraps rather than overflows: the box is rounded and clipped, so a
-         strip too wide for a phone would lose its last buttons entirely. -->
+         strip too wide for a phone would lose its last buttons entirely.
+         Each inner div is a unit that can't break, so the wrap always lands
+         between the draw tools and the edit actions — the same split on
+         every phone, never mid-tools wherever the width happens to run out. -->
     <div class="flex flex-wrap justify-center items-center gap-0.5 p-1">
-      <Button
-        variant="ghost"
-        size="icon"
-        class="size-8"
-        :class="!tool && 'bg-secondary text-foreground'"
-        :title="t('canvases.toolbar.select')"
-        :aria-label="t('canvases.toolbar.select')"
-        @click="emit('arm', null)"
-      >
-        <MousePointer2Icon class="size-4" />
-      </Button>
-
-      <Separator orientation="vertical" class="h-5 mx-0.5" />
-
-      <Button
-        v-for="item in TOOLS"
-        :key="item.id"
-        variant="ghost"
-        size="icon"
-        class="size-8"
-        :class="tool === item.id && 'bg-secondary text-foreground'"
-        :disabled="isDisabled(item)"
-        :title="toolTitle(item)"
-        :aria-label="t(`canvases.toolbar.tools.${item.id}`)"
-        @click="emit('arm', item.id)"
-      >
-        <component :is="item.icon" class="size-4" />
-      </Button>
-
-      <!-- Where the next mark gets filed. Only worth showing once there is
-           somewhere else for it to go. -->
-      <template v-if="groups.length && !isDrawing">
-        <Separator orientation="vertical" class="h-5 mx-0.5" />
-        <ResponsiveDropdown
-          :items="destinationItems"
-          align="end"
-          :title="t('canvases.groups.destination')"
+      <div class="flex items-center gap-0.5">
+        <Button
+          variant="ghost"
+          size="icon"
+          class="size-8"
+          :class="!tool && 'bg-secondary text-foreground'"
+          :title="t('canvases.toolbar.select')"
+          :aria-label="t('canvases.toolbar.select')"
+          @click="emit('arm', null)"
         >
-          <template #trigger>
-            <Button
-              variant="ghost"
-              size="sm"
-              class="h-8 gap-1.5 px-2 max-w-36"
-              :class="activeGroup && 'text-primary'"
-              :title="t('canvases.groups.destination')"
-            >
-              <component
-                :is="activeGroup ? FolderOpenIcon : LayersIcon"
-                class="size-4 shrink-0"
-              />
-              <!-- The bar is already tight on a phone; there the icon and its
-                   colour carry it, and the menu names the destination. -->
-              <span class="text-xs truncate hidden sm:inline">
-                {{ activeGroup?.name ?? t('canvases.groups.canvas') }}
-              </span>
-            </Button>
-          </template>
-        </ResponsiveDropdown>
-      </template>
+          <MousePointer2Icon class="size-4" />
+        </Button>
 
-      <!-- The trailing pair never changes shape, whatever the state.
-           The bar is centred over the map, so a button that comes and goes
-           re-centres the whole thing — which reads as flicker while you are
-           mid-shape and clicking. Undo is always undo; the second slot is
-           Redo until there is a shape to finish, and Done while there is. -->
-      <Separator orientation="vertical" class="h-5 mx-0.5" />
-      <Button
-        variant="ghost"
-        size="icon"
-        class="size-8"
-        :disabled="isDrawing ? !canUndo : !canUndoEdit"
-        :title="`${t('canvases.toolbar.undoEdit')} (⌘Z)`"
-        :aria-label="t('canvases.toolbar.undoEdit')"
-        @click="undo"
-      >
-        <UndoIcon class="size-4" />
-      </Button>
+        <Separator orientation="vertical" class="h-5 mx-0.5" />
 
-      <!-- Finishing is the only thing worth offering mid-shape, and it takes
-           the redo slot rather than a place of its own. -->
-      <Button
-        v-if="isDrawing"
-        variant="ghost"
-        size="icon"
-        class="size-8 text-primary hover:text-primary"
-        :disabled="!canFinish"
-        :title="`${t('general.done')} (⏎)`"
-        :aria-label="t('general.done')"
-        @click="emit('finish')"
-      >
-        <CheckIcon class="size-4" />
-      </Button>
-      <Button
-        v-else
-        variant="ghost"
-        size="icon"
-        class="size-8"
-        :disabled="!canRedoEdit"
-        :title="`${t('canvases.toolbar.redoEdit')} (⌘⇧Z)`"
-        :aria-label="t('canvases.toolbar.redoEdit')"
-        @click="emit('redoEdit')"
-      >
-        <RedoIcon class="size-4" />
-      </Button>
+        <Button
+          v-for="item in DRAW_TOOLS"
+          :key="item.id"
+          variant="ghost"
+          size="icon"
+          class="size-8"
+          :class="tool === item.id && 'bg-secondary text-foreground'"
+          :disabled="isDisabled(item)"
+          :title="toolTitle(item)"
+          :aria-label="t(`canvases.toolbar.tools.${item.id}`)"
+          @click="emit('arm', item.id)"
+        >
+          <component :is="item.icon" class="size-4" />
+        </Button>
+      </div>
+
+      <div class="flex items-center gap-0.5">
+        <!-- The boundary divider only makes sense while both units share a
+             row; on a wrapped row it would dangle at the front. -->
+        <Separator orientation="vertical" class="hidden sm:block h-5 mx-0.5" />
+
+        <Button
+          variant="ghost"
+          size="icon"
+          class="size-8"
+          :class="tool === ERASE_TOOL.id && 'bg-secondary text-foreground'"
+          :title="toolTitle(ERASE_TOOL)"
+          :aria-label="t(`canvases.toolbar.tools.${ERASE_TOOL.id}`)"
+          @click="emit('arm', ERASE_TOOL.id)"
+        >
+          <EraserIcon class="size-4" />
+        </Button>
+
+        <!-- Where the next mark gets filed. Only worth showing once there is
+             somewhere else for it to go. -->
+        <template v-if="groups.length && !isDrawing">
+          <Separator orientation="vertical" class="h-5 mx-0.5" />
+          <ResponsiveDropdown
+            :items="destinationItems"
+            align="end"
+            :title="t('canvases.groups.destination')"
+          >
+            <template #trigger>
+              <Button
+                variant="ghost"
+                size="sm"
+                class="h-8 gap-1.5 px-2 max-w-36"
+                :class="activeGroup && 'text-primary'"
+                :title="t('canvases.groups.destination')"
+              >
+                <component
+                  :is="activeGroup ? FolderOpenIcon : LayersIcon"
+                  class="size-4 shrink-0"
+                />
+                <!-- The bar is already tight on a phone; there the icon and
+                     its colour carry it, and the menu names the destination. -->
+                <span class="text-xs truncate hidden sm:inline">
+                  {{ activeGroup?.name ?? t('canvases.groups.canvas') }}
+                </span>
+              </Button>
+            </template>
+          </ResponsiveDropdown>
+        </template>
+
+        <!-- The trailing pair never changes shape, whatever the state.
+             The bar is centred over the map, so a button that comes and goes
+             re-centres the whole thing — which reads as flicker while you are
+             mid-shape and clicking. Undo is always undo; the second slot is
+             Redo until there is a shape to finish, and Done while there is. -->
+        <Separator orientation="vertical" class="h-5 mx-0.5" />
+        <Button
+          variant="ghost"
+          size="icon"
+          class="size-8"
+          :disabled="isDrawing ? !canUndo : !canUndoEdit"
+          :title="`${t('canvases.toolbar.undoEdit')} (⌘Z)`"
+          :aria-label="t('canvases.toolbar.undoEdit')"
+          @click="undo"
+        >
+          <UndoIcon class="size-4" />
+        </Button>
+
+        <!-- Finishing is the only thing worth offering mid-shape, and it takes
+             the redo slot rather than a place of its own. -->
+        <Button
+          v-if="isDrawing"
+          variant="ghost"
+          size="icon"
+          class="size-8 text-primary hover:text-primary"
+          :disabled="!canFinish"
+          :title="`${t('general.done')} (⏎)`"
+          :aria-label="t('general.done')"
+          @click="emit('finish')"
+        >
+          <CheckIcon class="size-4" />
+        </Button>
+        <Button
+          v-else
+          variant="ghost"
+          size="icon"
+          class="size-8"
+          :disabled="!canRedoEdit"
+          :title="`${t('canvases.toolbar.redoEdit')} (⌘⇧Z)`"
+          :aria-label="t('canvases.toolbar.redoEdit')"
+          @click="emit('redoEdit')"
+        >
+          <RedoIcon class="size-4" />
+        </Button>
+      </div>
     </div>
 
     <!-- What the armed tool is set to: the same box, under a divider, so

--- a/web/src/components/library/canvas/CanvasToolbar.vue
+++ b/web/src/components/library/canvas/CanvasToolbar.vue
@@ -110,6 +110,14 @@ function toolTitle(item: ToolItem) {
     : name
 }
 
+/**
+ * Nine buttons at 32px overflow a narrow phone, and the box is clipped, so the
+ * end tools would simply be lost. The strip steps down a size instead — the
+ * grouping survives, and every tool stays reachable.
+ */
+const TOOL_BUTTON = 'size-7 min-[380px]:size-8'
+const TOOL_ICON = 'size-3.5 min-[380px]:size-4'
+
 /** Mid-draw only for the shapes that don't finish themselves. */
 const isDrawing = computed(() => props.vertexCount > 0)
 
@@ -170,13 +178,12 @@ const destinationItems = computed(() => [
         <Button
           variant="ghost"
           size="icon"
-          class="size-8"
-          :class="!tool && 'bg-secondary text-foreground'"
+          :class="[TOOL_BUTTON, !tool && 'bg-secondary text-foreground']"
           :title="t('canvases.toolbar.select')"
           :aria-label="t('canvases.toolbar.select')"
           @click="emit('arm', null)"
         >
-          <MousePointer2Icon class="size-4" />
+          <MousePointer2Icon :class="TOOL_ICON" />
         </Button>
 
         <Separator orientation="vertical" class="h-5 mx-0.5" />
@@ -186,14 +193,13 @@ const destinationItems = computed(() => [
           :key="item.id"
           variant="ghost"
           size="icon"
-          class="size-8"
-          :class="tool === item.id && 'bg-secondary text-foreground'"
+          :class="[TOOL_BUTTON, tool === item.id && 'bg-secondary text-foreground']"
           :disabled="isDisabled(item)"
           :title="toolTitle(item)"
           :aria-label="t(`canvases.toolbar.tools.${item.id}`)"
           @click="emit('arm', item.id)"
         >
-          <component :is="item.icon" class="size-4" />
+          <component :is="item.icon" :class="TOOL_ICON" />
         </Button>
       </div>
 
@@ -205,13 +211,15 @@ const destinationItems = computed(() => [
         <Button
           variant="ghost"
           size="icon"
-          class="size-8"
-          :class="tool === ERASE_TOOL.id && 'bg-secondary text-foreground'"
+          :class="[
+            TOOL_BUTTON,
+            tool === ERASE_TOOL.id && 'bg-secondary text-foreground',
+          ]"
           :title="toolTitle(ERASE_TOOL)"
           :aria-label="t(`canvases.toolbar.tools.${ERASE_TOOL.id}`)"
           @click="emit('arm', ERASE_TOOL.id)"
         >
-          <EraserIcon class="size-4" />
+          <EraserIcon :class="TOOL_ICON" />
         </Button>
 
         <!-- Where the next mark gets filed. Only worth showing once there is
@@ -227,13 +235,13 @@ const destinationItems = computed(() => [
               <Button
                 variant="ghost"
                 size="sm"
-                class="h-8 gap-1.5 px-2 max-w-36"
+                class="h-7 min-[380px]:h-8 gap-1.5 px-2 max-w-36"
                 :class="activeGroup && 'text-primary'"
                 :title="t('canvases.groups.destination')"
               >
                 <component
                   :is="activeGroup ? FolderOpenIcon : LayersIcon"
-                  class="size-4 shrink-0"
+                  :class="[TOOL_ICON, 'shrink-0']"
                 />
                 <!-- The bar is already tight on a phone; there the icon and
                      its colour carry it, and the menu names the destination. -->
@@ -254,13 +262,13 @@ const destinationItems = computed(() => [
         <Button
           variant="ghost"
           size="icon"
-          class="size-8"
+          :class="TOOL_BUTTON"
           :disabled="isDrawing ? !canUndo : !canUndoEdit"
           :title="`${t('canvases.toolbar.undoEdit')} (⌘Z)`"
           :aria-label="t('canvases.toolbar.undoEdit')"
           @click="undo"
         >
-          <UndoIcon class="size-4" />
+          <UndoIcon :class="TOOL_ICON" />
         </Button>
 
         <!-- Finishing is the only thing worth offering mid-shape, and it takes
@@ -269,25 +277,25 @@ const destinationItems = computed(() => [
           v-if="isDrawing"
           variant="ghost"
           size="icon"
-          class="size-8 text-primary hover:text-primary"
+          :class="[TOOL_BUTTON, 'text-primary hover:text-primary']"
           :disabled="!canFinish"
           :title="`${t('general.done')} (⏎)`"
           :aria-label="t('general.done')"
           @click="emit('finish')"
         >
-          <CheckIcon class="size-4" />
+          <CheckIcon :class="TOOL_ICON" />
         </Button>
         <Button
           v-else
           variant="ghost"
           size="icon"
-          class="size-8"
+          :class="TOOL_BUTTON"
           :disabled="!canRedoEdit"
           :title="`${t('canvases.toolbar.redoEdit')} (⌘⇧Z)`"
           :aria-label="t('canvases.toolbar.redoEdit')"
           @click="emit('redoEdit')"
         >
-          <RedoIcon class="size-4" />
+          <RedoIcon :class="TOOL_ICON" />
         </Button>
       </div>
     </div>

--- a/web/src/router/index.ts
+++ b/web/src/router/index.ts
@@ -236,7 +236,10 @@ const router = createRouter({
             auth: true,
             // A canvas is a workspace, not a passing detail view: on mobile
             // the sheet stays put until it is closed deliberately.
-            sheet: { dismissable: false, snapPoints: ['160px', 0.6, 1] },
+            // The middle detent sits low: on a canvas the map is the work,
+            // so the half-open panel shows a few rows without burying it.
+            // The first entry is a fallback — the peek measures the header.
+            sheet: { dismissable: false, snapPoints: ['160px', 0.4, 1] },
           },
         },
         {

--- a/web/src/views/library/canvases/CanvasEditor.vue
+++ b/web/src/views/library/canvases/CanvasEditor.vue
@@ -905,9 +905,12 @@ const saveStatus = computed(() =>
     <Teleport v-if="canvas" to="body">
       <!-- Centred over the *map*, not the viewport: on desktop the sheet
            takes the left 26rem, and a toolbar centred on the window sits
-           half-over it and collides with the sheet's own controls. -->
+           half-over it and collides with the sheet's own controls.
+           z sits between the mobile sheet's overlay (30) and its content
+           (40), so dragging the sheet up slides it over the toolbar rather
+           than leaving the tools floating on top of the panel. -->
       <div
-        class="fixed z-40 top-3 inset-x-0 md:left-104 pointer-events-none flex justify-center px-3"
+        class="fixed z-[35] top-3 inset-x-0 md:left-104 pointer-events-none flex justify-center px-3"
       >
         <CanvasToolbar
           :tool="annotations.tool.value"

--- a/web/src/views/library/canvases/CanvasEditor.vue
+++ b/web/src/views/library/canvases/CanvasEditor.vue
@@ -761,7 +761,9 @@ const saveStatus = computed(() =>
 </script>
 
 <template>
-  <DetailPanelLayout>
+  <!-- peek-header: minimized on a phone, the sheet shows just this header —
+       the map, and the toolbar over it, are the workspace while drawing. -->
+  <DetailPanelLayout peek-header>
     <template #title>
       <div class="flex items-center gap-2 min-w-0">
         <!-- A canvas saves itself, so where that got to is a property of the


### PR DESCRIPTION
Mobile fixes for the canvas editor.

**Toolbar floated on top of the expanded bottom sheet.** The toolbar's wrapper was `z-40` — the same z-index as the mobile content sheet — and, being teleported to `body` later, always won the tie. It now sits at `z-[35]`: above the sheet's overlay (30) and the nav sheet (30), below the sheet content (40), so dragging the sheet up slides it over the toolbar.

**Tools wrapped at an arbitrary point on narrow screens.** The strip was one `flex-wrap` container, so the break landed wherever width ran out. It is now two non-wrapping units inside the wrapping container, so the break always falls at the same boundary: select + the eight drawing tools on one row, and the edit actions — erase, destination picker, undo, redo/done — below. Erase moved from the tools array into the actions group, since it removes marks the way undo does. The divider between the two groups hides below `sm` so a wrapped row doesn't start with a dangling separator.

**Tools overflowed the clipped box below ~350px.** Nine 32px buttons don't fit a narrow phone, and the box is `overflow-hidden`, so the end tools were simply lost. Below 380px the strip steps down to 28px buttons with 14px glyphs — the grouping survives and every tool stays reachable. Desktop is unchanged.

**Drawing popped the sheet open after every mark.** Committing a mark opens its row with the name field focused; on a phone that focus rides in with the keyboard and drags the sheet open mid-draw. The autofocus is now desktop-only — the row still opens, and a tap on the field starts naming.

**Minimized, the sheet showed an arbitrary 160px slice.** The editor registers its header as the sheet's dynamic-peek region (new opt-in `peek-header` prop on `DetailPanelLayout`), so the collapsed sheet rests exactly around the canvas icon, name, description and nav buttons.

**The middle detent sat too high.** It was 60% of the screen, which buries the map you're drawing on; it now rests at 40%.

Verified in the running app. At 320px: 28px buttons, first and last tool both inside the box, no overflow, wrap exactly between draw tools and actions. At 390px: 32px buttons, same wrap, nothing clipped. With the sheet expanded a hit-test over the toolbar lands on the sheet; minimized (78px peek hugging the header) placing pins leaves the sheet at peek with focus untouched; the middle detent measures 40%.