### PR TITLE
Show transit through buildings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Fixed
 
+* Transit lines show faintly through the buildings they pass behind again, instead of disappearing into the block.
+
 ## [0.10.1] - 2026-09-04
 
 ### Fixed

--- a/web/src/services/layers/features/portolan/portolan-anchors.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-anchors.test.ts
@@ -1,0 +1,36 @@
+import { describe, test, expect } from 'vitest'
+import { buildMapStyle, layerGroups } from '@/lib/map-style'
+import { firstLabelLayerId } from './portolan-anchors'
+
+const STACK = [
+  { id: 'Oneway', type: 'symbol' },
+  { id: 'Building', type: 'fill' },
+  { id: 'Building 3D', type: 'fill-extrusion' },
+  { id: 'River labels', type: 'symbol' },
+  { id: 'portolan-station-labels', type: 'symbol' },
+]
+
+describe('firstLabelLayerId', () => {
+  test('finds the basemap\'s first label layer, never one of ours', () => {
+    expect(firstLabelLayerId(STACK)).toBe('Oneway')
+    expect(firstLabelLayerId([{ id: 'portolan-cats', type: 'symbol' }])).toBeUndefined()
+  })
+
+  test('skips symbol layers drawn below the layer it must clear', () => {
+    expect(firstLabelLayerId(STACK, 'Building 3D')).toBe('River labels')
+  })
+
+  test('falls back to the whole stack when the layer to clear is absent', () => {
+    expect(firstLabelLayerId(STACK, 'Building 3D (mapbox)')).toBe('Oneway')
+  })
+
+  test('the real style has a label layer above the buildings for the ghost ribbon', () => {
+    // The ghost is the only thing that keeps a route readable where it passes
+    // behind a tower, and it only works anchored above the extrusion.
+    const layers = buildMapStyle({ tileServerUrl: 'https://example.test/tiles' } as any).layers
+    const anchor = firstLabelLayerId(layers, layerGroups.building3d)
+    expect(anchor).toBeTruthy()
+    const index = (id?: string) => layers.findIndex(l => l.id === id)
+    expect(index(anchor)).toBeGreaterThan(index(layerGroups.building3d))
+  })
+})

--- a/web/src/services/layers/features/portolan/portolan-anchors.ts
+++ b/web/src/services/layers/features/portolan/portolan-anchors.ts
@@ -1,0 +1,25 @@
+/**
+ * Where the overlay's layers slot into the basemap's stack — the pure half,
+ * so the ordering can be asserted against a layer list instead of a map.
+ */
+
+type StyleLayer = { id: string; type: string }
+
+/**
+ * The basemap's first label layer, optionally restricted to the layers drawn
+ * above `after`.
+ *
+ * The ghost ribbon passes the building layer here. Without it the search
+ * finds the style's oneway arrows — a symbol layer, but one drawn *below* the
+ * buildings — and the dimmed copy lands back underneath the towers it exists
+ * to show through, which reads as the route simply vanishing into the block.
+ */
+export function firstLabelLayerId(
+  layers: readonly StyleLayer[],
+  after?: string,
+): string | undefined {
+  const start = after ? layers.findIndex(l => l.id === after) + 1 : 0
+  return layers
+    .slice(start)
+    .find(l => l.type === 'symbol' && !l.id.startsWith('portolan-'))?.id
+}

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -78,6 +78,7 @@ import {
 import { cssFontFor, drawPortolanImage, estRows, estRowsFromAdvances } from './portolan-images'
 import { glyphAdvances } from './portolan-glyphs'
 import { TRANSIT_GROUP_ID, stopTargetFor } from './portolan-ui'
+import { firstLabelLayerId } from './portolan-anchors'
 
 const FLAG_KEY = 'parchment.portolan-transit'
 
@@ -556,12 +557,11 @@ let ribbonAnchor: string | undefined
  * The basemap's first label layer. Ribbons go UNDER it: a route drawn over
  * the street names and shop names it passes is ink on top of the map
  * rather than part of it, and the label is the thing a reader needs.
+ *
+ * `after` names a layer the anchor has to clear — see `firstLabelLayerId`.
  */
-function firstLabelLayer(): string | undefined {
-  for (const l of map?.getStyle?.()?.layers ?? []) {
-    if (l.type === 'symbol' && !l.id.startsWith('portolan-')) return l.id
-  }
-  return undefined
+function firstLabelLayer(after?: string): string | undefined {
+  return firstLabelLayerId(map?.getStyle?.()?.layers ?? [], after)
 }
 
 /**
@@ -682,7 +682,7 @@ function addRibbonLayer(spec: any, opacity: Expr, structural: Expr) {
         'line-opacity': ['*', opacity, OCCLUDED_OPACITY] as unknown as Expr,
       },
     },
-    ghostAnchorOr(labels),
+    ghostAnchorOr(firstLabelLayer(buildings)),
   )
 }
 

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -831,8 +831,6 @@ function addSourcesAndLayers(regions: PortolanIndexEntry[]) {
     }
   }
 
-  addSymbolLayers()
-
   ribbonAnchor = anchor
   addSymbolLayers()
 }


### PR DESCRIPTION
Transit ribbons stopped reading through the buildings they pass behind: on the tilted map a route simply vanished into a block.

MapLibre has no depth-aware line occlusion, so the overlay draws each ribbon twice — the solid line below the basemap's extrusions, a dimmed copy above them. The dimmed copy is inserted before the basemap's first label layer, and in the new style that layer is `Oneway`, which sits *below* `Building 3D`. Both copies ended up under the towers.

The ghost now anchors on the first label layer drawn above the buildings. Mapbox is untouched — it uses `line-occlusion-opacity` and was never affected.

Also fixes a duplicate `addSymbolLayers()` call from the same commit: the second one threw "layer already exists" and aborted the rest of that sync pass (stations, tile filters, hydration).