### PR TITLE
Pin sheet footers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,14 @@
 
 * Releases now deploy the API themselves instead of waiting up to an hour for the server to notice a new image.
 * Your account row stays pinned to the bottom of the mobile dashboard, so you can reach it without scrolling past every recent place.
+* Search suggestions run the full height of the panel instead of stopping half way down with empty space beneath them.
+* The layer picker opens as a sheet you can drag up to full screen again.
 
 ### Fixed
 
 * Panels inside the mobile sheet scroll with the sheet instead of trapping the drag — search results, the timeline, collections, notes and friend and tracker details all pan and expand properly again.
 * The layer picker's tabs stay put while you scroll the list, and the sheet itself drags instead of fighting an inner scrollbar.
+* Lists leave room for the on-screen keyboard, so you can scroll to the end of your results without dismissing it first.
 
 ## [0.10.4] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 ### Fixed
 
 * Panels inside the mobile sheet scroll with the sheet instead of trapping the drag — search results, the timeline, collections, notes and friend and tracker details all pan and expand properly again.
+* The layer picker's tabs stay put while you scroll the list, and the sheet itself drags instead of fighting an inner scrollbar.
 
 ## [0.10.4] - 2026-09-06
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,11 @@
 ### Changed
 
 * Releases now deploy the API themselves instead of waiting up to an hour for the server to notice a new image.
+* Your account row stays pinned to the bottom of the mobile dashboard, so you can reach it without scrolling past every recent place.
 
 ### Fixed
+
+* Panels inside the mobile sheet scroll with the sheet instead of trapping the drag — search results, the timeline, collections, notes and friend and tracker details all pan and expand properly again.
 
 ## [0.10.4] - 2026-09-06
 

--- a/web/src/App.vue
+++ b/web/src/App.vue
@@ -17,6 +17,7 @@ import { useStorage } from '@vueuse/core'
 import { useResponsive } from '@/lib/utils'
 import { isTauri } from '@/lib/api'
 import { useExternalLink } from '@/composables/useExternalLink'
+import { useVirtualKeyboard } from '@/composables/useVirtualKeyboard'
 import { useFriendLocationsLayer } from '@/composables/useFriendLocationsLayer'
 import { useTrackerLocationsLayer } from '@/composables/useTrackerLocationsLayer'
 import { useVehiclesStore } from '@/stores/vehicles.store'
@@ -57,6 +58,9 @@ const layersStore = useLayersStore()
 const bookmarksService = useBookmarksService()
 const collectionsService = useCollectionsService()
 const appStore = useAppStore()
+// Publishes `--keyboard-inset-height` app-wide; sheets and lists pad to it.
+useVirtualKeyboard()
+
 const friendLocationsLayer = useFriendLocationsLayer()
 const trackerLocationsLayer = useTrackerLocationsLayer()
 const vehiclesStore = useVehiclesStore()

--- a/web/src/components/BottomSheet.vue
+++ b/web/src/components/BottomSheet.vue
@@ -1,6 +1,90 @@
 <script setup lang="ts">
+/**
+ * ============================================================================
+ * SHEET LAYOUT CONTRACT
+ * ============================================================================
+ *
+ * Every sheet is made of the same three regions. All of them are optional, and
+ * a view opts into each one where it needs it:
+ *
+ *   ┌──────────────────────────────┐
+ *   │ chrome (drag handle, actions)│  owned by this component, floats over all
+ *   ├──────────────────────────────┤
+ *   │ STICKY HEADER   <SheetHeader>│  pins to the top; sizes the peek detent
+ *   ├──────────────────────────────┤
+ *   │                              │
+ *   │ SCROLLABLE CONTENT   default │  the one and only scroll surface
+ *   │  (may contain horizontally   │
+ *   │   scrolling rows)            │
+ *   ├──────────────────────────────┤
+ *   │ PINNED FOOTER   <SheetFooter>│  rides the sheet's visible bottom edge
+ *   └──────────────────────────────┘
+ *
+ * ── The one-scroll-surface rule ─────────────────────────────────────────────
+ *
+ * The sheet owns exactly one vertical scroll surface: the element below tagged
+ * `data-sheet-scroll`. A view rendered inside a sheet must NOT create its own
+ * (`h-full` + `flex-1 overflow-y-auto` is the shape to look out for). Nested
+ * scrollers fight the drag gesture on touch: the inner one swallows the
+ * upward pan, so the sheet can neither be expanded from inside its content nor
+ * dragged back down once you've scrolled, and the sheet's own at-top detection
+ * (which gates `data-vaul-no-drag` and the touchmove guard) is reading the
+ * wrong element.
+ *
+ * So a hosted view is a plain, unbounded column that grows as tall as its
+ * content — normally `<PanelLayout>`, which is `min-h-full` (fill a short
+ * sheet) and never `h-full` (which would cap it at one viewport and unstick
+ * sticky children once content scrolled past).
+ *
+ * Views that need the scrolling element itself — to save/restore a position,
+ * or to drive infinite scroll — resolve it with `findScrollAncestor()` from
+ * `@/lib/scroll` rather than assuming a particular ancestor. Horizontally
+ * scrolling rows (photo galleries, chip rows) are fine anywhere inside: they
+ * only take over the x axis, so vertical pans still reach the sheet.
+ *
+ * ── How the drag and the scroll cooperate ───────────────────────────────────
+ *
+ * Below the top detent the surface is `overflow-hidden` with `touch-action:
+ * none`, so every vertical pan is a sheet drag. At the top detent it becomes
+ * scrollable, and two guards hand the gesture back: `data-vaul-no-drag` once
+ * scrolled off the top (Vaul stops treating pans as drags), and a touchmove
+ * guard that swallows the overscroll at `scrollTop === 0` so a downward pull
+ * collapses the sheet instead of rubber-banding the page.
+ *
+ * ── Why the footer has to be portaled ───────────────────────────────────────
+ *
+ * A snap-point sheet is a full-viewport-tall panel translated down by the
+ * detent, so only its top `activeSnapPoint` pixels are on screen and its own
+ * bottom edge sits far below the fold. The sheet's visible bottom edge is
+ * therefore the *viewport* bottom, which nothing in the content flow can
+ * reach — `position: sticky; bottom: 0` sticks to the off-screen edge. So this
+ * component keeps a thin layer sized to `--sheet-visible-height` and pins the
+ * footer to the bottom of that; `<SheetFooter>` teleports into it. The layer
+ * holds only the footer, so the per-frame resize during a drag never touches
+ * the content's layout. (A `fit-content` sheet is sized to its content and
+ * genuinely sits on the viewport bottom, so its footer stays in flow.)
+ *
+ * The scroll surface reserves `--sheet-footer-height` of bottom padding so the
+ * last row can still be scrolled clear of the footer, and the peek detent
+ * grows by the same amount so a collapsed sheet shows its peek content *and*
+ * its footer rather than one on top of the other.
+ *
+ * ── CSS custom properties published to hosted views ─────────────────────────
+ *
+ *   --sheet-sticky-top      where a sticky header docks (below the chrome bar)
+ *   --sheet-visible-height  how much of the sheet is currently on screen
+ *   --sheet-footer-height   height of the pinned footer, 0 when there is none
+ */
 import type { HTMLAttributes } from 'vue'
