### PR TITLE
Skip-aware boards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+* Station bullets on the map fade with the timetable's clock everywhere, not only where a page has been opened — the B's bullet steps back at 3am on a map nobody asked anything of. A read board still outranks the clock, and the time slider's hour applies when it is set.
 ## [0.11.0] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 ### Fixed
 
+* A departure board no longer lists trains an alert says will skip the station. The runs after the skip window stay — their times are what say when the station reopens.
 * Station bullets on the map fade with the timetable's clock everywhere, not only where a page has been opened — the B's bullet steps back at 3am on a map nobody asked anything of. A read board still outranks the clock, and the time slider's hour applies when it is set.
 ## [0.11.0] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,13 @@
 
 ### Fixed
 
+## [0.11.1] - 2026-09-07
+
+### Fixed
+
 * A departure board no longer lists trains an alert says will skip the station. The runs after the skip window stay — their times are what say when the station reopens.
 * Station bullets on the map fade with the timetable's clock everywhere, not only where a page has been opened — the B's bullet steps back at 3am on a map nobody asked anything of. A read board still outranks the clock, and the time slider's hour applies when it is set.
+
 ## [0.11.0] - 2026-09-07
 
 ### Added

--- a/RELEASE_TITLE
+++ b/RELEASE_TITLE
@@ -1,1 +1,1 @@
-Transit lines as they run
+Skip-aware boards

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build:emails": "cd emails && bun install && npx maizzle build production",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.11.0",
+  "version": "0.11.1",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.11.0"
+version = "0.11.1"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",
@@ -66,7 +66,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 11000
+      "versionCode": 11010
     }
   }
 }

--- a/web/src/components/place/details/PlaceTransit.vue
+++ b/web/src/components/place/details/PlaceTransit.vue
@@ -10,7 +10,7 @@
 import { computed, markRaw, onBeforeUnmount, onUnmounted, watch } from 'vue'
 import { setPlaceTransitLines, usePlaceTransferLines, type StationLine } from '@/composables/usePlaceTransitLines'
 import { useTransitAlerts } from '@/composables/useTransitAlerts'
-import { alertStopSkips } from '@/lib/alert-service-overrides'
+import { alertStopSkips, filterSkippedDepartures } from '@/lib/alert-service-overrides'
 import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
 import { useI18n } from 'vue-i18n'
 import type { Place, TransitDeparture, TransitStopInfo } from '@/types/place.types'
