### PR TITLE
Rider-friendly transit subtitles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### Fixed
 
+* Transit search results describe themselves the way a rider would — "MTA New York City Transit · Subway line", "Commuter rail line", "Shuttle bus route" — instead of a bare lowercase mode word
+
 ## [0.10.0] - 2026-09-04
 
 ### Added

--- a/server/src/lib/transit-mode-label.test.ts
+++ b/server/src/lib/transit-mode-label.test.ts
@@ -1,0 +1,49 @@
+import { describe, test, expect } from 'bun:test'
+import { transitLineSubtitle, transitModeLabel, transitStopLabel } from './transit-mode-label'
+
+describe('transitLineSubtitle', () => {
+  test('names the mode like a rider would', () => {
+    expect(transitLineSubtitle(1, 'subway', 'MTA New York City Transit'))
+      .toBe('MTA New York City Transit · Subway line')
+    expect(transitLineSubtitle(4, 'ferry', 'NYC Ferry'))
+      .toBe('NYC Ferry · Ferry line')
+  })
+
+  test('a feed with no agency still gets a readable subtitle', () => {
+    // LIRR's feed names no agency; the old subtitle was the bare word "rail".
+    expect(transitLineSubtitle(2, 'rail', null)).toBe('Commuter rail line')
+  })
+
+  test('intercity carriers are not commuter rail', () => {
+    expect(transitLineSubtitle(2, 'rail', 'Amtrak')).toBe('Amtrak · Intercity rail line')
+    expect(transitLineSubtitle(2, 'rail', 'Via Rail Canada')).toBe('Via Rail Canada · Intercity rail line')
+    expect(transitLineSubtitle(2, 'rail', 'Metro-North Railroad')).toBe('Metro-North Railroad · Commuter rail line')
+  })
+
+  test('extended codes refine the label', () => {
+    expect(transitModeLabel(711, 'bus', 'MTA New York City Transit')).toBe('Shuttle bus route')
+    expect(transitModeLabel(702, 'bus', null)).toBe('Express bus route')
+    expect(transitModeLabel(109, 'rail', null)).toBe('Commuter rail line')
+  })
+
+  test('buses run routes, rail runs lines', () => {
+    expect(transitModeLabel(3, 'bus', null)).toBe('Bus route')
+    expect(transitModeLabel(0, 'tram', null)).toBe('Light rail line')
+  })
+
+  test('falls back to the coarse mode when the code is unknown', () => {
+    expect(transitModeLabel(null, 'subway', null)).toBe('Subway line')
+    expect(transitModeLabel(9999, 'ferry', null)).toBe('Ferry line')
+    expect(transitModeLabel(null, null, null)).toBe('Transit line')
+  })
+})
+
+describe('transitStopLabel', () => {
+  test('stations, stops and terminals by mode', () => {
+    expect(transitStopLabel('subway')).toBe('Subway station')
+    expect(transitStopLabel('rail')).toBe('Train station')
+    expect(transitStopLabel('bus')).toBe('Bus stop')
+    expect(transitStopLabel('ferry')).toBe('Ferry terminal')
+    expect(transitStopLabel(null)).toBe('Transit stop')
+  })
+})

