### PR TITLE
Fade map bullets by service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@
 * On the dark map, the rest of the network stays more visible behind an opened line.
 * An opened line sits on its own track rather than beside it, with stop dots sized to the line and drawn in its colour — no more white bundle markers or dots left in a lane the line no longer runs in.
 * An opened line shows its stop names and connection bullets at every zoom, including the whole-route overview.
-* Route bullets on the map fade for lines that aren't running at a station, matching the stop list. The map used to go by the timetable alone, which on a holiday or a reroute day says every line is running.
+* Route bullets on the map fade for lines that aren't running at a station, matching the stop list and the station header. The map used to go by the timetable alone, which reads the wrong day on a holiday — Labor Day runs a Sunday service, and the map still showed you Monday's.
 * A line's alerts now read in three tiers: disruptions in effect keep their full-width cards, service notices condense to one line each, and scheduled work stays folded away. Rows in effect no longer all repeat "Now".
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 * Live trains show on a line's stop timeline again, at the right point along it — they had collected at the top, taking the route line with them, once the list dropped the stops a line isn't running.
 * A line's page shows the trains that are actually running. On the 4 that meant 2 of the 21 in service, because most trains are only named by the part of the realtime feed we ignored — and a server running ten minutes slow discarded most of the rest.
 * Alerts for another railway no longer appear on a subway line. Metro-North and the LIRR each number a route "4" too, and all three share one alert feed.
+* An opened line keeps the map's own stations and bullets while you pan. Panning off the route could swap them for plain dots and labels partway through looking at it.
 * An isolated line ends where the trains really turn. When every 4 stops at Crown Hts–Utica Av, the map's line stops there too, instead of running on down a branch the schedule says it serves.
 * The train picker counts what it lists. It used to announce a train that was heading the other way and then offer nothing to select; trains running the other direction now live behind the direction toggle.
 * Connection bullets in a line's stop list fade when the line they name isn't running, matching the station page. They used to fade for being reachable by transfer — a fact about the walk between platforms, not about service.

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -7,8 +7,9 @@
  *     Headsign     Now, 7 min  📶
  *     Headsign     12, 25 min  📶
  */
-import { computed, markRaw, onBeforeUnmount, watch } from 'vue'
+import { computed, markRaw, onBeforeUnmount, onUnmounted, watch } from 'vue'
 import { setPlaceTransitLines, usePlaceTransferLines, type StationLine } from '@/composables/usePlaceTransitLines'
+import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
 import { useI18n } from 'vue-i18n'
 import type { Place, TransitDeparture, TransitStopInfo } from '@/types/place.types'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
@@ -57,6 +58,8 @@ const hasTransitData = computed(() => {
   return transitInfo.value && (transitInfo.value.onestopId || transitInfo.value.stopId || transitInfo.value.departures?.length)
 })
 
+const portolan = usePortolanTransitService()
+
 const departures = computed((): TransitDeparture[] => {
   return transitInfo.value?.departures || []
 })
@@ -93,6 +96,28 @@ watch(
     }),
   { immediate: true },
 )
