### PR TITLE
Open a line's route detail from its bullet on the transit map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+* Route bullets on the transit map are tappable — tap the line's bullet where it rides its track to open that line's route detail, the same page a bullet in a station header opens.
+
 ### Changed
 
 ### Fixed

--- a/server/src/controllers/transit.controller.test.ts
+++ b/server/src/controllers/transit.controller.test.ts
@@ -67,6 +67,7 @@ describe('authentication', () => {
     '/transit/route-vehicles',
     '/transit/trip-stops',
     '/transit/route-detail',
+    '/transit/resolve-route',
     '/transit/departures',
     '/transit/bikes-allowed',
     '/transit/nearest-entrance',
@@ -175,6 +176,7 @@ describe('caching', () => {
     // Topology only changes on a feed import.
     ['/transit/shapes', 'public, max-age=86400'],
     ['/transit/route-detail', 'public, max-age=3600'],
+    ['/transit/resolve-route', 'public, max-age=3600'],
     ['/transit/bikes-allowed', 'public, max-age=3600'],
     ['/transit/nearest-entrance', 'public, max-age=3600'],
     // Departures move, but not second to second.

--- a/server/src/controllers/transit.controller.ts
+++ b/server/src/controllers/transit.controller.ts
@@ -37,6 +37,14 @@ app.get('/route-detail', ({ query }) =>
   { detail: { tags: ['Transit'], summary: 'Route detail with stops and shape' } },
 )
 
+// A route id off a map tile belongs to a feed the tile never names, and
+// every other transit endpoint is keyed by the pair — so the map resolves
+// it here before it can open anything.
+app.get('/resolve-route', ({ query }) =>
+  requestBarrelman('/transit/resolve-route', query, { cacheControl: 'public, max-age=3600' }),
+  { detail: { tags: ['Transit'], summary: 'Resolve a bare GTFS route id at a location' } },
+)
+
 app.get('/departures', ({ query }) =>
   requestBarrelman('/transit/departures', query, { cacheControl: 'public, max-age=30' }),
   { detail: { tags: ['Transit'], summary: 'Upcoming departures at a stop' } },

--- a/web/src/services/layers/features/portolan/portolan-routes.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-routes.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A bullet on the map is a link to its line. Getting there means reading
+ * the route off the tile feature and turning the pyramid's id into the
+ * (feedId, routeId) pair the route detail is keyed by — once per route,
+ * however many bullets of it a rider taps.
+ */
+import { describe, test, expect, beforeEach, vi } from 'vitest'
+
+const get = vi.fn()
+vi.mock('@/lib/api', () => ({ api: { get: (...args: any[]) => get(...args) } }))
+
+const { bareRouteId, resetResolvedRoutes, resolveRouteRef, routeRefFor } = await import(
+  './portolan-routes'
+)
+
+const CAT = { route: '2', mode: 'metro', _feed: 'mta-subway' }
+const POINT = [-73.99, 40.75]
+
+beforeEach(() => {
+  resetResolvedRoutes()
+  get.mockReset()
+  get.mockResolvedValue({ data: { feedId: 'mta-subway', routeId: '2' } })
+})
+
+describe('reading the route off a bullet', () => {
+  test('carries the id, the mode and the bullet’s own point', () => {
+    expect(routeRefFor(CAT, POINT)).toMatchObject({
+      routeId: '2',
+      mode: 'metro',
+      lat: 40.75,
+      lng: -73.99,
+    })
+  })
+
+  test('a group pyramid’s prefix is not part of the id', () => {
+    expect(bareRouteId('f3:2')).toBe('2')
+    expect(routeRefFor({ ...CAT, route: 'f3:2' }, POINT)?.routeId).toBe('2')
+  })
+
+  test('a colon the feed put there survives', () => {
+    expect(bareRouteId('SEPTA:BSL')).toBe('SEPTA:BSL')
+  })
+
+  test('a feature with no route is not a link', () => {
+    expect(routeRefFor({ ftype: 'station', name: 'Canal St' }, POINT)).toBeNull()
+  })
+
+  test('nor is one with no usable point', () => {
+    expect(routeRefFor(CAT, undefined)).toBeNull()
+    expect(routeRefFor(CAT, ['x', 'y'])).toBeNull()
+  })
+})
+
+describe('resolving it to a feed', () => {
+  test('asks with the id, the point and the mode class', async () => {
+    await resolveRouteRef(routeRefFor(CAT, POINT)!)
+
+    expect(get).toHaveBeenCalledWith('/transit/resolve-route', {
+      params: { routeId: '2', lat: 40.75, lng: -73.99, mode: 'metro' },
+    })
+  })
+
+  test('every bullet of one route in one pyramid asks once', async () => {
+    const first = routeRefFor(CAT, POINT)!
+    const elsewhere = routeRefFor(CAT, [-73.94, 40.81])!
+
+    expect(await resolveRouteRef(first)).toEqual({ feedId: 'mta-subway', routeId: '2' })
+    expect(await resolveRouteRef(elsewhere)).toEqual({ feedId: 'mta-subway', routeId: '2' })
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  test('two pyramids drawing the same id are two questions', async () => {
+    await resolveRouteRef(routeRefFor(CAT, POINT)!)
+    await resolveRouteRef(routeRefFor({ ...CAT, _feed: 'northeast-corridor' }, POINT)!)
+
+    expect(get).toHaveBeenCalledTimes(2)
+  })
+
+  test('a route no feed claims stays unclaimed rather than being re-asked', async () => {
+    get.mockRejectedValue({ response: { status: 404 } })
+
+    const ref = routeRefFor(CAT, POINT)!
+    expect(await resolveRouteRef(ref)).toBeNull()
+    expect(await resolveRouteRef(ref)).toBeNull()
+    expect(get).toHaveBeenCalledTimes(1)
+  })
+
+  test('a request that lost the network is asked again', async () => {
+    get.mockRejectedValueOnce(new Error('Network Error'))
+
+    const ref = routeRefFor(CAT, POINT)!
+    expect(await resolveRouteRef(ref)).toBeNull()
+    expect(await resolveRouteRef(ref)).toEqual({ feedId: 'mta-subway', routeId: '2' })
+  })
+})

--- a/web/src/services/layers/features/portolan/portolan-routes.ts
+++ b/web/src/services/layers/features/portolan/portolan-routes.ts
@@ -1,0 +1,101 @@
+/**
+ * Portolan route ids, translated into the pair the rest of the app is
+ * keyed by.
+ *
+ * A bullet riding a ribbon knows its route the way the pyramid knows it:
+ * the feed's own GTFS `route_id`, prefixed when a group build merges
+ * several feeds ("f3:2"). The route detail is keyed by (feedId, routeId),
+ * and a bare id cannot supply the first half — "2" is the IRT Seventh
+ * Avenue line here and the Long Island Rail Road's Ronkonkoma branch
+ * twenty miles east, and the tiles never name either feed.
+ *
+ * Barrelman answers it from the one thing the tap does supply: WHERE.
+ * /transit/resolve-route takes the bare id, the bullet's own coordinate
+ * and its mode class, and returns the feed whose stops are nearest.
+ *
+ * The answer is cached per pyramid + tile id, not per point: every bullet
+ * of one route in one pyramid is the same route, so the second tap on a
+ * line is a navigation with nothing in front of it.
+ */
+import { api } from '@/lib/api'
+
+export interface PortolanRouteRef {
+  /** The feed's own GTFS route id, with any group prefix stripped. */
+  routeId: string
+  /** Portolan mode class — narrows a shared id to routes of its kind. */
+  mode?: string
+  lat: number
+  lng: number
+  /** Cache identity: same pyramid + same tile id is the same route. */
+  key: string
+}
+
+export interface ResolvedTransitRoute {
+  feedId: string
+  routeId: string
+}
+
+/**
+ * A group pyramid prefixes every feed after the first, so the 2 is `f3:2`
+ * there and plain `2` alone. Only that exact shape is a prefix: a route id
+ * with a colon of its own ("SEPTA:BSL") keeps every character.
+ */
+export function bareRouteId(token: string): string {
+  const m = /^f\d+:(.+)$/.exec(token)
+  return m ? m[1] : token
+}
+
+/** What a clicked caterpillar bullet identifies, or null when the feature
+ *  carries no route at all (an older tile, a stray symbol). */
+export function routeRefFor(props: any, coords: unknown): PortolanRouteRef | null {
+  const token = String(props?.route ?? '')
+  if (!token) return null
+  const point = Array.isArray(coords) ? coords : null
+  const lng = Number(point?.[0])
+  const lat = Number(point?.[1])
+  if (!Number.isFinite(lat) || !Number.isFinite(lng)) return null
+  const mode = props?.mode ? String(props.mode) : undefined
+  return {
+    routeId: bareRouteId(token),
+    mode,
+    lat,
+    lng,
+    key: `${props?._feed ?? ''}|${token}`,
+  }
+}
+
+const resolved = new Map<string, Promise<ResolvedTransitRoute | null>>()
+
+/**
+ * The (feedId, routeId) pair for a bullet, or null when nothing in the
+ * timetable database claims that id near that point — a pyramid built
+ * from a feed barrelman has not imported.
+ *
+ * An answer of "no such route" is a fact about the data and stays cached;
+ * a request that lost the network is not, and the next tap asks again.
+ */
+export function resolveRouteRef(ref: PortolanRouteRef): Promise<ResolvedTransitRoute | null> {
+  const hit = resolved.get(ref.key)
+  if (hit) return hit
+  const pending = api
+    .get<ResolvedTransitRoute>('/transit/resolve-route', {
+      params: {
+        routeId: ref.routeId,
+        lat: ref.lat,
+        lng: ref.lng,
+        ...(ref.mode ? { mode: ref.mode } : {}),
+      },
+    })
+    .then(({ data }) => (data?.feedId && data?.routeId ? data : null))
+    .catch((err: any) => {
+      if (!err?.response) resolved.delete(ref.key)
+      return null
+    })
+  resolved.set(ref.key, pending)
+  return pending
+}
+
+/** Test seam: forget every resolved pair. */
+export function resetResolvedRoutes() {
+  resolved.clear()
+}

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -79,6 +79,7 @@ import { cssFontFor, drawPortolanImage, estRows, estRowsFromAdvances } from './p
 import { glyphAdvances } from './portolan-glyphs'
 import { TRANSIT_GROUP_ID, stopTargetFor } from './portolan-ui'
 import { firstLabelLayerId } from './portolan-anchors'
+import { resolveRouteRef, routeRefFor } from './portolan-routes'
 
 const FLAG_KEY = 'parchment.portolan-transit'
 
@@ -106,6 +107,12 @@ const STOP_CLICK_LAYERS = [
   'portolan-station-labels',
   'portolan-station-labels-hi',
 ]
+
+// Layers whose features ARE a route: the caterpillar bullets riding the
+// ribbons and the word labels set along them. Each names exactly one
+// route, which is what makes it a link where a station's bullet strip —
+// one composed image for the whole row — cannot be.
+const ROUTE_CLICK_LAYERS = ['portolan-cats', 'portolan-cat-text']
 
 const EMPTY_FC = { type: 'FeatureCollection', features: [] } as any
 
@@ -472,7 +479,7 @@ function bindListeners() {
   const onStopEnter = (e: any) => {
     if (targetAt(e)) map.getCanvas().style.cursor = 'pointer'
   }
-  const onStopLeave = () => {
+  const onLeave = () => {
     if (map) map.getCanvas().style.cursor = ''
   }
   const onStopClick = (e: any) => {
@@ -480,11 +487,60 @@ function bindListeners() {
     if (!target) return
     router.push(target as any)
   }
-  boundLayerHandlers = STOP_CLICK_LAYERS.flatMap(layer => [
-    { event: 'mouseenter', layer, fn: onStopEnter },
-    { event: 'mouseleave', layer, fn: onStopLeave },
-    { event: 'click', layer, fn: onStopClick },
-  ])
+  // Route clicks → the line's own detail, the way tapping a bullet in a
+  // station header opens it. The pair that page is keyed by has to be
+  // resolved first (portolan-routes), so a hover warms the answer and the
+  // tap that follows navigates with nothing in front of it.
+  const refAt = (e: any) => {
+    const f = e.features?.[0]
+    return routeRefFor(f?.properties, f?.geometry?.coordinates)
+  }
+
+  /** Whether a stop that would open a place sits under this same point. */
+  const stopUnder = (e: any) => {
+    const layers = STOP_CLICK_LAYERS.filter(l => map.getLayer(l))
+    if (!layers.length) return false
+    return map
+      .queryRenderedFeatures(e.point, { layers })
+      .some((f: any) => stopTargetFor(f.properties))
+  }
+
+  const onRouteEnter = (e: any) => {
+    const ref = refAt(e)
+    if (!ref) return
+    map.getCanvas().style.cursor = 'pointer'
+    void resolveRouteRef(ref)
+  }
+  const onRouteClick = async (e: any) => {
+    const ref = refAt(e)
+    if (!ref) return
+    // A station's symbols are drawn above the bullets, and both layers get
+    // the click when they overlap. The one on top is the one being
+    // pointed at, so a bullet lying under a stop label yields to it —
+    // otherwise the two handlers would both navigate, ours last.
+    if (stopUnder(e)) return
+    const target = await resolveRouteRef(ref)
+    // No feed claims this id here — the pyramid draws a line barrelman has
+    // no timetable for. Nothing to open, and nothing to say about it.
+    if (!target) return
+    router.push({
+      name: AppRoute.TRANSIT_ROUTE,
+      params: { feedId: target.feedId, routeId: target.routeId },
+    })
+  }
+
+  boundLayerHandlers = [
+    ...STOP_CLICK_LAYERS.flatMap(layer => [
+      { event: 'mouseenter', layer, fn: onStopEnter },
+      { event: 'mouseleave', layer, fn: onLeave },
+      { event: 'click', layer, fn: onStopClick },
+    ]),
+    ...ROUTE_CLICK_LAYERS.flatMap(layer => [
+      { event: 'mouseenter', layer, fn: onRouteEnter },
+      { event: 'mouseleave', layer, fn: onLeave },
+      { event: 'click', layer, fn: onRouteClick },
+    ]),
+  ]
   for (const { event, layer, fn } of boundLayerHandlers) map.on(event, layer, fn)
 }
 


### PR DESCRIPTION
## What

The route bullets riding the ribbons on the transit map are links now. Tap the bullet where a line runs and its route detail opens — the same page a bullet in a station header goes to.

Hover shows a pointer and warms the lookup, so the tap itself navigates with nothing in front of it.

## The identity problem

A bullet knows its route the way the pyramid knows it: the feed's own GTFS `route_id`, prefixed when a group build merges several feeds (`f3:2`). The route detail is keyed by `(feedId, routeId)`, and the tiles never name a feed — a portolan feed key is not a barrelman feed id, they are joined by transitland onestop id at sync time and that mapping is not published anywhere the client can read.

So the pair is resolved from the one thing a tap does supply: **where**. Barrelman gains `GET /transit/resolve-route` (alexwohlbruck/barrelman#118) — bare id + point + mode class → the feed whose stops lie nearest. That is what separates a subway `2` from an LIRR `2`, which a bare-id lookup gets wrong roughly half the time in Manhattan.

## Changes

* `portolan-routes.ts` — strips the group prefix, resolves through the endpoint, caches per pyramid + tile id (every bullet of one line asks once; a 404 stays cached, a network failure does not).
* `portolan-transit.service.ts` — hover + click on `portolan-cats` and `portolan-cat-text`. A bullet under a station label yields to the label: both layers get the click when they overlap, and the station is the one drawn on top.
* Server proxies `/transit/resolve-route`, cached an hour, behind the same auth guard as the rest of `/transit`.

Only the caterpillar bullets are clickable. A station's bullet strip is one composed icon image for the whole row, so MapLibre cannot say which bullet inside it was hit — that strip keeps opening the station.

The bullets only render on the MapLibre transit fork (they need `symbol-anchor-offset`), so there is nothing to click on Mapbox.

## Testing

`bun run test run src/services/layers/features/portolan` — 140 pass, including 10 new ones over the id parsing, the per-pyramid cache, and the two failure modes. `vue-tsc` clean. Server: `bun test src/controllers/transit.controller.test.ts` — 27 pass.

No screenshot: the local stack was down while this was written and I did not want to start servers. It also needs barrelman on the branch above before the bullets resolve to anything.

## Depends on

* alexwohlbruck/barrelman#118
* Docs: alexwohlbruck/parchment-docs (endpoint reference)