-import { ref, computed, watch, onMounted, onUnmounted, provide, nextTick } from 'vue'
+import {
+  ref,
+  computed,
+  watch,
+  onMounted,
+  onUnmounted,
+  provide,
+  nextTick,
+} from 'vue'
 import { cn } from '@/lib/utils'
 import {
   useWindowSize,
@@ -28,6 +112,11 @@ import { useMapToolsStore } from '@/stores/map-tools.store'
 const props = withDefaults(
   defineProps<{
     class?: HTMLAttributes['class']
+    /**
+     * Collapsed detent. A pinned footer's height is added on top, so the peek
+     * shows the peek content *and* the footer; `dynamicPeek` replaces the value
+     * entirely with a measured one.
+     */
     peekHeight?: number | string
     modal?: boolean
     dismissable?: boolean
@@ -50,15 +139,22 @@ const props = withDefaults(
     parentId?: string
     zIndexOffset?: number
     respectSafeArea?: boolean
+    /**
+     * Size the sheet to its content and sit it on the viewport bottom, instead
+     * of the full-height snap-point panel. Popover-style sheets use this; a
+     * pinned footer then needs no portal, since the sheet really does end where
+     * it looks like it ends.
+     */
     fitContent?: boolean
     /**
      * When true, the peek (first) snap point is sized to fit a registered
      * peek element instead of the static `peekHeight`. A hosted view marks
-     * the bottom of its peek region with `useSheetPeek()`; we measure from
-     * the drawer top to that element's bottom and drive the first snap point
-     * from it. Async content that resizes the region re-snaps with the
-     * normal Vaul transition, so the sheet glides between heights. Opt-in:
-     * views without a registered element fall back to `peekHeight`.
+     * the bottom of its peek region with `useSheetPeek()` — or, more usually,
+     * just wraps it in `<SheetHeader>`; we measure from the drawer top to that
+     * element's bottom and drive the first snap point from it. Async content
+     * that resizes the region re-snaps with the normal Vaul transition, so the
+     * sheet glides between heights. Opt-in: views without a registered element
+     * fall back to `peekHeight`.
      */
     dynamicPeek?: boolean
   }>(),
@@ -86,12 +182,44 @@ const drawerContentRef = ref<InstanceType<typeof DrawerContent> | null>(null)
 const scrollContainer = ref<HTMLElement | null>(null)
 const headerRef = ref<HTMLElement | null>(null)
 
+// ==================== PINNED FOOTER ====================
+//
+// `<SheetFooter>` teleports into `footerHost`. It also registers itself, so we
+// know whether a footer exists before it has painted — the empty host must not
+// contribute a safe-area strip or a border to a sheet that has no footer.
+
+const footerHost = ref<HTMLElement | null>(null)
+const footerCount = ref(0)
+const hasFooter = computed(() => footerCount.value > 0)
+provide('sheetFooter', {
+  target: footerHost,
+  register: () => (footerCount.value += 1),
+  unregister: () => (footerCount.value -= 1),
+})
+
+const { height: footerHeight } = useElementSize(footerHost, undefined, {
+  box: 'border-box',
+})
+
 // A hosted view opts into the opaque in-flow chrome bar when it pins its own
 // header to the scroll surface (e.g. Directions) — content then scrolls
 // cleanly beneath it. Plain scrolling views (Place, etc.) leave it off and
 // keep the original transparent chrome with content near the top.
+//
+// Two ways in: a view can drive the flag itself (a header that comes and goes
+// with its data), or `<SheetHeader>` claims the bar for as long as it is
+// mounted. The claims are counted, so a sub-page's header releasing the bar
+// can't switch it off underneath the view it was pushed from.
 const chromeBarEnabled = ref(false)
+const chromeBarClaims = ref(0)
+const showChromeBar = computed(
+  () => chromeBarEnabled.value || chromeBarClaims.value > 0,
+)
 provide('sheetChromeBar', chromeBarEnabled)
+provide('sheetChromeBarClaim', {
+  acquire: () => (chromeBarClaims.value += 1),
+  release: () => (chromeBarClaims.value -= 1),
+})
 const activeSnapPoint = ref<number | string | null>(
   props.activeSnapPoint ?? null,
 )
@@ -359,16 +487,11 @@ function measureDynamicPeek() {
   if (!contentEl || typeof contentEl.getBoundingClientRect !== 'function') return
   const top = contentEl.getBoundingClientRect().top
   const bottom = peekEl.value.getBoundingClientRect().bottom
-  let h = bottom - top + DYNAMIC_PEEK_BUFFER
+  const h = bottom - top + DYNAMIC_PEEK_BUFFER
   if (h <= 0) return
 
-  // Keep the peek strictly below the next detent so snap points stay
-  // monotonic (Vaul's drag math assumes ascending heights). On a short
-  // screen a tall header would otherwise overshoot the 0.5 detent.
-  const nextPoint = props.customSnapPoints?.[1] ?? 0.5
-  const maxPeek = snapPointToPixels(nextPoint) - 24
-  if (maxPeek > 0) h = Math.min(h, maxPeek)
-
+  // `clampPeek` keeps the result below the next detent once the footer
+  // allowance has been folded in.
   dynamicPeekPx.value = Math.round(h)
 }
 
@@ -381,7 +504,7 @@ watch(
     peekContentHeight,
     peekEl,
     windowHeight,
-    () => chromeBarEnabled.value,
+    () => showChromeBar.value,
     () => safeAreaInsetBottom.value,
     () => props.dynamicPeek,
     // Re-measure when the sheet returns to the top, picking up any content
@@ -401,15 +524,46 @@ const baseSnapPoints = computed<SnapPoint[]>(
   () => props.customSnapPoints ?? [props.peekHeight, 0.5, 1],
 )
 
+// Grow a snap point by a pixel amount, preserving whichever format it came in
+// as. Non-pixel strings (e.g. '50%') pass through untouched.
+function addPixels(point: SnapPoint, px: number): SnapPoint {
+  if (px <= 0) return point
+  if (typeof point === 'string') {
+    return point.endsWith('px') ? `${parseFloat(point) + px}px` : point
+  }
+  if (point > 0 && point <= 1) {
+    return (point * windowHeight.value + px) / windowHeight.value
+  }
+  return point + px
+}
+
 // User-provided snap points, with the measured peek height swapped into the
 // first slot when dynamic peek is active and we have a measurement.
 const userSnapPoints = computed<SnapPoint[]>(() => {
   const base = baseSnapPoints.value
-  if (props.dynamicPeek && dynamicPeekPx.value != null && base.length > 0) {
-    return [`${dynamicPeekPx.value}px`, ...base.slice(1)]
-  }
-  return base
+  if (!base.length) return base
+  const peek =
+    props.dynamicPeek && dynamicPeekPx.value != null
+      ? `${dynamicPeekPx.value}px`
+      : base[0]
+  // The collapsed detent clears the pinned footer as well as the peek content,
+  // otherwise the footer just covers what the peek was meant to show. The
+  // footer carries the bottom safe area, so `adjustForSafeArea` stands down.
+  const footerAllowance = hasFooter.value ? footerHeight.value : 0
+  return [clampPeek(addPixels(peek, footerAllowance)), ...base.slice(1)]
 })
+
+// Keep the peek strictly below the next detent so snap points stay monotonic
+// (Vaul's drag math assumes ascending heights). On a short screen a tall
+// header plus a footer would otherwise overshoot the 0.5 detent.
+function clampPeek(point: SnapPoint): SnapPoint {
+  if (typeof point !== 'string' || !point.endsWith('px')) return point
+  const next = baseSnapPoints.value[1]
+  if (next === undefined) return point
+  const max = snapPointToPixels(next) - 24
+  if (max <= 0) return point
+  return `${Math.min(parseFloat(point), max)}px`
+}
 
 // Apply safe area adjustments to a snap point
 function adjustForSafeArea(point: SnapPoint, index: number): SnapPoint {
@@ -420,20 +574,10 @@ function adjustForSafeArea(point: SnapPoint, index: number): SnapPoint {
     return (windowHeight.value - safeAreaInsetTop.value) / windowHeight.value
   }
 
-  // First snap point (peek) → add bottom safe area (home indicator)
-  if (index === 0 && safeAreaInsetBottom.value > 0) {
-    if (typeof point === 'string' && point.endsWith('px')) {
-      return `${parseFloat(point) + safeAreaInsetBottom.value}px`
-    }
-    if (typeof point === 'number') {
-      if (point > 0 && point <= 1) {
-        return (
-          (point * windowHeight.value + safeAreaInsetBottom.value) /
-          windowHeight.value
-        )
-      }
-      return point + safeAreaInsetBottom.value
-    }
+  // First snap point (peek) → add bottom safe area (home indicator), unless a
+  // pinned footer is already holding that space open.
+  if (index === 0 && !hasFooter.value) {
+    return addPixels(point, safeAreaInsetBottom.value)
   }
 
   return point
@@ -458,6 +602,20 @@ const activeSnapPointIndex = computed(() => {
 const isFullyExpanded = computed(() => {
   if (props.fitContent) return props.open
   return activeSnapPoint.value === snapPoints.value.at(-1)
+})
+
+// How much of the sheet is actually on screen. The drawer element is a full
+// viewport-height panel translated down by the detent, so this is what its
+// height *looks* like — and where the pinned footer has to sit. Live bounds
+// while dragging or animating, the target detent at rest (see the bounds
+// tracking above for why the target rather than the measured rect).
+const visibleHeight = computed(() => {
+  if (!props.open && !isAnimating.value) return 0
+  if (liveBounds.value) {
+    return Math.max(0, windowHeight.value - liveBounds.value.y)
+  }
+  const point = activeSnapPoint.value ?? snapPoints.value[snapIndex.value]
+  return point == null ? 0 : snapPointToPixels(point)
 })
 
 // ==================== SNAP POINT SYNCING ====================
@@ -678,13 +836,15 @@ function handleAnimationEnd(open: boolean) {
           zIndex: 40 + props.zIndexOffset,
           '--tw-shadow':
             '0 -4px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
+          '--sheet-visible-height': `${visibleHeight}px`,
+          '--sheet-footer-height': `${footerHeight}px`,
         }"
         :data-vaul-no-drag="!isAtTop ? '' : undefined"
       >
         <!-- Chrome: drag handle + action buttons. Always an overlay that takes
              no layout space, so content sits high near the handle at rest. A
              view that pins its own header opts into the chrome bar (sets
-             `chromeBarEnabled`): its opaque backing then fades in as you scroll
+             the chrome bar): its opaque backing then fades in as you scroll
              so content reads cleanly under the handle / buttons, and the pinned
              header docks below the bar via `--sheet-sticky-top`. -->
         <!-- z above the trip-row content (dots/caps at z-20) so it hides
@@ -694,12 +854,12 @@ function handleAnimationEnd(open: boolean) {
           v-if="props.showDragHandle || $slots.actions"
           ref="headerRef"
           class="absolute top-0 left-0 right-0 z-[22] grid grid-cols-[1fr_auto_1fr] items-start pointer-events-none"
-          :class="chromeBarEnabled ? 'min-h-[2.75rem]' : ''"
+          :class="showChromeBar ? 'min-h-[2.75rem]' : ''"
         >
           <!-- Opaque backing (chrome views only) — fades in with scroll so the
                pinned header / content reads cleanly under the handle. -->
           <div
-            v-if="chromeBarEnabled"
+            v-if="showChromeBar"
             class="absolute inset-0 bg-background"
             :style="{ opacity: chromeFade }"
           />
@@ -748,7 +908,7 @@ function handleAnimationEnd(open: boolean) {
             touchAction: isFullyExpanded ? 'pan-y' : 'none',
             overscrollBehavior: 'none',
             // Sticky headers in chrome views dock just below the overlay bar.
-            '--sheet-sticky-top': chromeBarEnabled ? '2.75rem' : '0px',
+            '--sheet-sticky-top': showChromeBar ? '2.75rem' : '0px',
           }"
           @touchstart="handleTouchStart"
           @touchmove="handleTouchMove"
@@ -757,6 +917,34 @@ function handleAnimationEnd(open: boolean) {
           <slot />
           <!-- Spacer to account for safe area inset bottom -->
           <div class="w-full h-[env(safe-area-inset-bottom)]"></div>
+          <!-- Clear the pinned footer so the last row can still be read. -->
+          <div v-if="hasFooter" :style="{ height: `${footerHeight}px` }"></div>
+        </div>
+
+        <!-- Pinned footer. A fit-content sheet really does end at the viewport
+             bottom, so its footer is just the last child in the column. A
+             snap-point sheet does not, so the footer rides a layer sized to the
+             visible height, and slides away with the sheet once the sheet gets
+             shorter than the footer itself (closing, or dragged below peek). -->
+        <div
+          v-if="props.fitContent"
+          ref="footerHost"
+          :class="hasFooter ? 'shrink-0 pb-[env(safe-area-inset-bottom)]' : ''"
+        ></div>
+        <div
+          v-else
+          class="pointer-events-none absolute inset-x-0 top-0 z-[23]"
+          :style="{ height: 'var(--sheet-visible-height)' }"
+        >
+          <div
+            ref="footerHost"
+            class="pointer-events-auto absolute inset-x-0 bottom-0"
+            :class="hasFooter ? 'pb-[env(safe-area-inset-bottom)]' : ''"
+            :style="{
+              transform:
+                'translateY(max(0px, calc(var(--sheet-footer-height) - var(--sheet-visible-height))))',
+            }"
+          ></div>
         </div>
       </DrawerContent>
     </DrawerPortal>

--- a/web/src/components/BottomSheet.vue
+++ b/web/src/components/BottomSheet.vue
@@ -64,16 +64,18 @@
  * the content's layout. (A `fit-content` sheet is sized to its content and
  * genuinely sits on the viewport bottom, so its footer stays in flow.)
  *
- * The scroll surface reserves `--sheet-footer-height` of bottom padding so the
- * last row can still be scrolled clear of the footer, and the peek detent
- * grows by the same amount so a collapsed sheet shows its peek content *and*
- * its footer rather than one on top of the other.
+ * The peek detent belongs to the peek content alone: a collapsed sheet shows
+ * exactly that, with the footer parked below the fold. The footer slides up as
+ * the sheet is dragged open and is fully in once there is its own height to
+ * spare above the peek. The scroll surface reserves `--sheet-footer-height` of
+ * bottom padding so the last row can still be scrolled clear of it.
  *
  * ── CSS custom properties published to hosted views ─────────────────────────
  *
  *   --sheet-sticky-top      where a sticky header docks (below the chrome bar)
  *   --sheet-visible-height  how much of the sheet is currently on screen
  *   --sheet-footer-height   height of the pinned footer, 0 when there is none
+ *   --sheet-footer-space    how much of that footer has been revealed
  */
 import type { HTMLAttributes } from 'vue'
 import {
@@ -113,9 +115,9 @@ const props = withDefaults(
   defineProps<{
     class?: HTMLAttributes['class']
     /**
-     * Collapsed detent. A pinned footer's height is added on top, so the peek
-     * shows the peek content *and* the footer; `dynamicPeek` replaces the value
-     * entirely with a measured one.
+     * Collapsed detent — what the sheet shows when minimized. A pinned footer
+     * stays below it and slides in as the sheet opens, so the peek is the peek
+     * content and nothing else. `dynamicPeek` measures this instead.
      */
     peekHeight?: number | string
     modal?: boolean
@@ -546,16 +548,14 @@ const userSnapPoints = computed<SnapPoint[]>(() => {
     props.dynamicPeek && dynamicPeekPx.value != null
       ? `${dynamicPeekPx.value}px`
       : base[0]
-  // The collapsed detent clears the pinned footer as well as the peek content,
-  // otherwise the footer just covers what the peek was meant to show. The
-  // footer carries the bottom safe area, so `adjustForSafeArea` stands down.
-  const footerAllowance = hasFooter.value ? footerHeight.value : 0
-  return [clampPeek(addPixels(peek, footerAllowance)), ...base.slice(1)]
+  // The peek fits the peek content and nothing else — the footer is parked
+  // below the fold at this detent and slides up as the sheet grows.
+  return [clampPeek(peek), ...base.slice(1)]
 })
 
 // Keep the peek strictly below the next detent so snap points stay monotonic
-// (Vaul's drag math assumes ascending heights). On a short screen a tall
-// header plus a footer would otherwise overshoot the 0.5 detent.
+// (Vaul's drag math assumes ascending heights). On a short screen a tall header
+// would otherwise overshoot the 0.5 detent.
 function clampPeek(point: SnapPoint): SnapPoint {
   if (typeof point !== 'string' || !point.endsWith('px')) return point
   const next = baseSnapPoints.value[1]
@@ -574,11 +574,8 @@ function adjustForSafeArea(point: SnapPoint, index: number): SnapPoint {
     return (windowHeight.value - safeAreaInsetTop.value) / windowHeight.value
   }
 
-  // First snap point (peek) → add bottom safe area (home indicator), unless a
-  // pinned footer is already holding that space open.
-  if (index === 0 && !hasFooter.value) {
-    return addPixels(point, safeAreaInsetBottom.value)
-  }
+  // First snap point (peek) → add bottom safe area (home indicator)
+  if (index === 0) return addPixels(point, safeAreaInsetBottom.value)
 
   return point
 }
@@ -616,6 +613,16 @@ const visibleHeight = computed(() => {
   }
   const point = activeSnapPoint.value ?? snapPoints.value[snapIndex.value]
   return point == null ? 0 : snapPointToPixels(point)
+})
+
+// Room the footer has to occupy: everything the sheet shows beyond its peek.
+// The peek belongs to the peek content alone, so a collapsed sheet shows just
+// that — the footer is parked below the fold and slides up as the sheet is
+// dragged open, arriving fully once there's its own height to spare.
+const footerSpace = computed(() => {
+  const peek = snapPoints.value[0]
+  const peekPx = peek == null ? 0 : snapPointToPixels(peek)
+  return Math.max(0, visibleHeight.value - peekPx)
 })
 
 // ==================== SNAP POINT SYNCING ====================
@@ -838,6 +845,7 @@ function handleAnimationEnd(open: boolean) {
             '0 -4px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1)',
           '--sheet-visible-height': `${visibleHeight}px`,
           '--sheet-footer-height': `${footerHeight}px`,
+          '--sheet-footer-space': `${footerSpace}px`,
         }"
         :data-vaul-no-drag="!isAtTop ? '' : undefined"
       >
@@ -942,7 +950,7 @@ function handleAnimationEnd(open: boolean) {
             :class="hasFooter ? 'pb-[env(safe-area-inset-bottom)]' : ''"
             :style="{
               transform:
-                'translateY(max(0px, calc(var(--sheet-footer-height) - var(--sheet-visible-height))))',
+                'translateY(max(0px, calc(var(--sheet-footer-height) - var(--sheet-footer-space))))',
             }"
           ></div>
         </div>

--- a/web/src/components/BottomSheet.vue
+++ b/web/src/components/BottomSheet.vue
@@ -465,8 +465,16 @@ watch(
 const DYNAMIC_PEEK_BUFFER = 12
 
 const peekEl = ref<HTMLElement | null>(null)
-provide('sheetPeekRegister', (el: HTMLElement | null) => {
-  peekEl.value = el
+let peekOwner: symbol | null = null
+provide('sheetPeekRegister', (owner: symbol, el: HTMLElement | null) => {
+  if (el) {
+    peekOwner = owner
+    peekEl.value = el
+  } else if (peekOwner === owner) {
+    // Only the holder can give the anchor up — see `useSheetPeek`.
+    peekOwner = null
+    peekEl.value = null
+  }
 })
 
 // useElementSize gives us a reactive trigger whenever the peek content's box

--- a/web/src/components/BottomSheet.vue
+++ b/web/src/components/BottomSheet.vue
@@ -76,6 +76,10 @@
  *   --sheet-visible-height  how much of the sheet is currently on screen
  *   --sheet-footer-height   height of the pinned footer, 0 when there is none
  *   --sheet-footer-space    how much of that footer has been revealed
+ *
+ * `--keyboard-inset-height` (from `useVirtualKeyboard`, published app-wide) is
+ * respected too: the scroll surface reserves that much extra room at the end
+ * and the footer rides above the keyboard rather than under it.
  */
 import type { HTMLAttributes } from 'vue'
 import {
@@ -931,6 +935,9 @@ function handleAnimationEnd(open: boolean) {
           <div class="w-full h-[env(safe-area-inset-bottom)]"></div>
           <!-- Clear the pinned footer so the last row can still be read. -->
           <div v-if="hasFooter" :style="{ height: `${footerHeight}px` }"></div>
+          <!-- And clear the on-screen keyboard, so reaching the end of a list
+               doesn't mean dismissing the keyboard you're typing into. -->
+          <div class="w-full h-[var(--keyboard-inset-height,0px)]"></div>
         </div>
 
         <!-- Pinned footer. A fit-content sheet really does end at the viewport
@@ -954,7 +961,7 @@ function handleAnimationEnd(open: boolean) {
             :class="hasFooter ? 'pb-[env(safe-area-inset-bottom)]' : ''"
             :style="{
               transform:
-                'translateY(max(0px, calc(var(--sheet-footer-height) - var(--sheet-footer-space))))',
+                'translateY(calc(max(0px, calc(var(--sheet-footer-height) - var(--sheet-footer-space))) - var(--keyboard-inset-height, 0px)))',
             }"
           ></div>
         </div>

--- a/web/src/components/BottomSheet.vue
+++ b/web/src/components/BottomSheet.vue
@@ -908,6 +908,10 @@ function handleAnimationEnd(open: boolean) {
           :class="
             cn('pb-[env(safe-area-inset-bottom)]', {
               'flex-1 h-[200vh]': !props.fitContent,
+              // A content-sized sheet is capped by its own max-height, so the
+              // surface has to be allowed to shrink under its content before it
+              // will scroll rather than overflow the drawer.
+              'min-h-0': props.fitContent,
               'overflow-y-auto': isFullyExpanded,
               'overflow-y-hidden': !isFullyExpanded,
             })

--- a/web/src/components/dashboard/DashboardHome.vue
+++ b/web/src/components/dashboard/DashboardHome.vue
@@ -233,6 +233,7 @@ function recentSubtitle(subtitle: string | null | undefined, at: number): string
         <Palette
           ref="paletteRef"
           search-on-open
+          fill
           @input-focused="onPaletteInputFocused"
           @update:open="val => { if (!val) onPaletteClosed() }"
         />

--- a/web/src/components/layouts/DetailPanelLayout.vue
+++ b/web/src/components/layouts/DetailPanelLayout.vue
@@ -1,14 +1,17 @@
 <script setup lang="ts">
-import { ref, watchEffect } from 'vue'
 import { Button } from '@/components/ui/button'
 import { ArrowLeftIcon } from 'lucide-vue-next'
-import { useSheetPeek } from '@/composables/useSheetPeek'
+import { SheetHeader } from '@/components/sheet'
 
 /**
- * Sheet layout with a sticky header containing back button, title, and optional actions.
- * Use this for detail views that need navigation.
+ * Sheet layout with a sticky header containing back button, title, and optional
+ * actions. Use this for detail views that need navigation.
+ *
+ * Like every panel layout this is a plain column that grows with its content —
+ * the host sheet owns the scroll surface. See the layout contract in
+ * `components/BottomSheet.vue`.
  */
-const props = defineProps<{
+defineProps<{
   title?: string
   showBackButton?: boolean
   /**
@@ -22,20 +25,14 @@ const props = defineProps<{
 const emit = defineEmits<{
   back: []
 }>()
-
-const headerEl = ref<HTMLElement | null>(null)
-const { peekRef } = useSheetPeek()
-watchEffect(() => {
-  peekRef.value = props.peekHeader ? headerEl.value : null
-})
 </script>
 
 <template>
-  <div class="h-full flex flex-col">
-    <!-- Header -->
-    <div
-      ref="headerEl"
-      class="sticky top-0 z-10 bg-background/80 backdrop-blur-xl border-b border-border/50"
+  <div class="min-h-full flex flex-col">
+    <SheetHeader
+      :peek="!!peekHeader"
+      :solid="false"
+      class="bg-background/80 backdrop-blur-xl border-b border-border/50"
     >
       <div class="flex items-center gap-3 px-4 py-3">
         <Button
@@ -57,14 +54,13 @@ watchEffect(() => {
 
         <slot name="actions" />
       </div>
-    </div>
+    </SheetHeader>
 
     <!-- Content -->
-    <div class="flex-1 overflow-y-auto pt-2 pb-4">
+    <div class="flex-1 pt-2 pb-4">
       <div class="px-4">
         <slot />
       </div>
     </div>
   </div>
 </template>
-

--- a/web/src/components/library/BookmarkList.vue
+++ b/web/src/components/library/BookmarkList.vue
@@ -190,7 +190,7 @@ async function handleRemoveFromCollection(bookmark: Bookmark) {
     </div>
 
     <!-- Places List -->
-    <div v-else class="flex flex-col gap-2 pb-4 flex-1 overflow-y-auto touch-pan-y">
+    <div v-else class="flex flex-col gap-2 pb-4 flex-1">
       <BookmarkCard
         v-for="bookmark in filteredBookmarks"
         :key="bookmark.id"

--- a/web/src/components/map/controls/LayerControl.vue
+++ b/web/src/components/map/controls/LayerControl.vue
@@ -14,7 +14,8 @@ import ResponsiveHoverCard from '@/components/responsive/ResponsiveHoverCard.vue
     :side-offset="12"
     desktop-content-class="w-[380px] max-w-[calc(100vw-3.75rem)] max-h-[min(460px,calc(100vh-10rem))] overflow-y-auto rounded-md p-0 shadow-xl"
     mobile-content-class="p-0 pt-11"
-    :custom-snap-points="['400px', 0.7, 1]"
+    :custom-snap-points="['400px', 1]"
+    dynamic-peek
   >
     <template #trigger>
       <Button variant="outline" size="icon-sm" class="rounded-md size-11">

--- a/web/src/components/map/controls/LayerControl.vue
+++ b/web/src/components/map/controls/LayerControl.vue
@@ -14,7 +14,7 @@ import ResponsiveHoverCard from '@/components/responsive/ResponsiveHoverCard.vue
     :side-offset="12"
     desktop-content-class="w-[380px] max-w-[calc(100vw-3.75rem)] max-h-[min(460px,calc(100vh-10rem))] overflow-y-auto rounded-md p-0 shadow-xl"
     mobile-content-class="p-0 pt-11"
-    :fit-content="true"
+    :custom-snap-points="['400px', 0.7, 1]"
   >
     <template #trigger>
       <Button variant="outline" size="icon-sm" class="rounded-md size-11">

--- a/web/src/components/map/controls/LayerControl.vue
+++ b/web/src/components/map/controls/LayerControl.vue
@@ -12,8 +12,8 @@ import ResponsiveHoverCard from '@/components/responsive/ResponsiveHoverCard.vue
     side="left"
     align="end"
     :side-offset="12"
-    desktop-content-class="w-[380px] max-w-[calc(100vw-3.75rem)] overflow-hidden rounded-md p-0 shadow-xl"
-    mobile-content-class="p-0 pt-8"
+    desktop-content-class="w-[380px] max-w-[calc(100vw-3.75rem)] max-h-[min(460px,calc(100vh-10rem))] overflow-y-auto rounded-md p-0 shadow-xl"
+    mobile-content-class="p-0 pt-11"
     :fit-content="true"
   >
     <template #trigger>

--- a/web/src/components/navigation/LayersSelector.vue
+++ b/web/src/components/navigation/LayersSelector.vue
@@ -12,7 +12,7 @@ import { toRaw } from 'vue'
 import { useI18n } from 'vue-i18n'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
-import { ScrollArea } from '@/components/ui/scroll-area'
+import { SheetHeader } from '@/components/sheet'
 import { Switch } from '@/components/ui/switch'
 import { EmptyState } from '@/components/ui/empty-state'
 import ItemIcon from '@/components/ui/item-icon/ItemIcon.vue'
@@ -252,9 +252,17 @@ function findGroupNode(id: string, tree: any[]): any {
 </script>
 
 <template>
-  <div class="flex min-w-0 flex-col overflow-hidden">
-    <Tabs default-value="map" class="min-h-0">
-      <div class="flex items-end border-b px-3 pt-2.5">
+  <!-- A plain column: the host owns the scrolling — the bottom sheet's surface
+       on mobile, the hover card's on desktop. See the layout contract in
+       `components/BottomSheet.vue`. -->
+  <div class="flex min-w-0 flex-col">
+    <Tabs default-value="map">
+      <!-- Tabs pin while the layer tree scrolls under them. `peek` off: this
+           sheet is content-sized, so it has no peek detent to drive. -->
+      <SheetHeader
+        :peek="false"
+        class="flex items-end border-b px-3 pt-2.5"
+      >
         <TabsList variant="linear" class="w-full gap-2 border-b-0 sm:gap-5">
           <TabsTrigger value="map" variant="linear" class="flex-1">
             {{ t('layers.selector.tabs.map') }}
@@ -276,9 +284,9 @@ function findGroupNode(id: string, tree: any[]): any {
             {{ t('layers.selector.tabs.canvases') }}
           </TabsTrigger>
         </TabsList>
-      </div>
+      </SheetHeader>
 
-      <ScrollArea class="h-[min(460px,calc(100vh-10rem))] min-h-[260px]">
+      <div class="min-h-[260px]">
         <TabsContent value="map" class="m-0 space-y-3 p-3 focus-visible:ring-0">
           <section class="space-y-2">
             <p class="px-0.5 text-xs font-medium text-muted-foreground">
@@ -439,7 +447,7 @@ function findGroupNode(id: string, tree: any[]): any {
             variant="inline"
           />
         </TabsContent>
-      </ScrollArea>
+      </div>
     </Tabs>
   </div>
 </template>

--- a/web/src/components/navigation/LayersSelector.vue
+++ b/web/src/components/navigation/LayersSelector.vue
@@ -13,6 +13,7 @@ import { useI18n } from 'vue-i18n'
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group'
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
 import { SheetHeader } from '@/components/sheet'
+import { useSheetPeek } from '@/composables/useSheetPeek'
 import { Switch } from '@/components/ui/switch'
 import { EmptyState } from '@/components/ui/empty-state'
 import ItemIcon from '@/components/ui/item-icon/ItemIcon.vue'
@@ -48,6 +49,12 @@ const mapService = useMapService()
 const portolanStore = usePortolanTransitStore()
 const canvasesStore = useCanvasesStore()
 const { t } = useI18n()
+
+// The collapsed sheet fits the whole picker — tabs plus whatever the active
+// tab currently shows — so it rests around its content instead of an arbitrary
+// height, and re-snaps as groups expand. Capped below the full detent by the
+// host sheet. No-op on desktop.
+const { peekRef } = useSheetPeek()
 
 const {
   layers,
@@ -286,7 +293,7 @@ function findGroupNode(id: string, tree: any[]): any {
         </TabsList>
       </SheetHeader>
 
-      <div class="min-h-[260px]">
+      <div ref="peekRef" class="min-h-[260px]">
         <TabsContent value="map" class="m-0 space-y-3 p-3 focus-visible:ring-0">
           <section class="space-y-2">
             <p class="px-0.5 text-xs font-medium text-muted-foreground">

--- a/web/src/components/navigation/MobileNavigation.vue
+++ b/web/src/components/navigation/MobileNavigation.vue
@@ -6,6 +6,7 @@ import { Card } from '@/components/ui/card'
 import DashboardHome from '@/components/dashboard/DashboardHome.vue'
 import BottomSheet from '@/components/BottomSheet.vue'
 import AccountDropdown from '@/components/navigation/AccountDropdown.vue'
+import { SheetFooter } from '@/components/sheet'
 
 const route = useRoute()
 const activeSnapPoint = ref<number | string | null>(null)
@@ -63,10 +64,16 @@ watch(
       class="flex flex-col min-h-full p-2 bg-muted shadow-md rounded-b-none border-0"
     >
       <DashboardHome @update:palette-focused="v => paletteFocused = v" />
-
-      <div v-show="!paletteFocused" class="mt-auto pt-4 px-1">
-        <AccountDropdown @update:open="open => { if (open) minimizeSheet() }" />
-      </div>
     </Card>
+
+    <!-- The recents list below is endless, so the account row is pinned rather
+         than parked at the bottom of it — scrolling to the end to reach your
+         own account was never going to work. -->
+    <SheetFooter
+      v-if="!paletteFocused"
+      class="bg-muted border-t border-border/60 px-3 py-2"
+    >
+      <AccountDropdown @update:open="open => { if (open) minimizeSheet() }" />
+    </SheetFooter>
   </bottom-sheet>
 </template>

--- a/web/src/components/notes/NoteDetailPanel.vue
+++ b/web/src/components/notes/NoteDetailPanel.vue
@@ -2,6 +2,7 @@
 import { ref, computed } from 'vue'
 import { useI18n } from 'vue-i18n'
 import DetailPanelLayout from '@/components/layouts/DetailPanelLayout.vue'
+import { SheetFooter } from '@/components/sheet'
 import { Button } from '@/components/ui/button'
 import { Textarea } from '@/components/ui/textarea'
 import { Skeleton } from '@/components/ui/skeleton'
@@ -84,8 +85,8 @@ function handleReopen() {
 </script>
 
 <template>
-  <div class="h-full flex flex-col">
-    <DetailPanelLayout class="flex-1 min-h-0">
+  <div class="min-h-full flex flex-col">
+    <DetailPanelLayout class="flex-1">
       <template #title>
         <div class="flex items-center gap-2">
           <div class="relative shrink-0">
@@ -163,10 +164,11 @@ function handleReopen() {
       </template>
     </DetailPanelLayout>
 
-    <!-- Fixed footer -->
-    <div
+    <!-- Pinned footer — the comment box stays reachable however long the
+         thread gets. -->
+    <SheetFooter
       v-if="!loading && note"
-      class="shrink-0 border-t border-border/50 bg-background/80 backdrop-blur-xl px-4 py-3 space-y-3"
+      class="border-t border-border/50 bg-background/80 backdrop-blur-xl px-4 py-3 space-y-3"
     >
       <template v-if="isAuthenticated">
         <!-- Open note: comment box + comment/resolve buttons -->
@@ -221,6 +223,6 @@ function handleReopen() {
           </Button>
         </div>
       </template>
-    </div>
+    </SheetFooter>
   </div>
 </template>

--- a/web/src/components/palette/Palette.vue
+++ b/web/src/components/palette/Palette.vue
@@ -53,12 +53,30 @@ const props = withDefaults(
     searchOnOpen?: boolean
     open?: boolean
     showHints?: boolean
+    /**
+     * Let the results run to their natural length and hand the scrolling to
+     * whatever panel the palette sits in — the bottom sheet on mobile, the side
+     * panel on desktop — so a long list fills the screen instead of stopping
+     * half way down with empty space beneath it. Leave off inside a floating
+     * overlay (the ⌘K dialog), where the list has to bound itself.
+     */
+    fill?: boolean
   }>(),
   {
     searchOnOpen: false,
     open: true,
     showHints: false,
+    fill: false,
   },
+)
+
+// Inline, not a class: this has to beat CommandList's own `max-h-[50vh]`, and
+// which of two competing utility classes wins comes down to stylesheet order.
+// Both axes go visible together — CSS promotes a lone `overflow-y: visible`
+// back to `auto` when the other axis is clipped, which would quietly leave the
+// list a scroller again. Runaway width is caught by the Command root's clip.
+const listStyle = computed(() =>
+  props.fill ? { maxHeight: 'none', overflow: 'visible' } : undefined,
 )
 
 const { t } = useI18n()
@@ -502,7 +520,7 @@ const filterFunction = computed(() => {
 
       <template v-if="showResults">
         <!-- Top-level commands list -->
-        <CommandList v-if="!activeArgument">
+        <CommandList v-if="!activeArgument" :style="listStyle">
           <CommandGroup v-if="filteredCommands.length" heading="Commands">
             <CommandItem
               v-for="command in filteredCommands"
@@ -562,6 +580,7 @@ const filterFunction = computed(() => {
              no query typed so the empty state can show recents + shortcuts. -->
         <CommandList
           v-if="activeArgument && (!isSearch || query.length || (groupedArgumentOptions && groupedArgumentOptions.length > 0))"
+          :style="listStyle"
         >
           <div v-if="loadingOptions" class="py-6 text-center">
             <Spinner size="icon" class="mx-auto opacity-50" />

--- a/web/src/components/responsive/ResponsiveHoverCard.vue
+++ b/web/src/components/responsive/ResponsiveHoverCard.vue
@@ -74,6 +74,7 @@ watch(
       :modal="props.modal"
       :peek-height="props.peekHeight"
       :custom-snap-points="props.customSnapPoints"
+      :dynamic-peek="props.dynamicPeek"
       :fit-content="props.fitContent"
       :show-drag-handle="props.showDragHandle"
       :show-close-button="props.showCloseButton"

--- a/web/src/components/sheet/SheetFooter.vue
+++ b/web/src/components/sheet/SheetFooter.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import {
+  computed,
+  inject,
+  onUnmounted,
+  type HTMLAttributes,
+  type Ref,
+} from 'vue'
+import { cn } from '@/lib/utils'
+
+/**
+ * Pinned footer region of a sheet — see the layout contract in
+ * `components/BottomSheet.vue`.
+ *
+ * Stays on the sheet's bottom edge while the content above it scrolls, so a
+ * primary action stays reachable no matter how long the list is.
+ *
+ * A snap-point BottomSheet is a full-viewport-tall panel slid down off-screen,
+ * so its own bottom edge is nowhere near the visible one — a footer placed in
+ * the content flow (or stuck to the scroll surface's bottom) would sit below
+ * the fold. This teleports into the layer the sheet keeps pinned to its
+ * *visible* bottom edge instead. Without a host sheet (desktop LeftSheet, a
+ * plain panel) the fallback sticks to the bottom of the panel's own scroll
+ * surface, which is the same thing there.
+ */
+const props = defineProps<{
+  class?: HTMLAttributes['class']
+}>()
+
+interface SheetFooterHost {
+  target: Ref<HTMLElement | null>
+  register: () => void
+  unregister: () => void
+}
+
+const host = inject<SheetFooterHost | null>('sheetFooter', null)
+const target = computed(() => host?.target.value ?? null)
+
+host?.register()
+onUnmounted(() => host?.unregister())
+</script>
+
+<template>
+  <Teleport v-if="target" :to="target">
+    <div :class="props.class">
+      <slot />
+    </div>
+  </Teleport>
+
+  <div
+    v-else
+    :class="cn('sticky bottom-0 z-20 mt-auto bg-background', props.class)"
+  >
+    <slot />
+  </div>
+</template>

--- a/web/src/components/sheet/SheetHeader.vue
+++ b/web/src/components/sheet/SheetHeader.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import {
+  inject,
+  onMounted,
+  onUnmounted,
+  ref,
+  watchEffect,
+  type HTMLAttributes,
+} from 'vue'
+import { cn } from '@/lib/utils'
+import { useSheetPeek } from '@/composables/useSheetPeek'
+
+/**
+ * Sticky header region of a sheet — see the layout contract in
+ * `components/BottomSheet.vue`.
+ *
+ * Pins to the top of the host sheet's scroll surface while the content below
+ * scrolls under it, docking beneath the sheet's chrome (drag handle + nav
+ * buttons) via `--sheet-sticky-top`. It also becomes the sheet's peek anchor
+ * by default, so the collapsed detent rests exactly around this header.
+ *
+ * Renders in place — it never portals — so it works the same from a routed
+ * view inside the mobile sheet, from a direct child, and inside the desktop
+ * LeftSheet (where the sticky top is simply 0 and there is no peek).
+ */
+const props = withDefaults(
+  defineProps<{
+    class?: HTMLAttributes['class']
+    /**
+     * Size the host sheet's collapsed (peek) detent to this header. Turn off
+     * for a secondary sticky bar that shouldn't drive the detent — e.g. a tab
+     * row below a header that already anchors the peek.
+     */
+    peek?: boolean
+    /**
+     * Opaque backing so scrolled content dissolves behind the header. Turn off
+     * to supply your own (a gradient, a blur, a fade tied to scroll state).
+     */
+    solid?: boolean
+  }>(),
+  { peek: true, solid: true },
+)
+
+const el = ref<HTMLElement | null>(null)
+const { peekRef } = useSheetPeek()
+watchEffect(() => {
+  peekRef.value = props.peek ? el.value : null
+})
+
+// Opt the host sheet into its opaque chrome bar: with a header pinned to the
+// scroll surface, content has to scroll cleanly *under* the drag handle rather
+// than be shoved below it. Claims are counted by the sheet, so overlapping
+// headers (a pushed sub-page over the view it came from) don't fight. No-op
+// outside a BottomSheet.
+const chromeBar = inject<{
+  acquire: () => void
+  release: () => void
+} | null>('sheetChromeBarClaim', null)
+onMounted(() => chromeBar?.acquire())
+onUnmounted(() => chromeBar?.release())
+</script>
+
+<template>
+  <div
+    ref="el"
+    :class="cn('sticky z-20', props.solid && 'bg-background', props.class)"
+    :style="{ top: 'var(--sheet-sticky-top, 0px)' }"
+  >
+    <slot />
+  </div>
+</template>

--- a/web/src/components/sheet/index.ts
+++ b/web/src/components/sheet/index.ts
@@ -1,0 +1,2 @@
+export { default as SheetHeader } from './SheetHeader.vue'
+export { default as SheetFooter } from './SheetFooter.vue'

--- a/web/src/composables/useResponsiveOverlay.ts
+++ b/web/src/composables/useResponsiveOverlay.ts
@@ -10,6 +10,11 @@ export interface ResponsiveOverlayBaseProps {
   showCloseButton?: boolean
   peekHeight?: number | string
   customSnapPoints?: (number | string)[]
+  /**
+   * Mobile only: size the collapsed detent to the content rather than to
+   * `peekHeight`. The content marks its peek region with `useSheetPeek()`.
+   */
+  dynamicPeek?: boolean
 }
 
 /**

--- a/web/src/composables/useSheetPeek.ts
+++ b/web/src/composables/useSheetPeek.ts
@@ -23,6 +23,11 @@ import { ref, inject, watch, onUnmounted, type Ref } from 'vue'
  *
  * No-op when there is no host sheet (desktop LeftSheet, or any BottomSheet that
  * hasn't opted into `dynamic-peek`) — the inject simply resolves to null.
+ *
+ * Most views don't need this directly: `<SheetHeader>` registers itself as the
+ * peek anchor, which is the common case. Reach for the composable when the peek
+ * region isn't the sticky header — e.g. Place, where the collapsed detent fits
+ * the title and action buttons but nothing pins.
  */
 export function useSheetPeek(): { peekRef: Ref<HTMLElement | null> } {
   const register = inject<((el: HTMLElement | null) => void) | null>(

--- a/web/src/composables/useSheetPeek.ts
+++ b/web/src/composables/useSheetPeek.ts
@@ -30,17 +30,25 @@ import { ref, inject, watch, onUnmounted, type Ref } from 'vue'
  * the title and action buttons but nothing pins.
  */
 export function useSheetPeek(): { peekRef: Ref<HTMLElement | null> } {
-  const register = inject<((el: HTMLElement | null) => void) | null>(
-    'sheetPeekRegister',
-    null,
-  )
+  const register = inject<
+    ((owner: symbol, el: HTMLElement | null) => void) | null
+  >('sheetPeekRegister', null)
   const peekRef = ref<HTMLElement | null>(null)
 
   if (register) {
+    // Each caller registers under its own identity, so clearing only clears if
+    // this caller is the one currently holding the anchor. Views legitimately
+    // overlap — a `<SheetHeader peek="false">` above content that anchors the
+    // peek itself, or a pushed sub-page over the view it came from — and
+    // without this the later mount (or the earlier unmount) wins by accident.
+    const owner = Symbol('sheet-peek')
     // Register on mount and whenever the element swaps (v-if regions). The
     // immediate run covers the case where the ref is already populated.
-    watch(peekRef, el => register(el), { immediate: true, flush: 'post' })
-    onUnmounted(() => register(null))
+    watch(peekRef, el => register(owner, el), {
+      immediate: true,
+      flush: 'post',
+    })
+    onUnmounted(() => register(owner, null))
   }
 
   return { peekRef }

--- a/web/src/composables/useVirtualKeyboard.ts
+++ b/web/src/composables/useVirtualKeyboard.ts
@@ -1,0 +1,70 @@
+import { getCurrentScope, onScopeDispose, readonly, ref } from 'vue'
+
+/**
+ * How much of the screen the on-screen keyboard is currently covering.
+ *
+ * There's no portable keyboard API, so this reads the gap the keyboard opens up
+ * between the layout viewport and the visual viewport. When a browser shrinks
+ * the layout viewport instead — Android's `resizes-content` behaviour — that
+ * gap is zero, which is the right answer there: the page has already been laid
+ * out around the keyboard and needs no padding of its own.
+ *
+ * The value is published as `--keyboard-inset-height` on the document element,
+ * so layout can react in CSS alone, and is `0px` whenever no keyboard is up.
+ * Call it once high in the tree (App); the listeners are shared.
+ */
+
+const height = ref(0)
+let subscribers = 0
+
+function measure() {
+  const viewport = window.visualViewport
+  const next = viewport
+    ? Math.max(
+        0,
+        Math.round(window.innerHeight - viewport.height - viewport.offsetTop),
+      )
+    : 0
+  if (next === height.value) return
+  height.value = next
+  document.documentElement.style.setProperty(
+    '--keyboard-inset-height',
+    `${next}px`,
+  )
+}
+
+function attach() {
+  // Publish the resting value up front, so the property always resolves rather
+  // than leaning on every `var()` call site carrying a fallback.
+  document.documentElement.style.setProperty('--keyboard-inset-height', '0px')
+  // The visual viewport also *scrolls* under a keyboard (iOS pans the page to
+  // keep the focused field visible), so both events matter.
+  window.visualViewport?.addEventListener('resize', measure)
+  window.visualViewport?.addEventListener('scroll', measure)
+  window.addEventListener('resize', measure)
+  measure()
+}
+
+function detach() {
+  window.visualViewport?.removeEventListener('resize', measure)
+  window.visualViewport?.removeEventListener('scroll', measure)
+  window.removeEventListener('resize', measure)
+  height.value = 0
+  document.documentElement.style.setProperty('--keyboard-inset-height', '0px')
+}
+
+export function useVirtualKeyboard() {
+  if (typeof window !== 'undefined') {
+    if (subscribers === 0) attach()
+    subscribers += 1
+
+    if (getCurrentScope()) {
+      onScopeDispose(() => {
+        subscribers -= 1
+        if (subscribers === 0) detach()
+      })
+    }
+  }
+
+  return { keyboardHeight: readonly(height) }
+}

--- a/web/src/views/friends/FriendDetail.vue
+++ b/web/src/views/friends/FriendDetail.vue
@@ -259,14 +259,14 @@ watch([isLoading, friend], ([loading, f]) => {
 </script>
 
 <template>
-  <div v-if="isLoading" class="h-full flex items-center justify-center">
+  <div v-if="isLoading" class="min-h-full flex items-center justify-center">
     <div class="animate-pulse text-muted-foreground">
       {{ t('general.loading') }}
     </div>
   </div>
 
-  <div v-else-if="friend" class="h-full flex flex-col">
-    <div class="flex-1 overflow-y-auto pt-2 pb-4">
+  <div v-else-if="friend" class="min-h-full flex flex-col">
+    <div class="flex-1 pt-2 pb-4">
       <div class="px-4">
 
     <!-- Hero profile -->

--- a/web/src/views/library/Library.vue
+++ b/web/src/views/library/Library.vue
@@ -74,7 +74,7 @@ function handleTabChange(tabId: string | number) {
       <Tabs
         :model-value="tabValue"
         @update:model-value="handleTabChange"
-        class="w-full h-full flex flex-col"
+        class="w-full min-h-full flex flex-col"
       >
         <div class="-mx-3 px-3 flex items-end border-b" style="width: calc(100% + 1.5rem)">
           <TabsList variant="linear" class="border-b-0">

--- a/web/src/views/library/canvases/Canvases.vue
+++ b/web/src/views/library/canvases/Canvases.vue
@@ -77,7 +77,7 @@ function openCreated(canvas: Canvas) {
 
   <div
     v-else-if="!sorted.length"
-    class="h-full flex items-start justify-center p-4"
+    class="min-h-full flex items-start justify-center p-4"
   >
     <EmptyState
       :icon="MapIcon"
@@ -92,7 +92,7 @@ function openCreated(canvas: Canvas) {
     </EmptyState>
   </div>
 
-  <div v-else class="h-full flex flex-col gap-2">
+  <div v-else class="min-h-full flex flex-col gap-2">
     <div class="flex items-center gap-2">
       <div class="relative flex-1">
         <SearchIcon

--- a/web/src/views/library/collections/Collection.vue
+++ b/web/src/views/library/collections/Collection.vue
@@ -59,7 +59,7 @@ function handleCollectionDelete() {
 </script>
 
 <template>
-  <div v-if="loading" class="h-full flex items-center justify-center">
+  <div v-if="loading" class="min-h-full flex items-center justify-center">
     <div class="text-muted-foreground">
       {{ t('library.loading.collection') }}
     </div>

--- a/web/src/views/library/collections/Collections.vue
+++ b/web/src/views/library/collections/Collections.vue
@@ -29,7 +29,7 @@ const loading = computed(() => {
 </script>
 
 <template>
-  <div class="h-full flex flex-col">
+  <div class="min-h-full flex flex-col">
     <EmptyState
       v-if="showEmptyState"
       :icon="FolderIcon"

--- a/web/src/views/library/layers/Layers.vue
+++ b/web/src/views/library/layers/Layers.vue
@@ -74,7 +74,7 @@ const isEmpty = computed(
     <Spinner />
   </div>
 
-  <div v-else-if="isEmpty" class="h-full flex items-start justify-center p-4">
+  <div v-else-if="isEmpty" class="min-h-full flex items-start justify-center p-4">
     <EmptyState
       :icon="Layers3Icon"
       :title="t('layers.empty.title')"
@@ -88,7 +88,7 @@ const isEmpty = computed(
     </EmptyState>
   </div>
 
-  <div v-else class="h-full flex flex-col gap-2">
+  <div v-else class="min-h-full flex flex-col gap-2">
     <div class="flex items-center gap-2">
       <div class="relative flex-1">
         <SearchIcon

--- a/web/src/views/library/routes/Routes.vue
+++ b/web/src/views/library/routes/Routes.vue
@@ -27,7 +27,7 @@ const loading = computed(
 </script>
 
 <template>
-  <div class="h-full flex flex-col">
+  <div class="min-h-full flex flex-col">
     <div
       v-if="showEmptyState"
       class="flex-1 flex flex-col items-center gap-3 mt-32"

--- a/web/src/views/search/Search.vue
+++ b/web/src/views/search/Search.vue
@@ -27,6 +27,7 @@ import { PermissionId } from '@/types/auth.types'
 import { newViewFraction } from '@/lib/map-bounds.utils'
 import { useGeolocationService } from '@/services/geolocation.service'
 import { Spinner } from '@/components/ui/spinner'
+import { findScrollAncestor } from '@/lib/scroll'
 
 const route = useRoute()
 const router = useRouter()
@@ -494,15 +495,34 @@ async function loadMoreResults() {
   }
 }
 
-// Infinite scroll: pull the next page when the list nears the bottom.
-function onResultsScroll(e: Event) {
-  const el = e.target as HTMLElement
-  if (el.scrollHeight - el.scrollTop - el.clientHeight < 400) {
-    loadMoreResults()
-  }
+/**
+ * Infinite scroll. The scroll surface belongs to the host sheet (see the layout
+ * contract in `components/BottomSheet.vue`), so this listens to it rather than
+ * to a scroller of its own.
+ */
+const RESULTS_LOAD_MARGIN = 400
+const rootEl = ref<HTMLElement | null>(null)
+let scrollEl: HTMLElement | null = null
+
+function onResultsScroll() {
+  if (!scrollEl) return
+  const remaining =
+    scrollEl.scrollHeight - scrollEl.clientHeight - scrollEl.scrollTop
+  if (remaining < RESULTS_LOAD_MARGIN) loadMoreResults()
 }
 
+// A page that doesn't fill the sheet leaves nothing to scroll, and so no way to
+// ask for the next one. `loadMoreResults` stops itself once the server says
+// there is no more.
+watch(
+  () => searchStore.searchResults.length,
+  () => nextTick(onResultsScroll),
+)
+
 onMounted(async () => {
+  scrollEl = findScrollAncestor(rootEl.value)
+  scrollEl?.addEventListener('scroll', onResultsScroll, { passive: true })
+
   // Listen for search result clicks from map markers
   searchClickHandler = (event: Event) => {
     const customEvent = event as CustomEvent
@@ -536,6 +556,8 @@ onMounted(async () => {
 })
 
 onUnmounted(() => {
+  scrollEl?.removeEventListener('scroll', onResultsScroll)
+
   // Clear search results when leaving the page
   // This will automatically hide the search results layer and clear its data
   // via the reactive watchers in the layers service
@@ -581,7 +603,7 @@ watch(
 </script>
 
 <template>
-  <div class="h-full flex flex-col gap-3 pt-4 px-4">
+  <div ref="rootEl" class="min-h-full flex flex-col gap-3 pt-4 px-4">
     <!-- Search Header -->
     <div
       v-if="!searchStore.isLoading || searchStore.hasResults"
@@ -673,8 +695,7 @@ watch(
     <!-- Results take up remaining space -->
     <div
       v-if="searchStore.hasResults || searchStore.isLoading"
-      class="flex-1 overflow-auto"
-      @scroll.passive="onResultsScroll"
+      class="flex-1"
     >
       <div class="max-w-4xl mx-auto">
         <PlaceList

--- a/web/src/views/timeline/Timeline.vue
+++ b/web/src/views/timeline/Timeline.vue
@@ -346,7 +346,7 @@ onBeforeUnmount(() => {
     </div>
 
     <!-- Body -->
-    <div class="flex-1 overflow-y-auto -mx-4">
+    <div class="flex-1 -mx-4">
       <div v-if="loading" class="flex justify-center py-12">
         <Spinner />
       </div>

--- a/web/src/views/trackers/TrackerDetail.vue
+++ b/web/src/views/trackers/TrackerDetail.vue
@@ -111,12 +111,12 @@ watch(vehicle, (v) => {
 </script>
 
 <template>
-  <div v-if="!vehicle" class="h-full flex items-center justify-center">
+  <div v-if="!vehicle" class="min-h-full flex items-center justify-center">
     <div class="animate-pulse text-muted-foreground">Loading...</div>
   </div>
 
-  <div v-else class="h-full flex flex-col">
-    <div class="flex-1 overflow-y-auto pt-2 pb-4">
+  <div v-else class="min-h-full flex flex-col">
+    <div class="flex-1 pt-2 pb-4">
       <div class="px-4">
 
         <!-- Hero -->


### PR DESCRIPTION
The mobile dashboard's recents list is endless, so the account dropdown parked
below it was unreachable — you had to scroll past every recent place to get to
your own account. It's now pinned to the bottom of the sheet, with the list
scrolling between the search field and it.

Getting there meant writing down how scrolling inside a bottom sheet actually
works, and then fixing the views that were doing it wrong.

## The layout contract

Every sheet is now three optional regions, documented at the top of
`BottomSheet.vue` and in [parchment-docs](https://github.com/alexwohlbruck/parchment-docs/pull/9):

```
sticky header    <SheetHeader>   pins to the top; sizes the peek detent
scrollable content               the one and only scroll surface
pinned footer    <SheetFooter>   rides the sheet's visible bottom edge
```

Both new components live in `components/sheet` and render in place, so they work
the same from a routed view inside the mobile sheet, from a direct child, and
inside the desktop side panel.

**Why the footer needs a portal.** A snap-point sheet is a full-viewport-tall
panel translated down by the detent, so its own bottom edge sits far below the
fold — `position: sticky; bottom: 0` sticks to an off-screen edge. The sheet now
keeps a thin layer pinned to its *visible* bottom edge (sized by a new
`--sheet-visible-height`) and `<SheetFooter>` teleports into it. The layer holds
only the footer, so resizing it during a drag never touches the content's
layout. The peek detent grows by the footer's height, so a collapsed sheet shows
its peek content *and* its footer.

## Views fixed

The shape to look for is `h-full` + an inner `flex-1 overflow-y-auto`: the inner
scroller swallows the upward pan, so the sheet can't be expanded from inside its
content or dragged back down once scrolled. Removed from:

- `DetailPanelLayout` (collections, notes, layer and canvas editors, public canvases)
- Search results — infinite scroll now listens to the sheet's surface via `findScrollAncestor`, matching what the dashboard already did
- Timeline, `BookmarkList`, friend and tracker details
- Library index views, which were `h-full` where they wanted `min-h-full`

The note detail's comment box became a real `<SheetFooter>` — it was only
pinning by accident, via the scroller this removes.

## Checks

- `vue-tsc` clean, 2183 unit tests pass
- Verified on the preview at iPhone 12 Pro size: footer sits on the viewport bottom at the peek detent, stays there through a drag to full height, and content scrolls clear of it. Collection detail's header docks below the drag handle via `--sheet-sticky-top`.

Preview: https://vega5.tailc47d6.ts.net:8401