+
+/**
+ * The same reading, given to the map, so this station's bullets there fade
+ * exactly as the ones under the title do.
+ *
+ * The map's own answer comes from the tiles' activity masks, which are a
+ * WEEKLY timetable: today is a Monday, so they report the Monday service
+ * even when the agency is running a Sunday one for the holiday. Only a
+ * board knows that, and this is a board.
+ */
+watch(
+  [() => transitInfo.value?.stopId, runningRouteIds],
+  ([stopId, running]) => {
+    portolan.setStopService(
+      'place',
+      stopId && running.size ? new Map([[stopId, running]]) : null,
+    )
+  },
+  { immediate: true },
+)
+
+onUnmounted(() => portolan.setStopService('place', null))
 
 /** The bullets the map draws for these routes: portolan's curated shape,
  *  colour and label, resolved against the stop's own coordinates. */

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -524,9 +524,19 @@ function syncIsolatedLine() {
  */
 let stopService: Map<string, Set<string>> | null = null
 let stopServiceSig = ''
+/** Per publisher, so an opened line and an opened station can both answer
+ *  without erasing each other on the way in or out. */
+const stopServiceBySource = new Map<string, Map<string, Set<string>>>()
 
-function setStopService(running: Map<string, Set<string>> | null) {
-  const next = running && running.size ? running : null
+function setStopService(source: string, running: Map<string, Set<string>> | null) {
+  if (running?.size) stopServiceBySource.set(source, running)
+  else stopServiceBySource.delete(source)
+
+  const merged = new Map<string, Set<string>>()
+  for (const entries of stopServiceBySource.values()) {
+    for (const [stopId, routes] of entries) merged.set(stopId, routes)
+  }
+  const next = merged.size ? merged : null
   const sig = next
     ? [...next].map(([k, v]) => `${k}:${[...v].sort().join('+')}`).sort().join(';')
     : ''

--- a/web/src/services/layers/features/route-isolation.service.ts
+++ b/web/src/services/layers/features/route-isolation.service.ts
@@ -179,6 +179,18 @@ export function useRouteIsolationService() {
   let renderedSig = ''
 
   /**
+   * Who is drawing this isolation — decided ONCE, and never revisited.
+   *
+   * The test for "does portolan draw this route" reads the tiles loaded
+   * right now, so it answers no whenever the map has panned off the route.
+   * Re-running it on every settle (boards answering, alerts landing) let a
+   * pan tear portolan's ribbon, stations and bullets down and replace them
+   * mid-view with the plain shape-and-circles overlay. A later render may
+   * change WHAT is drawn; it may not change WHO draws it.
+   */
+  let renderer: 'portolan' | 'overlay' | null = null
+
+  /**
    * The route's shape cut down to the span between the running path's two
    * end stops, or null when there is nothing to cut with. The ends are
    * found by the stops' own distance-along metric, then projected onto the
@@ -218,6 +230,7 @@ export function useRouteIsolationService() {
     const generation = ++isolationGeneration
     isIsolated = true
     renderedSig = ''
+    renderer = null
     render(route, generation)
   }
 
@@ -239,6 +252,7 @@ export function useRouteIsolationService() {
     /** Portolan draws the route: dim everything else and stand the overlay
      *  down. Idempotent — the reconciler may land here repeatedly. */
     const renderViaPortolan = (token: string) => {
+      renderer = 'portolan'
       portolan.setIsolatedRoute(token)
       if (!portolanIsolated) {
         portolanIsolated = true
@@ -253,6 +267,7 @@ export function useRouteIsolationService() {
      *  only view there is. It too draws the running span, not the full
      *  timetable line. */
     const renderViaOverlay = () => {
+      renderer = 'overlay'
       if (portolanIsolated) {
         portolan.setIsolatedRoute(null)
         portolanIsolated = false
@@ -280,6 +295,14 @@ export function useRouteIsolationService() {
       broken ? runningSlice(route) : null,
       route.routeColor,
     )
+
+    // Settled already: the renderer stands, and the geometry above is the
+    // only thing this pass had to say.
+    if (renderer === 'portolan') return
+    if (renderer === 'overlay') {
+      renderViaOverlay()
+      return
+    }
 
     // First paint, from what is knowable right now. Optimistic about
     // portolan: asking for the token this instant would answer "no" for a
@@ -375,6 +398,7 @@ export function useRouteIsolationService() {
     if (!mapInstance || !isIsolated) return
     isolationGeneration++
     renderedSig = ''
+    renderer = null
     detachReconciler()
 
     if (portolanIsolated) {

--- a/web/src/services/layers/features/route-isolation.service.ts
+++ b/web/src/services/layers/features/route-isolation.service.ts
@@ -112,7 +112,7 @@ export function useRouteIsolationService() {
     // not running exactly where the stop list fades them.
     serviceWatchStop = watch(
       () => routeDetailStore.stopRunningRoutes,
-      (running) => portolan.setStopService(running.size ? running : null),
+      (running) => portolan.setStopService('route', running.size ? running : null),
       { immediate: true },
     )
 


### PR DESCRIPTION
Follows #467, which merged while this was in progress. Two changes, both about the map agreeing with the panel beside it.

## A station's own page fades its map bullets

#467 taught the map to fade a bullet for a line that isn't running, but only fed it from an opened **route**. An opened **station** had the same board data and was only giving it to the header — so the header dimmed the 2 and the 5 at Crown Hts–Utica while the map beside it showed all four lit.

The station page now publishes to the same channel. That channel is keyed by publisher (`route` / `place`) so an opened line and an opened station can each answer without erasing the other on teardown.

Worth stating plainly, because it is the whole reason boards are needed here: the tiles' `acts` masks are a **weekly** timetable indexed by day-of-week. Today is Labor Day — a Monday running a Sunday service — and the masks report Monday's, where the 2 and 5 do serve Utica. GTFS holiday exceptions (`calendar_dates.txt`) aren't in them, so no timestamp can correct it. Only a board knows.

Still limited to stations a board has been read for (an opened line or station). On the plain network map the timetable still answers.

## An isolation's renderer is decided once

A regression I introduced in #467. `render()` became re-entrant so the map could react as boards and alerts settled — but it also held the decision of *which* renderer draws the line, and that test scans the tiles **currently loaded**. So each settle re-asked the question; if the map had panned off the route, the answer came back "portolan doesn't draw this", the reconciler counted three idles, and it tore down portolan's ribbon, stations and bullets for the plain shape-and-circles overlay — mid-view.

Now: who draws is decided once per isolation and never revisited. A later pass may change *what* is drawn (the geometry, when a break is confirmed); it may not change *who*. Reset only on opening another route or closing the panel.

Reproduced and verified: opened the 4, panned to Queens while the boards were landing, waited out the idles, panned back — no `route-detail-*` layers at any point, 72 portolan ribbon layers, 23 portolan stations, Crown Hts–Utica reading `2~ | 3 | 4 | 5~`. Before, it was white dots and plain labels by then.

Tests: 2225 pass, typecheck clean.