### PR TITLE
Localize the transit labels

### DIFF
--- a/server/src/lib/i18n/locales/en-US.json
+++ b/server/src/lib/i18n/locales/en-US.json
@@ -363,5 +363,37 @@
   "info": {
     "warning": "Warning",
     "notice": "Notice"
+  },
+  "transit": {
+    "label": {
+      "lightRail": "Light rail line",
+      "subway": "Subway line",
+      "commuterRail": "Commuter rail line",
+      "intercityRail": "Intercity rail line",
+      "train": "Train line",
+      "bus": "Bus route",
+      "coach": "Coach route",
+      "expressBus": "Express bus route",
+      "shuttleBus": "Shuttle bus route",
+      "schoolBus": "School bus route",
+      "metro": "Metro line",
+      "ferry": "Ferry line",
+      "cableCar": "Cable car line",
+      "aerialTram": "Aerial tram line",
+      "funicular": "Funicular line",
+      "trolleybus": "Trolleybus route",
+      "monorail": "Monorail line",
+      "tram": "Tram line",
+      "transit": "Transit line"
+    },
+    "stop": {
+      "subwayStation": "Subway station",
+      "trainStation": "Train station",
+      "lightRailStation": "Light rail station",
+      "monorailStation": "Monorail station",
+      "ferryTerminal": "Ferry terminal",
+      "busStop": "Bus stop",
+      "transitStop": "Transit stop"
+    }
   }
 }

--- a/server/src/lib/i18n/locales/es-ES.json
+++ b/server/src/lib/i18n/locales/es-ES.json
@@ -363,5 +363,37 @@
   "info": {
     "warning": "Aviso",
     "notice": "Aviso"
+  },
+  "transit": {
+    "label": {
+      "lightRail": "Línea de tren ligero",
+      "subway": "Línea de metro",
+      "commuterRail": "Línea de cercanías",
+      "intercityRail": "Línea de tren interurbano",
+      "train": "Línea de tren",
+      "bus": "Ruta de autobús",
+      "coach": "Ruta de autocar",
+      "expressBus": "Ruta de autobús exprés",
+      "shuttleBus": "Ruta de autobús lanzadera",
+      "schoolBus": "Ruta de autobús escolar",
+      "metro": "Línea de metro",
+      "ferry": "Línea de ferri",
+      "cableCar": "Línea de tranvía de cable",
+      "aerialTram": "Línea de teleférico",
+      "funicular": "Línea de funicular",
+      "trolleybus": "Ruta de trolebús",
+      "monorail": "Línea de monorraíl",
+      "tram": "Línea de tranvía",
+      "transit": "Línea de transporte público"
+    },
+    "stop": {
+      "subwayStation": "Estación de metro",
+      "trainStation": "Estación de tren",
+      "lightRailStation": "Estación de tren ligero",
+      "monorailStation": "Estación de monorraíl",
+      "ferryTerminal": "Terminal de ferri",
+      "busStop": "Parada de autobús",
+      "transitStop": "Parada de transporte público"
+    }
   }
 }

--- a/server/src/lib/transit-mode-label.test.ts
+++ b/server/src/lib/transit-mode-label.test.ts
@@ -1,5 +1,10 @@
-import { describe, test, expect } from 'bun:test'
+import { describe, test, expect, beforeAll } from 'bun:test'
+import { initialization } from './i18n/translate'
 import { transitLineSubtitle, transitModeLabel, transitStopLabel } from './transit-mode-label'
