### PR TITLE
Deploy the API from the release pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -543,3 +543,95 @@ jobs:
             -f "$IPA_PATH" \
             --apiKey "${{ secrets.APPLE_API_KEY }}" \
             --apiIssuer "${{ secrets.APPLE_API_ISSUER }}"
+
+  # ── Deploy ────────────────────────────────────────────────────────────
+  #
+  # Push the new server image at vega7 instead of waiting for Watchtower's
+  # hourly poll to find it. Only the API is deployed here: the web frontend is
+  # served off-homelab, and the release's app artifacts go to the stores and
+  # the auto-updater from the jobs above.
+  #
+  # Unconfigured is not failed — without the secrets this no-ops and Watchtower
+  # keeps doing what it does. Required secrets (same names as barrelman's):
+  #
+  #   TS_OAUTH_CLIENT_ID / TS_OAUTH_SECRET  Tailscale OAuth client (scope
+  #     auth_keys, tag:ci) — the runner joins the tailnet as an ephemeral node,
+  #     so the host needs no public SSH port.
+  #   DEPLOY_SSH_KEY                        private half of a keypair whose
+  #     public half is in ~/.ssh/authorized_keys on the host.
+  #
+  # There is no drain gate here, unlike barrelman: the API holds no
+  # long-running work that a restart would abandon.
+  deploy-server:
+    name: Deploy to production
+    needs: [deploy-docker]
+    runs-on: ubuntu-latest
+    env:
+      # Tailnet IP, not a hostname: this tailnet has MagicDNS off, so `vega7`
+      # does not resolve from the runner.
+      DEPLOY_HOST: 100.83.151.102
+      DEPLOY_USER: alex
+      DEPLOY_PATH: /opt/parchment
+      DEPLOY_SERVICE: parchment-server
+    steps:
+      - name: Check for deploy credentials
+        id: creds
+        env:
+          TS_ID: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+        run: |
+          if [ -n "$TS_ID" ] && [ -n "$SSH_KEY" ]; then
+            echo "ready=true" >> $GITHUB_OUTPUT
+          else
+            echo "ready=false" >> $GITHUB_OUTPUT
+            echo "::notice::Deploy secrets not set — skipping. Watchtower will pick this release up on its next poll."
+          fi
+
+      - name: Join the tailnet
+        if: steps.creds.outputs.ready == 'true'
+        uses: tailscale/github-action@v4.1.3
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
+      - name: Load the deploy key
+        if: steps.creds.outputs.ready == 'true'
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "${{ secrets.DEPLOY_SSH_KEY }}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+
+      - name: Pull and recreate
+        if: steps.creds.outputs.ready == 'true'
+        run: |
+          ssh -o StrictHostKeyChecking=accept-new -o ConnectTimeout=20 \
+            "$DEPLOY_USER@$DEPLOY_HOST" \
+            "DEPLOY_PATH='$DEPLOY_PATH' DEPLOY_SERVICE='$DEPLOY_SERVICE' bash -se" <<'REMOTE'
+            set -euo pipefail
+            cd "$DEPLOY_PATH"
+            docker compose pull "$DEPLOY_SERVICE"
+            # --no-deps: recreate exactly this service. Without it compose
+            # reconciles its dependencies too, which is how a deploy meant for
+            # one container ends up restarting its neighbours.
+            docker compose up -d --no-deps "$DEPLOY_SERVICE"
+          REMOTE
+
+      - name: Verify
+        if: steps.creds.outputs.ready == 'true'
+        run: |
+          ssh -o ConnectTimeout=20 "$DEPLOY_USER@$DEPLOY_HOST" bash -se <<'REMOTE'
+            set -euo pipefail
+            # The server has no /health route; the root path answers 207 when
+            # every subsystem it reports on is up.
+            for _ in $(seq 1 30); do
+              code=$(curl -s -o /dev/null -m 10 -w '%{http_code}' localhost:5000/ || true)
+              case "$code" in
+                200|207) echo "healthy ($code)"; exit 0 ;;
+              esac
+              sleep 10
+            done
+            echo "did not come back healthy within five minutes (last: ${code:-none})"
+            docker logs --tail 50 parchment-server
+            exit 1
+          REMOTE

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### Changed
 
+* Releases now deploy the API themselves instead of waiting up to an hour for the server to notice a new image.
+
 ### Fixed
 
 ## [0.10.4] - 2026-09-06


### PR DESCRIPTION
## What

Adds a `deploy-server` job after `deploy-docker`: it joins the tailnet, pulls the new `parchment-server` image on vega7 and recreates that one container, then verifies the server answers before the job goes green.

Today a release sits until Watchtower's hourly poll finds it — 0.10.4 was deployed by hand an hour ahead of the sweep. Only the API is deployed here; the web frontend is served off-homelab and the app artifacts already go to the stores and the auto-updater from the jobs above.

## Notes

* `--no-deps` is deliberate, and it is the lesson from deploying 0.10.4: a bare `compose up -d <service>` reconciles dependencies too, and on vega2 that bounced the database when only the API was meant to move.
* No drain gate, unlike barrelman's equivalent (alexwohlbruck/barrelman#120) — this API holds no long-running work a restart would abandon.
* Health is `GET /` returning 207, since the server has no `/health` route. On failure the job prints the last 50 log lines and fails rather than reporting a green release over a dead container.

## Turning it on

Three repo secrets — `TS_OAUTH_CLIENT_ID`, `TS_OAUTH_SECRET`, `DEPLOY_SSH_KEY` (same names as barrelman's, so one Tailscale OAuth client and one keypair cover both). Without them the job logs a notice and no-ops, so merging changes nothing until they exist.

Verified only as far as it can be from here: the workflow parses, the job graph is right, and the remote scripts are the same commands run by hand against vega7 an hour ago. The first real proof is the next release.