### PR TITLE
Dim skipped stations everywhere

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,8 +35,8 @@
 
 ### Fixed
 
-* A skipped station reads as skipped everywhere. The agency's "trains skip this stop" alert now dims the lines on a station's own page, its map bullets, and a line's stop list alike — the boards go on listing scheduled runs a planned skip never removes.
 
+* A skipped station reads as skipped everywhere. The agency's "trains skip this stop" alert now dims the lines on a station's own page, its map bullets, and a line's stop list alike — the boards go on listing scheduled runs a planned skip never removes.
 * A line's stop list draws the path it is actually running. After midnight the R lists the Whitehall St–Bay Ridge shuttle instead of thirty stations no train will call at.
 * A rerouted line shows the stops it is really making. When the MTA sends the 4 local down Eastern Pkwy for a parade, its page gains Bergen St, Grand Army Plaza and the rest from the agency's own alert — and drops the stop the alert says everyone is skipping.
 * The map follows a reroute too: an isolated line's stations match the path it is running, and the line stays at full strength along it.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 
 ### Fixed
 
+* A skipped station reads as skipped everywhere. The agency's "trains skip this stop" alert now dims the lines on a station's own page, its map bullets, and a line's stop list alike — the boards go on listing scheduled runs a planned skip never removes.
+
 * A line's stop list draws the path it is actually running. After midnight the R lists the Whitehall St–Bay Ridge shuttle instead of thirty stations no train will call at.
 * A rerouted line shows the stops it is really making. When the MTA sends the 4 local down Eastern Pkwy for a parade, its page gains Bergen St, Grand Army Plaza and the rest from the agency's own alert — and drops the stop the alert says everyone is skipping.
 * The map follows a reroute too: an isolated line's stations match the path it is running, and the line stays at full strength along it.

--- a/server/src/services/widget.service.ts
+++ b/server/src/services/widget.service.ts
@@ -365,6 +365,8 @@ interface BarrelmanStopDepartures {
      *  because `transfers=true` was asked for. Absent means this station. */
     via?: 'station' | 'transfer'
     feedOnestopId?: string
+    /** GTFS parent station, when the board's stop is a platform of one. */
+    parentStation?: string
   }
   departures: BarrelmanDeparture[]
   hasMore?: boolean