+
+beforeAll(async () => {
+  await initialization
+})
 
 describe('transitLineSubtitle', () => {
   test('names the mode like a rider would', () => {
@@ -18,6 +23,13 @@ describe('transitLineSubtitle', () => {
     expect(transitLineSubtitle(2, 'rail', 'Amtrak')).toBe('Amtrak · Intercity rail line')
     expect(transitLineSubtitle(2, 'rail', 'Via Rail Canada')).toBe('Via Rail Canada · Intercity rail line')
     expect(transitLineSubtitle(2, 'rail', 'Metro-North Railroad')).toBe('Metro-North Railroad · Commuter rail line')
+  })
+
+  test('labels are localized; agency names ride along unchanged', () => {
+    expect(transitLineSubtitle(1, 'subway', 'MTA New York City Transit', 'es-ES'))
+      .toBe('MTA New York City Transit · Línea de metro')
+    expect(transitLineSubtitle(2, 'rail', null, 'es-ES')).toBe('Línea de cercanías')
+    expect(transitModeLabel(3, 'bus', null, 'es-ES')).toBe('Ruta de autobús')
   })
 
   test('extended codes refine the label', () => {
@@ -45,5 +57,10 @@ describe('transitStopLabel', () => {
     expect(transitStopLabel('bus')).toBe('Bus stop')
     expect(transitStopLabel('ferry')).toBe('Ferry terminal')
     expect(transitStopLabel(null)).toBe('Transit stop')
+  })
+
+  test('in Spanish too', () => {
+    expect(transitStopLabel('subway', 'es-ES')).toBe('Estación de metro')
+    expect(transitStopLabel('bus', 'es-ES')).toBe('Parada de autobús')
   })
 })

--- a/server/src/lib/transit-mode-label.ts
+++ b/server/src/lib/transit-mode-label.ts
@@ -4,62 +4,66 @@
  * covers two different things riders distinguish — GTFS files LIRR and Amtrak
  * both as plain 2, but "Commuter rail" and "Intercity rail" are different
  * promises about a trip.
+ *
+ * Labels resolve to i18n keys under `transit.*` and are stored as complete
+ * phrases per language ("Subway line" / "Línea de metro") rather than
+ * composed from parts — word order and casing don't survive composition
+ * across languages. The agency name is a proper noun and rides alongside
+ * unchanged.
  */
+
+import { DEFAULT_LANGUAGE, type Language } from './i18n'
+import { translate } from './i18n/translate'
 
 /** Agencies whose plain type-2 routes are intercity, not commuter, service. */
 const INTERCITY_AGENCIES = /amtrak|via rail|flixtrain|brightline/i
 
-function baseLabel(routeType: number | null | undefined, mode: string | null | undefined, agency: string | null | undefined): string {
+function labelKey(routeType: number | null | undefined, mode: string | null | undefined, agency: string | null | undefined): string {
   const rt = routeType ?? -1
   switch (rt) {
-    case 0: return 'Light rail'
-    case 1: return 'Subway'
-    case 2: return agency && INTERCITY_AGENCIES.test(agency) ? 'Intercity rail' : 'Commuter rail'
-    case 3: return 'Bus'
-    case 4: return 'Ferry'
-    case 5: return 'Cable car'
-    case 6: return 'Aerial tram'
-    case 7: return 'Funicular'
-    case 11: return 'Trolleybus'
-    case 12: return 'Monorail'
+    case 0: return 'lightRail'
+    case 1: return 'subway'
+    case 2: return agency && INTERCITY_AGENCIES.test(agency) ? 'intercityRail' : 'commuterRail'
+    case 3: return 'bus'
+    case 4: return 'ferry'
+    case 5: return 'cableCar'
+    case 6: return 'aerialTram'
+    case 7: return 'funicular'
+    case 11: return 'trolleybus'
+    case 12: return 'monorail'
   }
   if (rt >= 100 && rt < 200) {
-    if (rt === 101 || rt === 102) return 'Intercity rail'
-    if (rt === 109) return 'Commuter rail'
-    return 'Train'
+    if (rt === 101 || rt === 102) return 'intercityRail'
+    if (rt === 109) return 'commuterRail'
+    return 'train'
   }
-  if (rt >= 200 && rt < 300) return 'Coach'
-  if (rt >= 400 && rt < 500) return 'Metro'
+  if (rt >= 200 && rt < 300) return 'coach'
+  if (rt >= 400 && rt < 500) return 'metro'
   if (rt >= 700 && rt < 800) {
-    if (rt === 702) return 'Express bus'
-    if (rt === 711) return 'Shuttle bus'
-    if (rt === 712) return 'School bus'
-    return 'Bus'
+    if (rt === 702) return 'expressBus'
+    if (rt === 711) return 'shuttleBus'
+    if (rt === 712) return 'schoolBus'
+    return 'bus'
   }
-  if (rt === 800) return 'Trolleybus'
-  if (rt >= 900 && rt < 1000) return 'Tram'
-  if (rt >= 1000 && rt < 1100) return 'Ferry'
-  if (rt >= 1300 && rt < 1400) return 'Aerial tram'
-  if (rt === 1400) return 'Funicular'
+  if (rt === 800) return 'trolleybus'
+  if (rt >= 900 && rt < 1000) return 'tram'
+  if (rt >= 1000 && rt < 1100) return 'ferry'
+  if (rt >= 1300 && rt < 1400) return 'aerialTram'
+  if (rt === 1400) return 'funicular'
 
   // No usable code — fall back to barrelman's coarse mode word.
   switch (mode) {
-    case 'subway': return 'Subway'
-    case 'rail': return 'Commuter rail'
-    case 'tram': return 'Light rail'
-    case 'bus': return 'Bus'
-    case 'ferry': return 'Ferry'
-    case 'trolleybus': return 'Trolleybus'
-    case 'monorail': return 'Monorail'
-    case 'funicular': return 'Funicular'
-    case 'gondola': case 'cable_car': return 'Aerial tram'
-    default: return 'Transit'
+    case 'subway': return 'subway'
+    case 'rail': return 'commuterRail'
+    case 'tram': return 'lightRail'
+    case 'bus': return 'bus'
+    case 'ferry': return 'ferry'
+    case 'trolleybus': return 'trolleybus'
+    case 'monorail': return 'monorail'
+    case 'funicular': return 'funicular'
+    case 'gondola': case 'cable_car': return 'aerialTram'
+    default: return 'transit'
   }
-}
-
-/** Buses run routes; everything on rails or water runs lines. */
-function noun(label: string): string {
-  return /bus|coach/i.test(label) ? 'route' : 'line'
 }
 
 /**
@@ -69,25 +73,31 @@ export function transitModeLabel(
   routeType: number | null | undefined,
   mode: string | null | undefined,
   agency?: string | null,
+  language: Language = DEFAULT_LANGUAGE,
 ): string {
-  const label = baseLabel(routeType, mode, agency)
-  return `${label} ${noun(label)}`
+  return translate(language)(`transit.label.${labelKey(routeType, mode, agency)}`)
 }
 
 /**
  * What to call the place a route stops: rail modes have stations, buses have
  * stops, ferries have terminals.
  */
-export function transitStopLabel(mode: string | null | undefined): string {
-  switch (mode) {
-    case 'subway': return 'Subway station'
-    case 'rail': return 'Train station'
-    case 'tram': return 'Light rail station'
-    case 'monorail': return 'Monorail station'
-    case 'ferry': return 'Ferry terminal'
-    case 'bus': case 'trolleybus': return 'Bus stop'
-    default: return 'Transit stop'
-  }
+export function transitStopLabel(
+  mode: string | null | undefined,
+  language: Language = DEFAULT_LANGUAGE,
+): string {
+  const key = (() => {
+    switch (mode) {
+      case 'subway': return 'subwayStation'
+      case 'rail': return 'trainStation'
+      case 'tram': return 'lightRailStation'
+      case 'monorail': return 'monorailStation'
+      case 'ferry': return 'ferryTerminal'
+      case 'bus': case 'trolleybus': return 'busStop'
+      default: return 'transitStop'
+    }
+  })()
+  return translate(language)(`transit.stop.${key}`)
 }
 
 /**
@@ -98,7 +108,8 @@ export function transitLineSubtitle(
   routeType: number | null | undefined,
   mode: string | null | undefined,
   agency?: string | null,
+  language: Language = DEFAULT_LANGUAGE,
 ): string {
-  const label = transitModeLabel(routeType, mode, agency)
+  const label = transitModeLabel(routeType, mode, agency, language)
   return agency ? `${agency} · ${label}` : label
 }

--- a/server/src/lib/transit-mode-label.ts
+++ b/server/src/lib/transit-mode-label.ts
@@ -18,51 +18,51 @@ import { translate } from './i18n/translate'
 /** Agencies whose plain type-2 routes are intercity, not commuter, service. */
 const INTERCITY_AGENCIES = /amtrak|via rail|flixtrain|brightline/i
 
-function labelKey(routeType: number | null | undefined, mode: string | null | undefined, agency: string | null | undefined): string {
+function labelKey(routeType: number | null | undefined, mode: string | null | undefined, agency: string | null | undefined) {
   const rt = routeType ?? -1
   switch (rt) {
-    case 0: return 'lightRail'
-    case 1: return 'subway'
-    case 2: return agency && INTERCITY_AGENCIES.test(agency) ? 'intercityRail' : 'commuterRail'
-    case 3: return 'bus'
-    case 4: return 'ferry'
-    case 5: return 'cableCar'
-    case 6: return 'aerialTram'
-    case 7: return 'funicular'
-    case 11: return 'trolleybus'
-    case 12: return 'monorail'
+    case 0: return 'transit.label.lightRail'
+    case 1: return 'transit.label.subway'
+    case 2: return agency && INTERCITY_AGENCIES.test(agency) ? 'transit.label.intercityRail' : 'transit.label.commuterRail'
+    case 3: return 'transit.label.bus'
+    case 4: return 'transit.label.ferry'
+    case 5: return 'transit.label.cableCar'
+    case 6: return 'transit.label.aerialTram'
+    case 7: return 'transit.label.funicular'
+    case 11: return 'transit.label.trolleybus'
+    case 12: return 'transit.label.monorail'
   }
   if (rt >= 100 && rt < 200) {
-    if (rt === 101 || rt === 102) return 'intercityRail'
-    if (rt === 109) return 'commuterRail'
-    return 'train'
+    if (rt === 101 || rt === 102) return 'transit.label.intercityRail'
+    if (rt === 109) return 'transit.label.commuterRail'
+    return 'transit.label.train'
   }
-  if (rt >= 200 && rt < 300) return 'coach'
-  if (rt >= 400 && rt < 500) return 'metro'
+  if (rt >= 200 && rt < 300) return 'transit.label.coach'
+  if (rt >= 400 && rt < 500) return 'transit.label.metro'
   if (rt >= 700 && rt < 800) {
-    if (rt === 702) return 'expressBus'
-    if (rt === 711) return 'shuttleBus'
-    if (rt === 712) return 'schoolBus'
-    return 'bus'
+    if (rt === 702) return 'transit.label.expressBus'
+    if (rt === 711) return 'transit.label.shuttleBus'
+    if (rt === 712) return 'transit.label.schoolBus'
+    return 'transit.label.bus'
   }
-  if (rt === 800) return 'trolleybus'
-  if (rt >= 900 && rt < 1000) return 'tram'
-  if (rt >= 1000 && rt < 1100) return 'ferry'
-  if (rt >= 1300 && rt < 1400) return 'aerialTram'
-  if (rt === 1400) return 'funicular'
+  if (rt === 800) return 'transit.label.trolleybus'
+  if (rt >= 900 && rt < 1000) return 'transit.label.tram'
+  if (rt >= 1000 && rt < 1100) return 'transit.label.ferry'
+  if (rt >= 1300 && rt < 1400) return 'transit.label.aerialTram'
+  if (rt === 1400) return 'transit.label.funicular'
 
   // No usable code — fall back to barrelman's coarse mode word.
   switch (mode) {
-    case 'subway': return 'subway'
-    case 'rail': return 'commuterRail'
-    case 'tram': return 'lightRail'
-    case 'bus': return 'bus'
-    case 'ferry': return 'ferry'
-    case 'trolleybus': return 'trolleybus'
-    case 'monorail': return 'monorail'
-    case 'funicular': return 'funicular'
-    case 'gondola': case 'cable_car': return 'aerialTram'
-    default: return 'transit'
+    case 'subway': return 'transit.label.subway'
+    case 'rail': return 'transit.label.commuterRail'
+    case 'tram': return 'transit.label.lightRail'
+    case 'bus': return 'transit.label.bus'
+    case 'ferry': return 'transit.label.ferry'
+    case 'trolleybus': return 'transit.label.trolleybus'
+    case 'monorail': return 'transit.label.monorail'
+    case 'funicular': return 'transit.label.funicular'
+    case 'gondola': case 'cable_car': return 'transit.label.aerialTram'
+    default: return 'transit.label.transit'
   }
 }
 
@@ -75,7 +75,7 @@ export function transitModeLabel(
   agency?: string | null,
   language: Language = DEFAULT_LANGUAGE,
 ): string {
-  return translate(language)(`transit.label.${labelKey(routeType, mode, agency)}`)
+  return translate(language)(labelKey(routeType, mode, agency))
 }
 
 /**
@@ -88,16 +88,16 @@ export function transitStopLabel(
 ): string {
   const key = (() => {
     switch (mode) {
-      case 'subway': return 'subwayStation'
-      case 'rail': return 'trainStation'
-      case 'tram': return 'lightRailStation'
-      case 'monorail': return 'monorailStation'
-      case 'ferry': return 'ferryTerminal'
-      case 'bus': case 'trolleybus': return 'busStop'
-      default: return 'transitStop'
+      case 'subway': return 'transit.stop.subwayStation'
+      case 'rail': return 'transit.stop.trainStation'
+      case 'tram': return 'transit.stop.lightRailStation'
+      case 'monorail': return 'transit.stop.monorailStation'
+      case 'ferry': return 'transit.stop.ferryTerminal'
+      case 'bus': case 'trolleybus': return 'transit.stop.busStop'
+      default: return 'transit.stop.transitStop'
     }
   })()
-  return translate(language)(`transit.stop.${key}`)
+  return translate(language)(key)
 }
 
 /**

--- a/server/src/services/integrations/barrelman-integration.ts
+++ b/server/src/services/integrations/barrelman-integration.ts
@@ -761,7 +761,7 @@ export class BarrelmanIntegration
    * `transitStop` is what tells the rest of the pipeline (and the client)
    * that this row opens in the transit views, not the place detail view.
    */
-  private adaptTransitHit(r: BarrelmanPlaceResult): Place {
+  private adaptTransitHit(r: BarrelmanPlaceResult, language: Language = DEFAULT_LANGUAGE): Place {
     const timestamp = new Date().toISOString()
     const t = r.transit ?? ({} as NonNullable<BarrelmanPlaceResult['transit']>)
     const center = r.geometry?.coordinates
@@ -811,7 +811,9 @@ export class BarrelmanIntegration
       name: { value: r.name ?? null, sourceId, timestamp },
       description: null,
       placeType: {
-        value: isLine ? transitModeLabel(t.routeType, mode, t.agency) : transitStopLabel(mode),
+        value: isLine
+          ? transitModeLabel(t.routeType, mode, t.agency, language)
+          : transitStopLabel(mode, language),
         sourceId,
         timestamp,
       },
@@ -827,7 +829,7 @@ export class BarrelmanIntegration
       amenities: {},
       tags: {},
       summary: isLine
-        ? transitLineSubtitle(t.routeType, mode, t.agency)
+        ? transitLineSubtitle(t.routeType, mode, t.agency, language)
         : null,
       transitLine: line,
       transitStop: stop,
@@ -861,7 +863,7 @@ export class BarrelmanIntegration
       { headers: this.headers, timeout: SEARCH_BACKSTOP_TIMEOUT, signal: options?.signal },
     )
     return (response.data || []).map((r: any) =>
-      r.kind ? this.adaptTransitHit(r) : this.adaptPlace(r, options?.language))
+      r.kind ? this.adaptTransitHit(r, options?.language) : this.adaptPlace(r, options?.language))
   }
 
   async getAutocomplete(
@@ -893,7 +895,7 @@ export class BarrelmanIntegration
       { headers: this.headers, timeout: SEARCH_BACKSTOP_TIMEOUT, signal: options?.signal },
     )
     return (response.data || []).map((r: any) =>
-      r.kind ? this.adaptTransitHit(r) : this.adaptPlace(r, options?.language))
+      r.kind ? this.adaptTransitHit(r, options?.language) : this.adaptPlace(r, options?.language))
   }
 
   /**


### PR DESCRIPTION
Follow-up to #455 — the two i18n commits were pushed after that PR was merged, so dev got the friendly labels hardcoded in English. This moves them into the server i18n catalog (en-US + es-ES, full phrases per language since word order inverts — "Subway line" / "Línea de metro"), threads the request language through `adaptTransitHit`, and uses literal translation keys so the catalog type-checks them.