@@ -62,8 +62,16 @@ const hasTransitData = computed(() => {
 
 const portolan = usePortolanTransitService()
 
+// The board with the runs a skip alert disowns removed — a station closed
+// for a parade until 9:30 must not list a 2 "in 5 minutes". Judged per run
+// against the alert's window, so the trains after it stay: their times ARE
+// the reopening.
 const departures = computed((): TransitDeparture[] => {
-  return transitInfo.value?.departures || []
+  const raw = transitInfo.value?.departures || []
+  return filterSkippedDepartures(raw, stopAlertsInEffect.value, [
+    transitInfo.value?.stopId,
+    transitInfo.value?.parentStation,
+  ])
 })
 
 /** Every line serving this station, across its whole transfer complex.

--- a/web/src/components/place/pages/PlaceTransitPage.vue
+++ b/web/src/components/place/pages/PlaceTransitPage.vue
@@ -14,6 +14,7 @@ import {
 import ServiceAlerts from '@/components/transit/ServiceAlerts.vue'
 import ServiceAlertBadge from '@/components/transit/ServiceAlertBadge.vue'
 import { useTransitAlerts } from '@/composables/useTransitAlerts'
+import { filterSkippedDepartures } from '@/lib/alert-service-overrides'
 import { alertsFor, worstAlert } from '@/lib/transit-alerts'
 import { api } from '@/lib/api'
 import { useExternalLink } from '@/composables/useExternalLink'
@@ -60,8 +61,14 @@ watch(
   () => { laterDepartures.value = null },
 )
 
+// Same rule the widget applies: runs a skip alert disowns come off the
+// board; the ones after the window stay, because they say when it lifts.
 const departures = computed((): TransitDeparture[] => {
-  return laterDepartures.value || props.transitInfo?.departures || []
+  const raw = laterDepartures.value || props.transitInfo?.departures || []
+  return filterSkippedDepartures(raw, stopAlerts.value, [
+    props.transitInfo?.stopId,
+    props.transitInfo?.parentStation,
+  ])
 })
 
 /** Same curated bullets as the card this page expands. */
@@ -184,7 +191,13 @@ const alertQuery = computed(() => {
   return {
     feedId,
     stopIds: [stopId],
-    routeIds: [...new Set(departures.value.map((d) => d.route?.id).filter(Boolean) as string[])],
+    // Off the RAW board, not the filtered one — the filter reads these
+    // alerts, and a query that read the filter back would chase itself.
+    routeIds: [...new Set(
+      (laterDepartures.value || props.transitInfo?.departures || [])
+        .map((d) => d.route?.id)
+        .filter(Boolean) as string[],
+    )],
     includeUpcoming: true,
   }
 })

--- a/web/src/lib/alert-service-overrides.test.ts
+++ b/web/src/lib/alert-service-overrides.test.ts
@@ -8,7 +8,11 @@
  */
 
 import { describe, it, expect } from 'vitest'
-import { alertServiceOverrides, alertStopSkips } from './alert-service-overrides'
+import {
+  alertServiceOverrides,
+  alertStopSkips,
+  filterSkippedDepartures,
+} from './alert-service-overrides'
 import type { ServiceAlert } from '@/types/transit.types'
 
 const alert = (
@@ -134,5 +138,61 @@ describe('alertStopSkips', () => {
       alert('DETOUR', [{ routeId: '4' }, { stopId: '238' }]),
     ])
     expect(skips.size).toBe(0)
+  })
+})
+
+describe('filterSkippedDepartures', () => {
+  const HOUR = 3_600_000
+  const iso = (ms: number) => new Date(ms).toISOString()
+  const dep = (routeId: string, at: number) => ({
+    route: { id: routeId },
+    departureAt: iso(at),
+  })
+  // The parade: 2/3/4 skip stop 238 from an hour ago until an hour from now.
+  const skip = {
+    ...alert('DETOUR', [
+      { routeId: '2', stopId: '238' },
+      { routeId: '3', stopId: '238' },
+      { routeId: '4', stopId: '238' },
+    ]),
+    activePeriods: [{ start: iso(Date.now() - HOUR), end: iso(Date.now() + HOUR) }],
+  }
+
+  it('drops runs inside the window and keeps the ones after it', () => {
+    const now = Date.now()
+    const out = filterSkippedDepartures(
+      [dep('2', now + 5 * 60_000), dep('4', now + 2 * HOUR)],
+      [skip],
+      ['238'],
+    )
+    // The 2 "in 5 minutes" is a train that will not stop; the 4 two hours
+    // out departs after the station reopens.
+    expect(out.map(d => d.route!.id)).toEqual(['4'])
+  })
+
+  it('leaves other routes and other stops alone', () => {
+    const now = Date.now()
+    const out = filterSkippedDepartures(
+      [dep('5', now + 5 * 60_000)],
+      [skip],
+      ['238'],
+    )
+    expect(out).toHaveLength(1)
+    expect(filterSkippedDepartures([dep('2', now)], [skip], ['999'])).toHaveLength(1)
+  })
+
+  it('matches through any of the stop ids given (platform or parent)', () => {
+    const now = Date.now()
+    const out = filterSkippedDepartures([dep('3', now)], [skip], ['238N', '238'])
+    expect(out).toHaveLength(0)
+  })
+
+  it('keeps a run it cannot time', () => {
+    const out = filterSkippedDepartures(
+      [{ route: { id: '2' } }],
+      [skip],
+      ['238'],
+    )
+    expect(out).toHaveLength(1)
   })
 })

--- a/web/src/lib/alert-service-overrides.ts
+++ b/web/src/lib/alert-service-overrides.ts
@@ -1,4 +1,5 @@
 import type { ServiceAlert } from '@/types/transit.types'
