### PR TITLE
Remove unused map theme setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+* Removed the non-functional "map theme" dropdown from appearance settings.
+
 ### Fixed
 
 ## [0.10.1] - 2026-09-04

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -1775,17 +1775,6 @@
             "dark": "Dark"
           }
         }
-      },
-      "mapTheme": {
-        "title": "Map theme",
-        "values": {
-          "matchTime": "Match app theme and time of day",
-          "match": "Match app theme",
-          "day": "Day",
-          "night": "Night",
-          "dawn": "Dawn",
-          "dusk": "Dusk"
-        }
       }
     },
     "mapSettings": {

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -1690,17 +1690,6 @@
             "dark": "Oscuro"
           }
         }
-      },
-      "mapTheme": {
-        "title": "Tema del mapa",
-        "values": {
-          "matchTime": "Coincidir con el tema de la aplicación y la hora del día",
-          "match": "Coincidir con el tema de la aplicación",
-          "day": "Día",
-          "night": "Noche",
-          "dawn": "Amanecer",
-          "dusk": "Atardecer"
-        }
       }
     },
     "mapSettings": {

--- a/web/src/views/settings/pages/appearance/Appearance.vue
+++ b/web/src/views/settings/pages/appearance/Appearance.vue
@@ -36,8 +36,6 @@ import { useI18n } from 'vue-i18n'
 import { SettingsSection, SettingsItem } from '@/components/settings'
 import Layers from '@/components/map/Layers.vue'
 
-const mapTheme = ref('auto')
-
 // Theme store
 const themeStore = useThemeStore()
 const { isDark, accentColor, radius } = storeToRefs(themeStore)
@@ -138,41 +136,6 @@ const handleColorChange = (value: any) => {
             <SelectItem value="dark">
               {{ $t('settings.appearance.appTheme.theme.values.dark') }}
             </SelectItem>
-          </SelectContent>
-        </Select>
-      </SettingsItem>
-    </SettingsSection>
-
-    <SettingsSection
-      id="map-theme"
-      :title="$t('settings.appearance.mapTheme.title')"
-    >
-      <SettingsItem :title="$t('settings.appearance.mapTheme.title')">
-        <Select v-model="mapTheme">
-          <SelectTrigger class="w-fit">
-            <SelectValue placeholder="Choose an option" />
-          </SelectTrigger>
-          <SelectContent>
-            <SelectGroup>
-              <SelectItem value="auto">
-                {{ $t('settings.appearance.mapTheme.values.matchTime') }}
-              </SelectItem>
-              <SelectItem value="match">{{
-                $t('settings.appearance.mapTheme.values.match')
-              }}</SelectItem>
-              <SelectItem value="light">{{
-                $t('settings.appearance.mapTheme.values.day')
-              }}</SelectItem>
-              <SelectItem value="dark">{{
-                $t('settings.appearance.mapTheme.values.night')
-              }}</SelectItem>
-              <SelectItem value="dawn">{{
-                $t('settings.appearance.mapTheme.values.dawn')
-              }}</SelectItem>
-              <SelectItem value="dusk">{{
-                $t('settings.appearance.mapTheme.values.dusk')
-              }}</SelectItem>
-            </SelectGroup>
           </SelectContent>
         </Select>
       </SettingsItem>

--- a/web/src/views/settings/settingsIndex.ts
+++ b/web/src/views/settings/settingsIndex.ts
@@ -210,11 +210,6 @@ export const settingsIndex: SettingsPageDef[] = [
         ],
       },
       {
-        id: 'map-theme',
-        titleKey: 'settings.appearance.mapTheme.title',
-        keywords: ['day', 'night', 'dawn', 'dusk', 'time of day'],
-      },
-      {
         id: 'configuration',
         titleKey: 'settings.mapSettings.configuration.title',
         items: [


### PR DESCRIPTION
## Summary
* Removes the "Map theme" dropdown from Appearance settings — it was dead UI, bound only to a local, never-persisted ref and never wired into the map's actual theming.
* Cleans up the corresponding settings-search index entry and `en-US`/`es-ES` i18n strings.

The real day/night basemap switching (tied to the app's dark-mode toggle via `MapTheme` enum, `map.service.ts`, `mapbox.strategy.ts`, `maplibre.strategy.ts`) is untouched — that's a separate, working mechanism.

## Test plan
- [x] `bun run test` (via pre-commit hook)
- [ ] Manually confirm the Appearance settings page no longer shows "Map theme" and nothing else shifted