### PR TITLE
Skip-aware departure boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+* A departure board no longer lists trains an alert says will skip the station. The runs after the skip window stay — their times are what say when the station reopens.
 * Station bullets on the map fade with the timetable's clock everywhere, not only where a page has been opened — the B's bullet steps back at 3am on a map nobody asked anything of. A read board still outranks the clock, and the time slider's hour applies when it is set.
 ## [0.11.0] - 2026-09-07
 

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -10,7 +10,7 @@
 import { computed, markRaw, onBeforeUnmount, onUnmounted, watch } from 'vue'
 import { setPlaceTransitLines, usePlaceTransferLines, type StationLine } from '@/composables/usePlaceTransitLines'
 import { useTransitAlerts } from '@/composables/useTransitAlerts'
-import { alertStopSkips } from '@/lib/alert-service-overrides'
+import { alertStopSkips, filterSkippedDepartures } from '@/lib/alert-service-overrides'
 import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
 import { useI18n } from 'vue-i18n'
 import type { Place, TransitDeparture, TransitStopInfo } from '@/types/place.types'
@@ -62,8 +62,16 @@ const hasTransitData = computed(() => {
 
 const portolan = usePortolanTransitService()
 
+// The board with the runs a skip alert disowns removed — a station closed
+// for a parade until 9:30 must not list a 2 "in 5 minutes". Judged per run
+// against the alert's window, so the trains after it stay: their times ARE
+// the reopening.
 const departures = computed((): TransitDeparture[] => {
-  return transitInfo.value?.departures || []
+  const raw = transitInfo.value?.departures || []
+  return filterSkippedDepartures(raw, stopAlertsInEffect.value, [
+    transitInfo.value?.stopId,
+    transitInfo.value?.parentStation,
+  ])
 })
 
 /** Every line serving this station, across its whole transfer complex.

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -14,6 +14,7 @@ import {
 import ServiceAlerts from '@/components/transit/ServiceAlerts.vue'
 import ServiceAlertBadge from '@/components/transit/ServiceAlertBadge.vue'
 import { useTransitAlerts } from '@/composables/useTransitAlerts'
+import { filterSkippedDepartures } from '@/lib/alert-service-overrides'
 import { alertsFor, worstAlert } from '@/lib/transit-alerts'
 import { api } from '@/lib/api'
 import { useExternalLink } from '@/composables/useExternalLink'
@@ -60,8 +61,14 @@ watch(
   () => { laterDepartures.value = null },
 )
 
+// Same rule the widget applies: runs a skip alert disowns come off the
+// board; the ones after the window stay, because they say when it lifts.
 const departures = computed((): TransitDeparture[] => {
-  return laterDepartures.value || props.transitInfo?.departures || []
+  const raw = laterDepartures.value || props.transitInfo?.departures || []
+  return filterSkippedDepartures(raw, stopAlerts.value, [
+    props.transitInfo?.stopId,
+    props.transitInfo?.parentStation,
+  ])
 })
 
 /** Same curated bullets as the card this page expands. */
@@ -184,7 +191,13 @@ const alertQuery = computed(() => {
   return {
     feedId,
     stopIds: [stopId],
-    routeIds: [...new Set(departures.value.map((d) => d.route?.id).filter(Boolean) as string[])],
+    // Off the RAW board, not the filtered one — the filter reads these
+    // alerts, and a query that read the filter back would chase itself.
+    routeIds: [...new Set(
+      (laterDepartures.value || props.transitInfo?.departures || [])
+        .map((d) => d.route?.id)
+        .filter(Boolean) as string[],
+    )],
     includeUpcoming: true,
   }
 })

--- a/web/src/lib/alert-service-overrides.test.ts
+++ b/web/src/lib/alert-service-overrides.test.ts
@@ -8,7 +8,11 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { alertServiceOverrides, alertStopSkips } from './alert-service-overrides'
+import {
+  alertServiceOverrides,
+  alertStopSkips,
+  filterSkippedDepartures,
+} from './alert-service-overrides'
 import type { ServiceAlert } from '@/types/transit.types'
 
 const alert = (
@@ -134,5 +138,61 @@ describe('alertStopSkips', () => {
       alert('DETOUR', [{ routeId: '4' }, { stopId: '238' }]),
     ])
     expect(skips.size).toBe(0)
+  })
+})
+
+describe('filterSkippedDepartures', () => {
+  const HOUR = 3_600_000
+  const iso = (ms: number) => new Date(ms).toISOString()
+  const dep = (routeId: string, at: number) => ({
+    route: { id: routeId },
+    departureAt: iso(at),
+  })
+  // The parade: 2/3/4 skip stop 238 from an hour ago until an hour from now.
+  const skip = {
+    ...alert('DETOUR', [
+      { routeId: '2', stopId: '238' },
+      { routeId: '3', stopId: '238' },
+      { routeId: '4', stopId: '238' },
+    ]),
+    activePeriods: [{ start: iso(Date.now() - HOUR), end: iso(Date.now() + HOUR) }],
+  }
+
+  it('drops runs inside the window and keeps the ones after it', () => {
+    const now = Date.now()
+    const out = filterSkippedDepartures(
+      [dep('2', now + 5 * 60_000), dep('4', now + 2 * HOUR)],
+      [skip],
+      ['238'],
+    )
+    // The 2 "in 5 minutes" is a train that will not stop; the 4 two hours
+    // out departs after the station reopens.
+    expect(out.map(d => d.route!.id)).toEqual(['4'])
+  })
+
+  it('leaves other routes and other stops alone', () => {
+    const now = Date.now()
+    const out = filterSkippedDepartures(
+      [dep('5', now + 5 * 60_000)],
+      [skip],
+      ['238'],
+    )
+    expect(out).toHaveLength(1)
+    expect(filterSkippedDepartures([dep('2', now)], [skip], ['999'])).toHaveLength(1)
+  })
+
+  it('matches through any of the stop ids given (platform or parent)', () => {
+    const now = Date.now()
+    const out = filterSkippedDepartures([dep('3', now)], [skip], ['238N', '238'])
+    expect(out).toHaveLength(0)
+  })
+
+  it('keeps a run it cannot time', () => {
+    const out = filterSkippedDepartures(
+      [{ route: { id: '2' } }],
+      [skip],
+      ['238'],
+    )
+    expect(out).toHaveLength(1)
   })
 })