--- a/server/src/lib/transit-mode-label.ts
+++ b/server/src/lib/transit-mode-label.ts
@@ -1,0 +1,104 @@
+/**
+ * A rider-friendly label for a GTFS route, from its route_type (basic 0-12 or
+ * the extended European codes) with the agency as a tiebreaker where one code
+ * covers two different things riders distinguish — GTFS files LIRR and Amtrak
+ * both as plain 2, but "Commuter rail" and "Intercity rail" are different
+ * promises about a trip.
+ */
+
+/** Agencies whose plain type-2 routes are intercity, not commuter, service. */
+const INTERCITY_AGENCIES = /amtrak|via rail|flixtrain|brightline/i
+
+function baseLabel(routeType: number | null | undefined, mode: string | null | undefined, agency: string | null | undefined): string {
+  const rt = routeType ?? -1
+  switch (rt) {
+    case 0: return 'Light rail'
+    case 1: return 'Subway'
+    case 2: return agency && INTERCITY_AGENCIES.test(agency) ? 'Intercity rail' : 'Commuter rail'
+    case 3: return 'Bus'
+    case 4: return 'Ferry'
+    case 5: return 'Cable car'
+    case 6: return 'Aerial tram'
+    case 7: return 'Funicular'
+    case 11: return 'Trolleybus'
+    case 12: return 'Monorail'
+  }
+  if (rt >= 100 && rt < 200) {
+    if (rt === 101 || rt === 102) return 'Intercity rail'
+    if (rt === 109) return 'Commuter rail'
+    return 'Train'
+  }
+  if (rt >= 200 && rt < 300) return 'Coach'
+  if (rt >= 400 && rt < 500) return 'Metro'
+  if (rt >= 700 && rt < 800) {
+    if (rt === 702) return 'Express bus'
+    if (rt === 711) return 'Shuttle bus'
+    if (rt === 712) return 'School bus'
+    return 'Bus'
+  }
+  if (rt === 800) return 'Trolleybus'
+  if (rt >= 900 && rt < 1000) return 'Tram'
+  if (rt >= 1000 && rt < 1100) return 'Ferry'
+  if (rt >= 1300 && rt < 1400) return 'Aerial tram'
+  if (rt === 1400) return 'Funicular'
+
+  // No usable code — fall back to barrelman's coarse mode word.
+  switch (mode) {
+    case 'subway': return 'Subway'
+    case 'rail': return 'Commuter rail'
+    case 'tram': return 'Light rail'
+    case 'bus': return 'Bus'
+    case 'ferry': return 'Ferry'
+    case 'trolleybus': return 'Trolleybus'
+    case 'monorail': return 'Monorail'
+    case 'funicular': return 'Funicular'
+    case 'gondola': case 'cable_car': return 'Aerial tram'
+    default: return 'Transit'
+  }
+}
+
+/** Buses run routes; everything on rails or water runs lines. */
+function noun(label: string): string {
+  return /bus|coach/i.test(label) ? 'route' : 'line'
+}
+
+/**
+ * The label alone: "Subway line", "Commuter rail line", "Shuttle bus route".
+ */
+export function transitModeLabel(
+  routeType: number | null | undefined,
+  mode: string | null | undefined,
+  agency?: string | null,
+): string {
+  const label = baseLabel(routeType, mode, agency)
+  return `${label} ${noun(label)}`
+}
+
+/**
+ * What to call the place a route stops: rail modes have stations, buses have
+ * stops, ferries have terminals.
+ */
+export function transitStopLabel(mode: string | null | undefined): string {
+  switch (mode) {
+    case 'subway': return 'Subway station'
+    case 'rail': return 'Train station'
+    case 'tram': return 'Light rail station'
+    case 'monorail': return 'Monorail station'
+    case 'ferry': return 'Ferry terminal'
+    case 'bus': case 'trolleybus': return 'Bus stop'
+    default: return 'Transit stop'
+  }
+}
+
+/**
+ * The search-result subtitle: "MTA New York City Transit · Subway line", or
+ * just "Commuter rail line" for a feed that names no agency (LIRR's doesn't).
+ */
+export function transitLineSubtitle(
+  routeType: number | null | undefined,
+  mode: string | null | undefined,
+  agency?: string | null,
+): string {
+  const label = transitModeLabel(routeType, mode, agency)
+  return agency ? `${agency} · ${label}` : label
+}

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -53,6 +53,7 @@ import { getPlaceType, getLocalizedName } from '../../lib/place.utils'
 import { parseOsmHours } from '../../lib/hours.utils'
 import { isPermanentlyClosedByOsmTags } from '../../lib/osm-lifecycle'
 import { getTimezone } from '../../lib/timezone'
+import { transitLineSubtitle, transitModeLabel, transitStopLabel } from '../../lib/transit-mode-label'
 
 /**
  * All Barrelman HTTP traffic flows through one bounded connection pool.
@@ -810,7 +811,7 @@ export class BarrelmanIntegration
       name: { value: r.name ?? null, sourceId, timestamp },
       description: null,
       placeType: {
-        value: isLine ? 'Transit line' : 'Transit stop',
+        value: isLine ? transitModeLabel(t.routeType, mode, t.agency) : transitStopLabel(mode),
         sourceId,
         timestamp,
       },
@@ -826,7 +827,7 @@ export class BarrelmanIntegration
       amenities: {},
       tags: {},
       summary: isLine
-        ? [t.agency, mode ? mode.replace(/_/g, ' ') : null].filter(Boolean).join(' · ') || null
+        ? transitLineSubtitle(t.routeType, mode, t.agency)
         : null,
       transitLine: line,
       transitStop: stop,


### PR DESCRIPTION
Search subtitles for transit hits now read the way a rider talks, built from route_type (basic + extended GTFS codes) with agency as tiebreaker — surveyed against every route_type actually present in production:

- "MTA New York City Transit · Subway line" (was "… · subway")
- "Commuter rail line" for LIRR, whose feed names no agency (was the bare word "rail")
- "Amtrak · Intercity rail line" vs "Metro-North Railroad · Commuter rail line" — same GTFS code 2, different promises
- "Shuttle bus route" for the MTA's 260 extended-code-711 routes; buses run *routes*, rail runs *lines*
- Stops get the same treatment: "Subway station", "Bus stop", "Ferry terminal" instead of "Transit stop"

Server-only (label engine in `server/src/lib/transit-mode-label.ts`, unit-tested); no barrelman change needed.