### PR TITLE
Library tab search + actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+* The layers library tab's add and store buttons no longer overlap the tab bar — they now sit at the top of the list, matching the routes tab.
+
 ## [0.9.0] - 2026-09-03
 
 ### Added

--- a/web/src/components/map/Layers.vue
+++ b/web/src/components/map/Layers.vue
@@ -1,60 +1,21 @@
 <script setup lang="ts">
-import { ref, computed, watch, onMounted } from 'vue'
+import { ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
-import { useRouter } from 'vue-router'
-import { AppRoute } from '@/router'
 import { useLayersStore } from '@/stores/layers.store'
-import { useAppService } from '@/services/app.service'
 import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import { useDragState } from '@/composables/useDragState'
 import type { Layer, LayerGroup } from '@/types/map.types'
-import LayerGroupConfiguration from './layers/LayerGroupConfiguration.vue'
 import LayerItemComponent from './layers/LayerItem.vue'
 import LayerGroupItem from './layers/LayerGroupItem.vue'
-import LayerStoreDialog from './layers/LayerStoreDialog.vue'
-import { Button } from '@/components/ui/button'
-import { FolderIcon, PlusIcon, LayersIcon, StoreIcon } from 'lucide-vue-next'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu'
+import { FolderIcon } from 'lucide-vue-next'
 import draggable from 'vuedraggable'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
-const appService = useAppService()
-const router = useRouter()
 const layersStore = useLayersStore()
 const { mainReorderableItems, groupsWithLayers, groupTree } = storeToRefs(layersStore)
 const { t } = useI18n()
 const { isDragActive } = useDragState()
-
-const hasTeleportTarget = ref(false)
-onMounted(() => {
-  hasTeleportTarget.value = !!document.getElementById('library-tab-actions')
-})
-
-// The layer editor is a sheet view, not a dialog: it renders the draft on
-// the live map while you edit, which a modal over the map cannot do.
-function openLayerEditor(layerId?: string) {
-  router.push(
-    layerId
-      ? { name: AppRoute.LAYER_EDITOR, params: { id: layerId } }
-      : { name: AppRoute.LAYER_EDITOR_NEW },
-  )
-}
-
-function openLayerGroupConfigDialog(groupId?: string) {
-  appService.componentDialog({
-    component: LayerGroupConfiguration,
-    continueText: t('general.save'),
-    props: { groupId },
-  })
-}
-
-const storeOpen = ref(false)
 
 // Track expanded groups
 const expandedGroups = ref(new Set<string>())
@@ -143,39 +104,6 @@ async function handleMainChange(evt: any) {
 </script>
 
 <template>
-  <Teleport v-if="hasTeleportTarget" to="#library-tab-actions">
-    <DropdownMenu>
-      <DropdownMenuTrigger as-child>
-        <Button variant="ghost" size="icon" class="size-7">
-          <PlusIcon class="size-4" />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem @click="openLayerEditor()">
-          <LayersIcon class="size-4" />
-          {{ t('layers.actions.newLayer') }}
-        </DropdownMenuItem>
-        <DropdownMenuItem @click="openLayerGroupConfigDialog()">
-          <FolderIcon class="size-4" />
-          {{ t('layers.actions.newGroup') }}
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
-    <!-- Sits outside `TooltipProvider`, so this one labels itself natively. -->
-    <Button
-      variant="ghost"
-      size="icon"
-      class="size-7"
-      :aria-label="t('layers.store.title')"
-      :title="t('layers.store.title')"
-      @click="storeOpen = true"
-    >
-      <StoreIcon class="size-4" />
-    </Button>
-  </Teleport>
-
-  <LayerStoreDialog v-model:open="storeOpen" />
-
   <TooltipProvider>
     <div class="h-full flex flex-col">
       <div class="space-y-1 flex-1 min-h-0">

--- a/web/src/components/map/Layers.vue
+++ b/web/src/components/map/Layers.vue
@@ -1,21 +1,40 @@
 <script setup lang="ts">
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
 import { useLayersStore } from '@/stores/layers.store'
 import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import { useDragState } from '@/composables/useDragState'
 import type { Layer, LayerGroup } from '@/types/map.types'
+import { groupSubtreeMatches, matchesQuery } from '@/lib/layer-search'
 import LayerItemComponent from './layers/LayerItem.vue'
 import LayerGroupItem from './layers/LayerGroupItem.vue'
 import { FolderIcon } from 'lucide-vue-next'
 import draggable from 'vuedraggable'
 import { TooltipProvider } from '@/components/ui/tooltip'
 
+// `filter` is the library search query. Reordering is disabled while a search
+// is active, and non-matching rows are hidden rather than removed so the drag
+// model stays intact.
+const props = defineProps<{ filter?: string }>()
+
 const layersStore = useLayersStore()
 const { mainReorderableItems, groupsWithLayers, groupTree } = storeToRefs(layersStore)
 const { t } = useI18n()
 const { isDragActive } = useDragState()
+
+const query = computed(() => (props.filter ?? '').trim().toLowerCase())
+const isFiltering = computed(() => query.value.length > 0)
+
+function itemMatches(item: Layer | LayerGroup): boolean {
+  if (!isFiltering.value) return true
+  if ('groupId' in item) return matchesQuery(item.name, query.value)
+  return groupSubtreeMatches(getGroupForElement(item), query.value)
+}
+
+const hasMatches = computed(() =>
+  !isFiltering.value || draggableItems.value.some(itemMatches),
+)
 
 // Track expanded groups
 const expandedGroups = ref(new Set<string>())
@@ -111,6 +130,7 @@ async function handleMainChange(evt: any) {
           v-if="draggableItems?.length > 0"
           v-model="draggableItems"
           v-bind="mainDragOptions"
+          :disabled="isFiltering"
           @start="onDragStart"
           @end="onDragEnd"
           @move="onDragMove"
@@ -123,6 +143,7 @@ async function handleMainChange(evt: any) {
         >
           <template #item="{ element }">
             <div
+              v-show="itemMatches(element)"
               :key="
                 'groupId' in element
                   ? getLayerKey(element)
@@ -134,6 +155,7 @@ async function handleMainChange(evt: any) {
                 v-if="!('groupId' in element)"
                 :group="getGroupForElement(element)"
                 :expanded-groups="expandedGroups"
+                :filter="filter"
                 @toggle-expanded="toggleGroup"
               />
 
@@ -150,6 +172,13 @@ async function handleMainChange(evt: any) {
         >
           <FolderIcon class="size-8 mx-auto mb-2 opacity-50" />
           <p class="text-sm">{{ t('layers.empty.message') }}</p>
+        </div>
+
+        <div
+          v-else-if="isFiltering && !hasMatches"
+          class="text-center py-8 text-muted-foreground"
+        >
+          <p class="text-sm">{{ t('layers.search.noResults') }}</p>
         </div>
       </div>
     </div>

--- a/web/src/components/map/layers/LayerGroupItem.vue
+++ b/web/src/components/map/layers/LayerGroupItem.vue
@@ -5,6 +5,7 @@ import { useLayersStore } from '@/stores/layers.store'
 import { useLayersService } from '@/services/layers/layers.service'
 import { useAppService } from '@/services/app.service'
 import type { LayerGroupWithLayers, LayerGroup, Layer } from '@/types/map.types'
+import { groupSubtreeMatches, matchesQuery } from '@/lib/layer-search'
 import { useDragAndDrop } from '@/composables/useDragAndDrop'
 import * as LucideIcons from 'lucide-vue-next'
 import LayerItemComponent from './LayerItem.vue'
@@ -47,6 +48,7 @@ interface Props {
   group: GroupTreeNode
   expandedGroups: Set<string>
   depth?: number
+  filter?: string
 }
 
 const props = withDefaults(defineProps<Props>(), {
@@ -63,7 +65,14 @@ const layersService = useLayersService()
 const appService = useAppService()
 const mapService = useMapService()
 
-const expanded = computed(() => props.expandedGroups.has(props.group.id))
+const query = computed(() => (props.filter ?? '').trim().toLowerCase())
+const isFiltering = computed(() => query.value.length > 0)
+
+// While searching, every rendered group is expanded so matches nested inside
+// it are visible without the user having to open each one.
+const expanded = computed(
+  () => props.expandedGroups.has(props.group.id) || isFiltering.value,
+)
 
 const childGroups = computed(() => props.group.children ?? [])
 
@@ -93,6 +102,15 @@ function isLayer(item: Layer | LayerGroup): item is Layer {
 
 function isGroup(item: Layer | LayerGroup): item is LayerGroup {
   return !('groupId' in item)
+}
+
+// When the group's own name matches, everything inside it stays visible;
+// otherwise only the layers and child groups that match the query show.
+function itemMatches(item: Layer | LayerGroup): boolean {
+  if (!isFiltering.value) return true
+  if (matchesQuery(props.group.name, query.value)) return true
+  if (isLayer(item)) return matchesQuery(item.name, query.value)
+  return groupSubtreeMatches(findChildTreeNode(item), query.value)
 }
 
 function getItemKey(item: Layer | LayerGroup): string {
@@ -291,6 +309,7 @@ function findChildTreeNode(group: LayerGroup): GroupTreeNode {
           <draggable
             v-model="mixedItems"
             v-bind="groupDragOptions"
+            :disabled="isFiltering"
             @start="onDragStart"
             @end="onDragEnd"
             @move="onDragMove"
@@ -300,13 +319,14 @@ function findChildTreeNode(group: LayerGroup): GroupTreeNode {
             tag="div"
           >
             <template #item="{ element }">
-              <div class="draggable-item">
+              <div v-show="itemMatches(element)" class="draggable-item">
                 <!-- Child Group (recursive) -->
                 <LayerGroupItem
                   v-if="isGroup(element)"
                   :group="findChildTreeNode(element)"
                   :expanded-groups="expandedGroups"
                   :depth="depth + 1"
+                  :filter="filter"
                   @toggle-expanded="(id: string) => emit('toggleExpanded', id)"
                 />
 

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -440,6 +440,10 @@
   },
   "layers": {
     "title": "Layers",
+    "search": {
+      "placeholder": "Search layers…",
+      "noResults": "No matching layers"
+    },
     "selector": {
       "tabs": {
         "map": "Map",
@@ -2285,6 +2289,10 @@
   },
   "canvases": {
     "title": "Canvases",
+    "search": {
+      "placeholder": "Search canvases…",
+      "noResults": "No matching canvases"
+    },
     "layerCount": "No layers | 1 layer | {count} layers",
     "showOnMap": "Show on the map",
     "saved": "Saved",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -434,6 +434,10 @@
   },
   "layers": {
     "title": "Capas",
+    "search": {
+      "placeholder": "Buscar capas…",
+      "noResults": "Sin capas coincidentes"
+    },
     "selector": {
       "tabs": {
         "map": "Mapa",
@@ -2162,6 +2166,10 @@
   },
   "canvases": {
     "title": "Lienzos",
+    "search": {
+      "placeholder": "Buscar lienzos…",
+      "noResults": "Sin lienzos coincidentes"
+    },
     "layerCount": "Sin capas | 1 capa | {count} capas",
     "showOnMap": "Mostrar en el mapa",
     "saved": "Guardado",

--- a/web/src/lib/layer-search.ts
+++ b/web/src/lib/layer-search.ts
@@ -1,0 +1,33 @@
+import type { Layer } from '@/types/map.types'
+
+/**
+ * Shared name matching for the layers library search box. Both the top-level
+ * list (`components/map/Layers.vue`) and each group (`LayerGroupItem.vue`)
+ * filter against the same rules, so the logic lives here rather than being
+ * duplicated per component.
+ *
+ * Callers pass a query that is already trimmed and lower-cased.
+ */
+
+export function matchesQuery(name: string, query: string): boolean {
+  return name.toLowerCase().includes(query)
+}
+
+export interface SearchableGroupNode {
+  name: string
+  layers?: Layer[]
+  children?: SearchableGroupNode[]
+}
+
+/**
+ * A group is a match when its own name matches, or when anything nested inside
+ * it — a layer or a descendant group — matches.
+ */
+export function groupSubtreeMatches(
+  node: SearchableGroupNode,
+  query: string,
+): boolean {
+  if (matchesQuery(node.name, query)) return true
+  if (node.layers?.some(layer => matchesQuery(layer.name, query))) return true
+  return Boolean(node.children?.some(child => groupSubtreeMatches(child, query)))
+}

--- a/web/src/views/library/Library.vue
+++ b/web/src/views/library/Library.vue
@@ -76,7 +76,7 @@ function handleTabChange(tabId: string | number) {
         @update:model-value="handleTabChange"
         class="w-full h-full flex flex-col"
       >
-        <div class="-mx-3 px-3 flex items-end border-b relative" style="width: calc(100% + 1.5rem)">
+        <div class="-mx-3 px-3 flex items-end border-b" style="width: calc(100% + 1.5rem)">
           <TabsList variant="linear" class="border-b-0">
             <TabsTrigger
               v-for="tab in tabs"
@@ -88,7 +88,6 @@ function handleTabChange(tabId: string | number) {
               {{ tab.label }}
             </TabsTrigger>
           </TabsList>
-          <div id="library-tab-actions" class="absolute right-3 bottom-1 flex items-center gap-0.5" />
         </div>
 
         <div class="flex-1 pt-3">

--- a/web/src/views/library/canvases/Canvases.vue
+++ b/web/src/views/library/canvases/Canvases.vue
@@ -13,8 +13,9 @@ import CanvasCard from '@/components/library/CanvasCard.vue'
 import CanvasDialog from '@/components/library/canvas/CanvasDialog.vue'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
-import { MapIcon, PlusIcon } from 'lucide-vue-next'
+import { MapIcon, PlusIcon, SearchIcon } from 'lucide-vue-next'
 import type { Canvas } from '@/types/canvas.types'
 
 const { t } = useI18n()
@@ -26,13 +27,9 @@ const { canvases } = storeToRefs(canvasesStore)
 const loading = ref(canvases.value.length === 0)
 const dialogOpen = ref(false)
 const editing = ref<Canvas | null>(null)
-
-// The tab strip hosts the per-tab actions; mounting order means the target
-// only exists once the Library shell has rendered.
-const hasTeleportTarget = ref(false)
+const searchQuery = ref('')
 
 onMounted(async () => {
-  hasTeleportTarget.value = !!document.getElementById('library-tab-actions')
   await canvasesService.fetchCanvases()
   loading.value = false
 })
@@ -43,6 +40,14 @@ const sorted = computed(() =>
       new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
   ),
 )
+
+const filtered = computed(() => {
+  const q = searchQuery.value.trim().toLowerCase()
+  if (!q) return sorted.value
+  return sorted.value.filter(canvas =>
+    (canvas.name ?? '').toLowerCase().includes(q),
+  )
+})
 
 function create() {
   editing.value = null
@@ -60,19 +65,6 @@ function openCreated(canvas: Canvas) {
 </script>
 
 <template>
-  <Teleport v-if="hasTeleportTarget" to="#library-tab-actions">
-    <Button
-      variant="ghost"
-      size="icon"
-      class="size-7"
-      :title="t('canvases.actions.new')"
-      :aria-label="t('canvases.actions.new')"
-      @click="create"
-    >
-      <PlusIcon class="size-4" />
-    </Button>
-  </Teleport>
-
   <CanvasDialog
     v-model:open="dialogOpen"
     :canvas="editing"
@@ -100,13 +92,42 @@ function openCreated(canvas: Canvas) {
     </EmptyState>
   </div>
 
-  <div v-else class="flex flex-col gap-2 pb-4">
-    <CanvasCard
-      v-for="canvas in sorted"
-      :key="canvas.id"
-      :canvas="canvas"
-      class="w-full"
-      @rename="rename"
-    />
+  <div v-else class="h-full flex flex-col gap-2">
+    <div class="flex items-center gap-2">
+      <div class="relative flex-1">
+        <SearchIcon
+          class="absolute left-2.5 top-3 size-4 text-muted-foreground"
+        />
+        <Input
+          v-model="searchQuery"
+          class="w-full pl-8"
+          :placeholder="t('canvases.search.placeholder')"
+        />
+      </div>
+      <Button
+        variant="outline"
+        size="icon"
+        class="h-10 w-10"
+        :aria-label="t('canvases.actions.new')"
+        :title="t('canvases.actions.new')"
+        @click="create"
+      >
+        <PlusIcon class="h-4 w-4" />
+      </Button>
+    </div>
+
+    <div v-if="filtered.length" class="flex flex-col gap-2 pb-4">
+      <CanvasCard
+        v-for="canvas in filtered"
+        :key="canvas.id"
+        :canvas="canvas"
+        class="w-full"
+        @rename="rename"
+      />
+    </div>
+
+    <div v-else class="text-center py-8 text-muted-foreground">
+      <p class="text-sm">{{ t('canvases.search.noResults') }}</p>
+    </div>
   </div>
 </template>

--- a/web/src/views/library/layers/Layers.vue
+++ b/web/src/views/library/layers/Layers.vue
@@ -10,17 +10,48 @@
 import { computed, onMounted, ref } from 'vue'
 import { storeToRefs } from 'pinia'
 import { useI18n } from 'vue-i18n'
-import { Layers3Icon, StoreIcon } from 'lucide-vue-next'
+import { useRouter } from 'vue-router'
+import {
+  FolderIcon,
+  Layers3Icon,
+  LayersIcon,
+  PlusIcon,
+  StoreIcon,
+} from 'lucide-vue-next'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
 import { Spinner } from '@/components/ui/spinner'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu'
+import { AppRoute } from '@/router'
+import { useAppService } from '@/services/app.service'
 import { useLayersStore } from '@/stores/layers.store'
 import Layers from '@/components/map/Layers.vue'
 import LayerStoreDialog from '@/components/map/layers/LayerStoreDialog.vue'
+import LayerGroupConfiguration from '@/components/map/layers/LayerGroupConfiguration.vue'
 
 const { t } = useI18n()
+const router = useRouter()
+const appService = useAppService()
 const layersStore = useLayersStore()
 const { mainReorderableItems } = storeToRefs(layersStore)
+
+// The layer editor is a sheet view, not a dialog: it renders the draft on
+// the live map while you edit, which a modal over the map cannot do.
+function newLayer() {
+  router.push({ name: AppRoute.LAYER_EDITOR_NEW })
+}
+
+function newGroup() {
+  appService.componentDialog({
+    component: LayerGroupConfiguration,
+    continueText: t('general.save'),
+  })
+}
 
 const loading = ref(mainReorderableItems.value.length === 0)
 const storeOpen = ref(false)
@@ -52,8 +83,40 @@ const isEmpty = computed(
         {{ t('layers.store.title') }}
       </Button>
     </EmptyState>
-    <LayerStoreDialog v-model:open="storeOpen" />
   </div>
 
-  <Layers v-else />
+  <div v-else class="h-full flex flex-col gap-2">
+    <div class="flex items-center justify-end gap-2">
+      <Button
+        variant="outline"
+        size="icon"
+        class="h-10 w-10"
+        :aria-label="t('layers.store.title')"
+        :title="t('layers.store.title')"
+        @click="storeOpen = true"
+      >
+        <StoreIcon class="h-4 w-4" />
+      </Button>
+      <DropdownMenu>
+        <DropdownMenuTrigger as-child>
+          <Button variant="outline" size="icon" class="h-10 w-10">
+            <PlusIcon class="h-4 w-4" />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end">
+          <DropdownMenuItem @click="newLayer">
+            <LayersIcon class="size-4" />
+            {{ t('layers.actions.newLayer') }}
+          </DropdownMenuItem>
+          <DropdownMenuItem @click="newGroup">
+            <FolderIcon class="size-4" />
+            {{ t('layers.actions.newGroup') }}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+    <Layers class="flex-1 min-h-0" />
+  </div>
+
+  <LayerStoreDialog v-model:open="storeOpen" />
 </template>

--- a/web/src/views/library/layers/Layers.vue
+++ b/web/src/views/library/layers/Layers.vue
@@ -16,10 +16,12 @@ import {
   Layers3Icon,
   LayersIcon,
   PlusIcon,
+  SearchIcon,
   StoreIcon,
 } from 'lucide-vue-next'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
 import { Spinner } from '@/components/ui/spinner'
 import {
   DropdownMenu,
@@ -55,6 +57,7 @@ function newGroup() {
 
 const loading = ref(mainReorderableItems.value.length === 0)
 const storeOpen = ref(false)
+const searchQuery = ref('')
 
 onMounted(async () => {
   await layersStore.loadLayers()
@@ -86,7 +89,17 @@ const isEmpty = computed(
   </div>
 
   <div v-else class="h-full flex flex-col gap-2">
-    <div class="flex items-center justify-end gap-2">
+    <div class="flex items-center gap-2">
+      <div class="relative flex-1">
+        <SearchIcon
+          class="absolute left-2.5 top-3 size-4 text-muted-foreground"
+        />
+        <Input
+          v-model="searchQuery"
+          class="w-full pl-8"
+          :placeholder="t('layers.search.placeholder')"
+        />
+      </div>
       <Button
         variant="outline"
         size="icon"
@@ -115,7 +128,7 @@ const isEmpty = computed(
         </DropdownMenuContent>
       </DropdownMenu>
     </div>
-    <Layers class="flex-1 min-h-0" />
+    <Layers class="flex-1 min-h-0" :filter="searchQuery" />
   </div>
 
   <LayerStoreDialog v-model:open="storeOpen" />


### PR DESCRIPTION
Two related library-panel changes.

### 1. Move the layers tab's action buttons into the content
The **Layers** tab's add and store buttons were teleported into the tab strip, where they overlapped the **Canvases** tab on narrow widths. They now sit in a right-aligned header row above the list, matching the **Routes** tab.

### 2. Add a search box to the Layers and Canvases tabs
Both tabs get a search input in that header row, reusing the Routes search pattern.

- **Canvases** filters its list by name, and its add button moves out of the tab strip into the header too — retiring the last user of the `#library-tab-actions` teleport target, which is removed from `Library.vue`.
- **Layers** is a nested tree, so matching lives in `lib/layer-search.ts` and is shared by the list and each group: a group shows when its own name matches (revealing all its layers) or when a layer inside it matches (revealing only those). Matching groups auto-expand, and reordering is disabled while a search is active. Clearing the box restores the tree and its collapsed state.

New i18n keys (`layers.search`, `canvases.search`) added to en-US and es-ES.

Verified with `vue-tsc` (clean) and in the running app: layers filtering by group name and by nested layer name, the no-results state, and the canvases search box + relocated add button.