--- a/web/src/lib/alert-service-overrides.ts
+++ b/web/src/lib/alert-service-overrides.ts
@@ -1,4 +1,5 @@
 import type { ServiceAlert } from '@/types/transit.types'
+import { isInEffect } from './transit-alerts'
 
 /**
  * What the agency's alerts say about which stops a line is serving right now.
@@ -90,4 +91,41 @@ export function alertStopSkips(alerts: ServiceAlert[]): Map<string, Set<string>>
     }
   }
   return skips
+}
+
+/**
+ * A departure board with the runs a skip alert disowns removed.
+ *
+ * The board reads MOTIS — the schedule plus whatever realtime reached it —
+ * and a planned skip often never does: a station closed for a parade until
+ * 9:30 went on listing 2s "in 5 minutes". Each run is judged at ITS OWN
+ * time against the alert's window, not the current one, so the trains that
+ * resume after the window stay on the board — which is exactly what tells
+ * a rider when the station reopens.
+ */
+export function filterSkippedDepartures<
+  T extends { route?: { id?: string }; departureAt?: string; arrivalAt?: string },
+>(
+  departures: T[],
+  alerts: ServiceAlert[],
+  stopIds: Array<string | null | undefined>,
+): T[] {
+  const ids = new Set(stopIds.filter(Boolean) as string[])
+  const skips = alerts.filter(
+    a => SKIP_EFFECTS.has(a.effect) &&
+      (a.informedEntities ?? []).some(e => e.routeId && e.stopId && ids.has(e.stopId)),
+  )
+  if (!ids.size || !skips.length) return departures
+
+  return departures.filter(d => {
+    const routeId = d.route?.id
+    const at = Date.parse(d.departureAt || d.arrivalAt || '')
+    if (!routeId || Number.isNaN(at)) return true
+    return !skips.some(
+      a => isInEffect(a, at) &&
+        (a.informedEntities ?? []).some(
+          e => e.routeId === routeId && e.stopId && ids.has(e.stopId),
+        ),
+    )
+  })
 }


### PR DESCRIPTION
Client half of barrelman #129 (released as 0.2.23, which fixes this server-side for every consumer): the departures widget and the full board page drop runs an in-effect skip alert disowns at this station, judged at each run's own time so post-window trains stay — their times say when the station reopens.

Kept client-side as well as server-side deliberately: the filter shares its alert fetch with the bullets and alert cards already on the page, so the page cannot disagree with itself even against an older API.

The alert query on the full board page now derives its routeIds from the RAW board — the filtered board depends on those alerts, and a query reading the filter back would chase itself.

Verified live at Eastern Pkwy–Brooklyn Museum during the parade closure: 10 of 50 runs dropped; the 2's first listed departure moved from "5 min" (a train that would not stop) to ~9:02pm, the first after reopening.

Tests: 13 in the overrides lib (+4), suites green.