+import { isInEffect } from './transit-alerts'
 
 /**
  * What the agency's alerts say about which stops a line is serving right now.
@@ -90,4 +91,41 @@ export function alertStopSkips(alerts: ServiceAlert[]): Map<string, Set<string>>
     }
   }
   return skips
+}
+
+/**
+ * A departure board with the runs a skip alert disowns removed.
+ *
+ * The board reads MOTIS — the schedule plus whatever realtime reached it —
+ * and a planned skip often never does: a station closed for a parade until
+ * 9:30 went on listing 2s "in 5 minutes". Each run is judged at ITS OWN
+ * time against the alert's window, not the current one, so the trains that
+ * resume after the window stay on the board — which is exactly what tells
+ * a rider when the station reopens.
+ */
+export function filterSkippedDepartures<
+  T extends { route?: { id?: string }; departureAt?: string; arrivalAt?: string },
+>(
+  departures: T[],
+  alerts: ServiceAlert[],
+  stopIds: Array<string | null | undefined>,
+): T[] {
+  const ids = new Set(stopIds.filter(Boolean) as string[])
+  const skips = alerts.filter(
+    a => SKIP_EFFECTS.has(a.effect) &&
+      (a.informedEntities ?? []).some(e => e.routeId && e.stopId && ids.has(e.stopId)),
+  )
+  if (!ids.size || !skips.length) return departures
+
+  return departures.filter(d => {
+    const routeId = d.route?.id
+    const at = Date.parse(d.departureAt || d.arrivalAt || '')
+    if (!routeId || Number.isNaN(at)) return true
+    return !skips.some(
+      a => isInEffect(a, at) &&
+        (a.informedEntities ?? []).some(
+          e => e.routeId === routeId && e.stopId && ids.has(e.stopId),
+        ),
+    )
+  })
 }

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -567,21 +567,35 @@ const bareRouteId = (token: string) => token.replace(/^f\d+:/, '')
 /**
  * A station's bullets, with the lines not running here faded.
  *
- * Leaves the feature untouched when no board covers it, so a map with no
- * service loaded looks exactly as it always did.
+ * Two authorities, in rank order. A departure board, where one has been
+ * read (an open station or line) — realtime, and the only source that
+ * knows a holiday timetable or a reroute. Everywhere else, the tiles'
+ * own activity masks at `at`: the timetable, which is what makes the B's
+ * bullet step back at 3am on a map nobody has asked anything of. A
+ * bullet is faded, never dropped — its absence reads as "wrong station",
+ * not "not now".
  */
-function serviceDimmedBullets(f: any): any {
+function serviceDimmedBullets(f: any, at: Date | null): any {
   const p = f.properties
   const labeled = p.ftype === 'station' || (p.ftype === 'marker' && p.nmarkers > 1)
   if (!labeled) return f
-  const running = serviceAt(p)
-  if (!running) return f
 
-  const routes = routesOf(p)
-  const ids = bulletIdsOf(p, i => {
-    const id = routes[i] ? bareRouteId(routes[i]) : ''
-    return !!id && !running.has(id)
-  })
+  const running = serviceAt(p)
+  if (running) {
+    const routes = routesOf(p)
+    const ids = bulletIdsOf(p, i => {
+      const id = routes[i] ? bareRouteId(routes[i]) : ''
+      return !!id && !running.has(id)
+    })
+    if (!ids.length) return f
+    return { ...f, properties: { ...p, brow: 'row-' + ids.join('|') } }
+  }
+
+  if (!at) return f
+  const idx = activeRouteIdx(p, NO_MASKS, at, classesOff)
+  if (!idx) return f // every line awake, or nothing to judge by
+  const awake = new Set(idx)
+  const ids = bulletIdsOf(p, i => !awake.has(i))
   if (!ids.length) return f
   return { ...f, properties: { ...p, brow: 'row-' + ids.join('|') } }
 }
@@ -809,10 +823,33 @@ function initializePortolanTransit(mapStrategy: MapStrategy | undefined) {
     clearMounts()
     bindListeners()
   }
+  startBulletClock()
   void sync()
 }
 