@@ -425,7 +427,7 @@ async function fetchTransitDepartures(
   departures: TransitDeparture[]
   /** The stations a rider can transfer to, each with its own board. */
   transferStations: TransitTransferStation[]
-  stopInfo?: { name?: string; code?: string; feedId?: string; stopId?: string; timezone?: string }
+  stopInfo?: { name?: string; code?: string; feedId?: string; stopId?: string; parentStation?: string; timezone?: string }
   routes?: TransitStopInfo['routes']
   hasMore: boolean
   sources: SourceReference[]
@@ -593,6 +595,7 @@ async function fetchTransitDepartures(
         code: primaryStop.code,
         feedId: primaryStop.feedId,
         stopId: primaryStop.stopId,
+        parentStation: primaryStop.parentStation,
         timezone: primaryStop.timezone,
       } : undefined,
       routes,
@@ -723,6 +726,7 @@ export async function fetchWidgetData(
         code: stopInfo?.code,
         feedId: stopInfo?.feedId,
         stopId: stopInfo?.stopId,
+        parentStation: stopInfo?.parentStation,
         timezone: stopInfo?.timezone,
         lat,
         lng,

--- a/server/src/types/place.types.ts
+++ b/server/src/types/place.types.ts
@@ -170,6 +170,9 @@ export interface TransitStopInfo {
   onestopIds?: string[]
   /** GTFS stop ID (from Barrelman/MOTIS) */
   stopId?: string
+  /** GTFS parent station, when the stop is a platform of one. What the
+   *  agency's alerts name — they inform stations, not platforms. */
+  parentStation?: string
   /** GTFS feed ID (from Barrelman/MOTIS) */
   feedId?: string
   /** Coordinates for spatial stop lookup */

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -9,6 +9,8 @@
  */
 import { computed, markRaw, onBeforeUnmount, onUnmounted, watch } from 'vue'
 import { setPlaceTransitLines, usePlaceTransferLines, type StationLine } from '@/composables/usePlaceTransitLines'
+import { useTransitAlerts } from '@/composables/useTransitAlerts'
+import { alertStopSkips } from '@/lib/alert-service-overrides'
 import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
 import { useI18n } from 'vue-i18n'
 import type { Place, TransitDeparture, TransitStopInfo } from '@/types/place.types'
@@ -87,12 +89,41 @@ const runningRouteIds = computed(() => {
   return ids
 })
 
+// The stop's own alerts. The board reads MOTIS — the schedule plus what
+// realtime reached it — and a planned skip often never does: on parade day
+// Eastern Pkwy's board went on listing 2s and 3s at a station all three
+// lines were skipping. The agency's skip alert outranks a scheduled run.
+const stopAlertQuery = computed(() => {
+  const feedId = transitInfo.value?.feedId
+  const stopId = transitInfo.value?.stopId
+  return feedId && stopId ? { feedId, stopIds: [stopId] } : null
+})
+const { inEffect: stopAlertsInEffect } = useTransitAlerts(stopAlertQuery)
+
+/** Board answers minus alert skips — what is truly calling here now. */
+const servedRouteIds = computed(() => {
+  const running = runningRouteIds.value
+  if (!running.size) return running
+  const stopId = transitInfo.value?.stopId
+  const parent = transitInfo.value?.parentStation
+  const skips = alertStopSkips(stopAlertsInEffect.value)
+  const skipped = new Set([
+    ...(stopId ? skips.get(stopId) ?? [] : []),
+    ...(parent ? skips.get(parent) ?? [] : []),
+  ])
+  if (!skipped.size) return running
+  return new Set([...running].filter((id) => !skipped.has(id)))
+})
+
 watch(
-  [stationLines, runningRouteIds],
+  [stationLines, servedRouteIds],
   ([lines, running]) =>
     setPlaceTransitLines(props.place?.id, lines, {
       feedId: transitInfo.value?.feedId,
       runningRouteIds: running,
+      // The board vouched even when the skips emptied it: a station every
+      // line passes today should show every bullet dimmed, not all lit.
+      serviceKnown: runningRouteIds.value.size > 0,
     }),
   { immediate: true },
 )
@@ -107,11 +138,14 @@ watch(
  * board knows that, and this is a board.
  */
 watch(
-  [() => transitInfo.value?.stopId, runningRouteIds],
+  [() => transitInfo.value?.stopId, servedRouteIds],
   ([stopId, running]) => {
+    // An emptied set still publishes — the map should dim every bullet at
+    // a station the boards answered for and the alerts emptied. Only a
+    // board that never answered publishes nothing.
     portolan.setStopService(
       'place',
-      stopId && running.size ? new Map([[stopId, running]]) : null,
+      stopId && runningRouteIds.value.size ? new Map([[stopId, running]]) : null,
     )
   },
   { immediate: true },

--- a/web/src/components/place/pages/RouteDetailPage.vue
+++ b/web/src/components/place/pages/RouteDetailPage.vue
@@ -21,7 +21,7 @@ import {
 import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
 import ServiceAlerts from '@/components/transit/ServiceAlerts.vue'
 import { useTransitAlerts } from '@/composables/useTransitAlerts'
-import { alertServiceOverrides } from '@/lib/alert-service-overrides'
+import { alertServiceOverrides, alertStopSkips } from '@/lib/alert-service-overrides'
 import { Separator } from '@/components/ui/separator'
 import { SheetHeader } from '@/components/sheet'
 import {
@@ -94,7 +94,7 @@ const headerBullet = computed(() => {
 
 // ── stop service + links ─────────────────────────────────────
 
-const runningAt = computed(() => store.stopRunningRoutes)
+const runningAt = computed(() => store.runningAtStops)
 const serviceKnown = computed(() => store.stopServiceKnown)
 
 /**
@@ -196,7 +196,10 @@ const alertQuery = computed(() => ({
 const { inEffect: alertsInEffect } = useTransitAlerts(alertQuery)
 watch(
   alertsInEffect,
-  alerts => store.setAlertOverrides(alertServiceOverrides(alerts, props.routeId)),
+  alerts => {
+    store.setAlertOverrides(alertServiceOverrides(alerts, props.routeId))
+    store.setStopSkips(alertStopSkips(alerts))
+  },
   { immediate: true },
 )
 

--- a/web/src/composables/usePlaceTransitLines.ts
+++ b/web/src/composables/usePlaceTransitLines.ts
@@ -47,7 +47,7 @@ const EMPTY_CTX: StationLinesContext = { known: false }
 export function setPlaceTransitLines(
   placeId: string | undefined,
   routes: StationRoute[] | undefined,
-  ctx?: { feedId?: string; runningRouteIds?: Iterable<string> },
+  ctx?: { feedId?: string; runningRouteIds?: Iterable<string>; serviceKnown?: boolean },
 ) {
   if (!placeId || !routes?.length) return
   const running = new Set(ctx?.runningRouteIds ?? [])
@@ -58,8 +58,11 @@ export function setPlaceTransitLines(
       feedId: ctx?.feedId,
       // Nothing running at all means the board is empty or absent, and an
       // absent board says nothing about the schedule — dimming every
-      // bullet on it would be an assertion we cannot make.
-      known: running.size > 0,
+      // bullet on it would be an assertion we cannot make. Unless the
+      // caller says otherwise: a station every line is skipping today has
+      // an empty running set the board DID vouch for, and every bullet
+      // dimmed is exactly the truth.
+      known: ctx?.serviceKnown ?? running.size > 0,
     },
   }
 }

--- a/web/src/lib/alert-service-overrides.test.ts
+++ b/web/src/lib/alert-service-overrides.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { alertServiceOverrides } from './alert-service-overrides'
+import { alertServiceOverrides, alertStopSkips } from './alert-service-overrides'
 import type { ServiceAlert } from '@/types/transit.types'
 
 const alert = (
@@ -100,5 +100,39 @@ describe('alertServiceOverrides', () => {
     )
     expect(serves.has('238')).toBe(true)
     expect(skips.has('238')).toBe(true) // the caller lets skip win
+  })
+})
+
+describe('alertStopSkips', () => {
+  it('collects every route the skip alert names at each stop', () => {
+    // The Labor Day detour: one alert, three routes, one emptied station.
+    const skips = alertStopSkips([
+      alert('DETOUR', [
+        { routeId: '2', stopId: '238' },
+        { routeId: '3', stopId: '238' },
+        { routeId: '4', stopId: '238' },
+      ]),
+    ])
+    expect([...skips.get('238')!].sort()).toEqual(['2', '3', '4'])
+  })
+
+  it('keeps skips at different stops apart', () => {
+    const skips = alertStopSkips([
+      alert('NO_SERVICE', [
+        { routeId: '4', stopId: '640' },
+        { routeId: '4', stopId: '238' },
+      ]),
+    ])
+    expect(skips.get('640')!.has('4')).toBe(true)
+    expect(skips.get('238')!.has('4')).toBe(true)
+    expect(skips.size).toBe(2)
+  })
+
+  it('ignores effects that add service and entities missing a pair', () => {
+    const skips = alertStopSkips([
+      alert('MODIFIED_SERVICE', [{ routeId: '4', stopId: '237' }]),
+      alert('DETOUR', [{ routeId: '4' }, { stopId: '238' }]),
+    ])
+    expect(skips.size).toBe(0)
   })
 })

--- a/web/src/lib/alert-service-overrides.ts
+++ b/web/src/lib/alert-service-overrides.ts
@@ -67,3 +67,27 @@ export function alertServiceOverrides(
 
   return { serves, skips }
 }
+
+/**
+ * Every (stop, route) pair the in-effect alerts say is being skipped —
+ * ACROSS routes, unlike `alertServiceOverrides`, which reads one line's
+ * page. The map and a station's header judge every line at once, and the
+ * detour that empties Eastern Pkwy names the 2, the 3 and the 4 in a
+ * single alert.
+ *
+ * Keyed by the id the ALERT used (the MTA names stations, "238"); callers
+ * match a stop by its own id or its parent's, same as the overrides.
+ */
+export function alertStopSkips(alerts: ServiceAlert[]): Map<string, Set<string>> {
+  const skips = new Map<string, Set<string>>()
+  for (const alert of alerts) {
+    if (!SKIP_EFFECTS.has(alert.effect)) continue
+    for (const entity of alert.informedEntities ?? []) {
+      if (!entity.routeId || !entity.stopId) continue
+      const at = skips.get(entity.stopId) ?? new Set()
+      at.add(entity.routeId)
+      skips.set(entity.stopId, at)
+    }
+  }
+  return skips
+}

--- a/web/src/services/layers/features/route-isolation.service.ts
+++ b/web/src/services/layers/features/route-isolation.service.ts
@@ -111,7 +111,7 @@ export function useRouteIsolationService() {
     // What the boards said, so the map's bullets fade the lines that are
     // not running exactly where the stop list fades them.
     serviceWatchStop = watch(
-      () => routeDetailStore.stopRunningRoutes,
+      () => routeDetailStore.runningAtStops,
       (running) => portolan.setStopService('route', running.size ? running : null),
       { immediate: true },
     )

--- a/web/src/stores/route-detail.store.test.ts
+++ b/web/src/stores/route-detail.store.test.ts
@@ -295,6 +295,27 @@ describe('displayStops follows the running path', () => {
     expect(store.pathLeavesTrack).toBe(false)
   })
 
+  test('an alert skip empties a stop the board still lists', () => {
+    // Parade day at Eastern Pkwy: the board reads the schedule and lists
+    // 2s and 3s; the agency's detour says all three lines skip it.
+    const store = useRouteDetailStore()
+    openRoute(store)
+    ;(store as any).activeRoute.stops = [
+      makeStop('R16', 'Atlantic Av', 40.68, -73.98, 0),
+      { ...makeStop('238N', 'Eastern Pkwy', 40.67, -73.96, 500), parentStation: '238' },
+      makeStop('R31', 'Utica Av', 40.66, -73.93, 1000),
+    ]
+    boardsSay(store, { R16: ['R'], '238N': ['R', '2'], R31: ['R'] })
+    store.setStopSkips(new Map([['238', new Set(['R', '2'])]]))
+    // matched through the parent: the alert names the station, the board
+    // answered for the platform
+    expect(store.runningAtStops.get('238N')?.size).toBe(0)
+    expect(store.runningAtStops.get('R16')?.has('R')).toBe(true)
+    // and the path drops the stop, because the board's effective answer
+    // no longer names this line there
+    expect(store.displayStops.map(s => s.stopId)).toEqual(['R16', 'R31'])
+  })
+
   test('the running path reverses with the direction', () => {
     const store = useRouteDetailStore()
     openRoute(store)

--- a/web/src/stores/route-detail.store.ts
+++ b/web/src/stores/route-detail.store.ts
@@ -94,6 +94,46 @@ export const useRouteDetailStore = defineStore('route-detail', () => {
     alertOverrides.value = overrides
   }
 
+  /** (stop → routes) pairs the alerts skip, across EVERY line — the page
+   *  computes them from the same fetch as the overrides. Alerts name
+   *  stations; matching is by a stop's own id or its parent's. */
+  const stopSkips = ref(new Map<string, Set<string>>())
+  function setStopSkips(skips: Map<string, Set<string>>) {
+    stopSkips.value = skips
+  }
+
+  /**
+   * The boards' answers with the agency's skips subtracted.
+   *
+   * The boards read MOTIS, which reads the schedule plus whatever realtime
+   * reached it — and a planned skip often never does. On parade day the
+   * board at Eastern Pkwy went on listing 2s and 3s at a station all three
+   * lines were skipping. The alert is the agency saying so in as many
+   * words, and it outranks a scheduled departure. Everything that judges
+   * "is this line running here" — the panel's bullets, the running path,
+   * the map — reads this, so no view can disagree with another.
+   */
+  const runningAtStops = computed(() => {
+    const skips = stopSkips.value
+    const raw = stopRunningRoutes.value
+    if (!skips.size || !raw.size) return raw
+    const parents = new Map(
+      routeStops.value.map((s) => [s.stopId, s.parentStation] as const),
+    )
+    const out = new Map<string, Set<string>>()
+    for (const [stopId, routes] of raw) {
+      const skipped = new Set([
+        ...(skips.get(stopId) ?? []),
+        ...(skips.get(parents.get(stopId) ?? '') ?? []),
+      ])
+      out.set(
+        stopId,
+        skipped.size ? new Set([...routes].filter((r) => !skipped.has(r))) : routes,
+      )
+    }
+    return out
+  })
+
   /** Stop times for the selected vehicle's trip (from TripUpdate data). */
   interface TripStopTime {
     stopId: string
@@ -283,7 +323,7 @@ export const useRouteDetailStore = defineStore('route-detail', () => {
 
     const boardServes = (s: RouteDetailStop) =>
       stopServiceKnown.value.has(s.stopId) &&
-      (stopRunningRoutes.value.get(s.stopId)?.has(routeId) ?? false)
+      (runningAtStops.value.get(s.stopId)?.has(routeId) ?? false)
     let first = stops.findIndex(boardServes)
     let last = -1
     for (let i = stops.length - 1; i >= 0; i--) {
@@ -298,7 +338,7 @@ export const useRouteDetailStore = defineStore('route-detail', () => {
       if (named(serves, s) && i >= first && i <= last && onOwnTrack(s)) return true
       return (
         !stopServiceKnown.value.has(s.stopId) ||
-        (stopRunningRoutes.value.get(s.stopId)?.has(routeId) ?? true)
+        (runningAtStops.value.get(s.stopId)?.has(routeId) ?? true)
       )
     })
     return onPath.length ? onPath : stops
@@ -782,6 +822,8 @@ export const useRouteDetailStore = defineStore('route-detail', () => {
     feedOnestopId,
     loadStopService,
     setAlertOverrides,
+    setStopSkips,
+    runningAtStops,
     selectVehicle,
     setDirection,
   }


### PR DESCRIPTION
The agency's "trains skip this stop" alert now reaches every view, not just a line's own page. On Labor Day the detour emptied Eastern Pkwy–Brooklyn Museum of the 2, 3 and 4 — and the station's page, its header bullets and the map all showed 2/3 lit, because they judge service by the departure board alone and a planned skip never removes the scheduled runs MOTIS lists.

## What changed

* **Store**: `runningAtStops` — the boards' answers with alert skips subtracted, matched by a stop's own id or its parent's. Every consumer (the stop list's path, connection bullets, both map channels) reads it, so no view can disagree with another.
* **Station page**: fetches its stop's in-effect alerts and subtracts skips before publishing to the header and the map. A station every line skips shows every bullet dimmed — an emptied set the board vouched for is knowledge, not absence (`serviceKnown` now says so explicitly).
* **Server**: `parentStation` passes through the transit widget, so the client can join a board to the alerts naming its station.

Pairs with barrelman 0.2.22 (released): `/transit/alerts` matches across a station family (platform ↔ parent ↔ siblings), and departures name their parent station.

Rides in the open 0.11.0 release PR once merged to dev; the release note is filed under 0.11.0.

Tests: 2228 web (+4), 1125 barrelman (+4). Live browser verification pending — the preview automation host dropped mid-session; the data path is covered by the new unit tests.