+/** The bullets fade by the wall clock when no slider is set, and a mask's
+ *  resolution is the hour — so re-apply once each hour turns over. */
+let bulletClockTimer: ReturnType<typeof setInterval> | null = null
+let bulletClockHour = -1
+
+function startBulletClock() {
+  if (bulletClockTimer) return
+  bulletClockHour = new Date().getHours()
+  bulletClockTimer = setInterval(() => {
+    const hour = new Date().getHours()
+    if (hour === bulletClockHour) return
+    bulletClockHour = hour
+    if (!serviceTime) applyStations()
+  }, 60_000)
+}
+
+function stopBulletClock() {
+  if (bulletClockTimer) clearInterval(bulletClockTimer)
+  bulletClockTimer = null
+}
+
 function teardownPortolanTransit() {
+  stopBulletClock()
   unbindListeners()
   if (map?.style && map.isStyleLoaded()) removeAll()
   map = null
@@ -2330,8 +2367,7 @@ function applyStations() {
           ? stationServesRoute(f.properties, isolatedRoute!, NO_MASKS, null) && onIsolatedPath(f)
           : stationServesRoute(f.properties, isolatedRoute!, NO_MASKS, at),
       )
-      .map((f: any) => timeFilteredBullets(f, at, classesOff))
-      .map((f: any) => serviceDimmedBullets(f))
+      .map((f: any) => serviceDimmedBullets(f, at))
       .map((f: any) => isolatedMarkerFeature(f, isolatedRoute!))
     src.setData({ type: 'FeatureCollection', features: feats })
     return
@@ -2340,14 +2376,17 @@ function applyStations() {
   const off = classesOff
   const filtered =
     date || off.size
-      ? stationsRaw.features
-          .filter((f: any) => stationVisible(f.properties, NO_MASKS, date, off))
-          .map((f: any) => timeFilteredBullets(f, date, off))
+      ? stationsRaw.features.filter((f: any) =>
+          stationVisible(f.properties, NO_MASKS, date, off),
+        )
       : stationsRaw.features
-  // The boards outrank the timetable wherever they have spoken, so this
-  // runs last and on every view — an opened station dims its own bullets
-  // the same way a route's stops do.
-  const feats = stopService ? filtered.map((f: any) => serviceDimmedBullets(f)) : filtered
+  // Bullet fade runs on EVERY view: boards outrank the timetable where one
+  // has been read, and the timetable's clock answers everywhere else — the
+  // slider's hour when it is set, the wall clock when it is not. The
+  // stations themselves keep the network view's rule (all hours drawn);
+  // only the bullets say what is awake.
+  const at = date ?? new Date()
+  const feats = filtered.map((f: any) => serviceDimmedBullets(f, at))
   src.setData({ type: 'FeatureCollection', features: feats })
 }
 
@@ -2381,28 +2420,3 @@ function isolatedMarkerFeature(f: any, routeId: string): any {
   return { ...f, properties: { ...p, icon: `dots-${hex}@0` } }
 }
 
-/** A surviving station's bullet strip shows only the routes awake at the
- *  chosen time (and in enabled classes) — the 2am map must not advertise
- *  lines that stopped at midnight. Pure: filtered features are copies,
- *  the cached data stays the union. */
-function timeFilteredBullets(f: any, date: Date | null, off: Set<string>): any {
-  const p = f.properties
-  const labeled = p.ftype === 'station' || (p.ftype === 'marker' && p.nmarkers > 1)
-  if (!labeled) return f
-  const idx = activeRouteIdx(p, NO_MASKS, date, off)
-  if (!idx) return f
-  const pick = (s: string) => {
-    const all = String(s ?? '').split(',')
-    return idx.map(i => all[i]).join(',')
-  }
-  const ids = bulletIdsOf({
-    labels: pick(p.labels),
-    route_colors: pick(p.route_colors),
-    modes: pick(p.modes),
-    shapes: pick(p.shapes),
-  })
-  const props = { ...p }
-  if (ids.length) props.brow = 'row-' + ids.join('|')
-  else delete props.brow
-  return { ...f, properties: props }
-}


### PR DESCRIPTION
### Fixed

* A departure board no longer lists trains an alert says will skip the station. The runs after the skip window stay — their times are what say when the station reopens.
* Station bullets on the map fade with the timetable's clock everywhere, not only where a page has been opened — the B's bullet steps back at 3am on a map nobody asked anything of. A read board still outranks the clock, and the time slider's hour applies when it is set.