### PR TITLE
Trains where they are

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@
 
 ### Fixed
 
+* Live trains sit where they are on a route's timeline. They were pinned to
+  the top of the stop list, and the line ran on past the last stop, whenever
+  the list shortened under the panel
+* A route's map shows only that line's own trains. The 4 drew the 5s and 6s
+  too, since all three are the same green
+* Picking a train fills the stop list with its times again
+* The train picker sits with the direction picker in the pinned header, and a
+  train no longer rides over that header while scrolling
+
 ## [0.11.1] - 2026-09-07
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Fixed
 
+## [0.11.2] - 2026-09-07
+
+### Fixed
+
 * Live trains sit where they are on a route's timeline. They were pinned to
   the top of the stop list, and the line ran on past the last stop, whenever
   the list shortened under the panel

--- a/RELEASE_TITLE
+++ b/RELEASE_TITLE
@@ -1,1 +1,1 @@
-Skip-aware boards
+Trains where they are

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "parchment",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "scripts": {
     "dev": "bun src/index.ts --watch",
     "build:emails": "cd emails && bun install && npx maizzle build production",

--- a/web/package.json
+++ b/web/package.json
@@ -1,7 +1,7 @@
 {
   "name": "parchment",
   "private": true,
-  "version": "0.11.1",
+  "version": "0.11.2",
   "type": "module",
   "scripts": {
     "dev": "vite --host",

--- a/web/src-tauri/Cargo.toml
+++ b/web/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "app"
-version = "0.11.1"
+version = "0.11.2"
 description = "A Tauri App"
 authors = ["you"]
 license = ""

--- a/web/src-tauri/tauri.conf.json
+++ b/web/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Parchment",
-  "version": "0.11.1",
+  "version": "0.11.2",
   "identifier": "app.parchment",
   "build": {
     "frontendDist": "../dist",
@@ -66,7 +66,7 @@
       "minimumSystemVersion": "16.0"
     },
     "android": {
-      "versionCode": 11010
+      "versionCode": 11020
     }
   }
 }

--- a/web/src/components/place/pages/RouteDetailPage.test.ts
+++ b/web/src/components/place/pages/RouteDetailPage.test.ts
@@ -144,12 +144,53 @@ describe('RouteDetailPage stop timeline', () => {
     expect(last.top + last.height).toBeCloseTo(134 + 12, 5)
   })
 
-  // Before the rows are measured there is nothing to segment, and a column
-  // of unconnected dots reads as "the line does not run here" — which is a
-  // claim the panel has no basis for. One whole-length line instead.
-  it('still draws a connected line before the rows are measured', async () => {
-    const wrapper = await mountWithStops(false)
-    const segs = wrapper.findAll('.absolute.z-0')
+  // The list shortens under the panel — alerts land and the run turns out
+  // to end early — and the spine has to shorten with it. It used to keep the
+  // longer list's measurements and run on past the last stop, off the bottom
+  // of the page.
+  it('does not outrun the last stop when the list shortens', async () => {
+    const wrapper = await mountWithStops(true)
+    const store = useRouteDetailStore()
+    await layOutRows(wrapper, [32, 70, 32, 54])
+
+    store.activeRoute = { ...store.activeRoute!, stops: [0, 1].map(i => stop(i, true)) }
+    await wrapper.vm.$nextTick()
+    await layOutRows(wrapper, [32, 70])
+
+    const dots = wrapper.findAll('.rounded-full.border-2')
+    expect(dots.length).toBe(2)
+    const segs = wrapper.findAll('.absolute.z-0').map(w => {
+      const style = w.attributes('style') ?? ''
+      return px(style, 'top') + px(style, 'height')
+    })
+    // one gap between two stops, ending on the second dot — not the fourth
     expect(segs.length).toBe(1)
+    expect(segs[0]).toBeCloseTo(12 + 32, 5)
+  })
+
+  // A train sits where it is along the line. When measurement went stale
+  // every one of them pinned to the top of the list instead, which read as
+  // a fleet parked at the terminus.
+  it('places a vehicle by its distance along the route', async () => {
+    const wrapper = await mountWithStops(false)
+    const store = useRouteDetailStore()
+    store.vehicles = new Map([
+      ['v1', {
+        vehicleId: 'v1',
+        feedId: 'f',
+        routeId: 'F',
+        position: { lat: 40.025, lng: -73 },
+        bearing: 0,
+        timestamp: new Date().toISOString(),
+      } as never],
+    ])
+    await wrapper.vm.$nextTick()
+    await layOutRows(wrapper, [40, 40, 40, 40])
+
+    const marker = wrapper.find('.absolute.z-20')
+    expect(marker.exists()).toBe(true)
+    // halfway between the third and fourth dots (12 + 40*2 = 92, next 132),
+    // and in any case well clear of the top of the list
+    expect(px(marker.attributes('style') ?? '', 'top')).toBeGreaterThan(60)
   })
 })

--- a/web/src/components/place/pages/RouteDetailPage.vue
+++ b/web/src/components/place/pages/RouteDetailPage.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUpdate, onMounted, onUnmounted, onUpdated, ref, watch } from 'vue'
+import { computed, onMounted, onUnmounted, onUpdated, ref, watch } from 'vue'
 import {
   useRouteDetailStore,
   type DepartureContext,
@@ -360,23 +360,31 @@ const STOP_DOT_CENTER_Y = 12
  * layout instead — re-measured whenever it changes.
  */
 const listEl = ref<HTMLElement | null>(null)
-const rowEls = ref<HTMLElement[]>([])
 const dotCenters = ref<number[]>([])
 
-// Vue fills a v-for ref array but never empties it, so a list that
-// SHRINKS keeps the tail entries of the longer one. That left more dot
-// centres than stops — the count check below then failed, and with it went
-// the per-gap spine and every vehicle's placement.
-onBeforeUpdate(() => { rowEls.value = [] })
+/**
+ * The rows, read from the DOM.
+ *
+ * Not from a `v-for` ref array: Vue fills one but never empties it, so a
+ * list that SHRANK kept the tail entries of the longer one — and once the
+ * count stopped matching, measurement bailed and left the old, longer
+ * numbers standing. That is what pinned every train to the top of the
+ * timeline and ran the line on past the last stop. The DOM cannot be stale.
+ */
+const rowEls = () =>
+  Array.from(listEl.value?.querySelectorAll<HTMLElement>('[data-stop-row]') ?? [])
 
 function measureRows() {
   const list = listEl.value
   if (!list) return
+  const rows = rowEls()
+  // A half-built list measures to nonsense, and numbers belonging to a
+  // different list are worse than none: drop them rather than draw with them.
+  if (rows.length !== displayStops.value.length) {
+    if (dotCenters.value.length !== displayStops.value.length) dotCenters.value = []
+    return
+  }
   const top = list.getBoundingClientRect().top
-  const rows = rowEls.value.filter(Boolean)
-  // A half-built list measures to nonsense; the spine and the vehicles
-  // would rather keep the last good numbers than take them.
-  if (rows.length !== displayStops.value.length) return
   dotCenters.value = rows.map(
     el => el.getBoundingClientRect().top - top + STOP_DOT_CENTER_Y,
   )
@@ -385,8 +393,10 @@ function measureRows() {
 let rowObserver: ResizeObserver | null = null
 watch(
   () => [listEl.value, displayStops.value.map(s => s.stopId).join(',')] as const,
-  async () => {
-    await nextTick()
+  () => {
+    // `flush: 'post'` — the rows this measures are already in the DOM, so
+    // measuring now rather than a tick later leaves no frame in which the
+    // spine has no numbers to draw from.
     measureRows()
     rowObserver?.disconnect()
     if (!listEl.value || typeof ResizeObserver === 'undefined') return
@@ -395,7 +405,7 @@ watch(
     // when they do.
     rowObserver = new ResizeObserver(() => measureRows())
     rowObserver.observe(listEl.value)
-    for (const el of rowEls.value) if (el) rowObserver.observe(el)
+    for (const el of rowEls()) rowObserver.observe(el)
   },
   { flush: 'post' },
 )
@@ -414,24 +424,14 @@ const spineBottom = computed(
  * The spine, cut into one segment per gap between stops.
  *
  * Drawn per gap rather than as one bar so the stretch behind the selected
- * vehicle can grey out on its own.
- *
- * Falls back to one whole-length segment before the rows have been
- * measured, so the timeline is never a column of unconnected dots.
+ * vehicle can grey out on its own. Empty until the rows have been measured —
+ * one frame, and a line drawn from numbers that do not match the rows on
+ * screen is worse than no line at all.
  */
 const spineSegments = computed(() => {
   const centers = dotCenters.value
   const stops = displayStops.value
-  if (centers.length < 2 || centers.length !== stops.length) {
-    return [
-      {
-        key: 'whole',
-        top: spineTop.value,
-        height: Math.max(0, spineBottom.value - spineTop.value),
-        passed: false,
-      },
-    ]
-  }
+  if (centers.length < 2 || centers.length !== stops.length) return []
   return centers.slice(0, -1).map((top, i) => ({
     key: stops[i].stopId,
     top,
@@ -534,8 +534,9 @@ onUnmounted(() => {
             </div>
           </div>
 
-          <!-- Pinned with the header: which way the line is running is part of
-               reading the stop list, so it stays reachable from the bottom of it. -->
+          <!-- Pinned with the header: which way the line is running, and which
+               train you are following, are both part of reading the stop list,
+               so they stay reachable from the bottom of it. -->
           <div v-if="directions.length > 1" class="mt-3">
             <Select
               :modelValue="activeDirection ?? undefined"
@@ -547,6 +548,42 @@ onUnmounted(() => {
               <SelectContent>
                 <SelectItem v-for="dir in directions" :key="dir" :value="dir">
                   {{ dir }}
+                </SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+
+          <!-- Unpicked, the trigger reads as the count of what the list below
+               holds — the viewed direction only. A train the other way is one
+               the direction picker reveals, not a value this one owes. -->
+          <div v-if="vehiclesOnRoute.length > 0" class="mt-2">
+            <Select
+              :modelValue="selectedId || undefined"
+              @update:modelValue="(v) => onSelectVehicle(v as string)"
+            >
+              <SelectTrigger class="w-full h-9">
+                <div class="flex items-center gap-2 min-w-0">
+                  <div
+                    class="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
+                    :style="{ background: bgColor }"
+                  >
+                    <component :is="routeTypeIcon" class="h-3 w-3" :style="{ color: textColor }" />
+                  </div>
+                  <SelectValue
+                    :placeholder="t('place.transit.activeVehicles', {
+                      count: vehiclesOnRoute.length,
+                      type: t(`place.transit.vehicleType.${vehicleTypeKey}`, vehiclesOnRoute.length),
+                    })"
+                  />
+                </div>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem
+                  v-for="vr in vehiclesOnRoute"
+                  :key="vr.vehicleId"
+                  :value="vr.vehicleId"
+                >
+                  <span class="truncate">{{ vehicleLabel(vr) }}</span>
                 </SelectItem>
               </SelectContent>
             </Select>
@@ -579,40 +616,6 @@ onUnmounted(() => {
         </div>
       </div>
 
-      <!-- ── Vehicle dropdown ──────────────────────────── -->
-      <!-- Counts what the list below holds — the viewed direction only.
-           A train the other way is one the direction toggle reveals, not
-           a value this dropdown owes. -->
-      <div v-if="vehiclesOnRoute.length > 0" class="mb-3">
-        <div class="text-sm font-semibold mb-1.5">
-          {{ t('place.transit.activeVehicles', { count: vehiclesOnRoute.length, type: t(`place.transit.vehicleType.${vehicleTypeKey}`, vehiclesOnRoute.length) }) }}
-        </div>
-        <Select
-          :modelValue="selectedId || undefined"
-          @update:modelValue="(v) => onSelectVehicle(v as string)"
-        >
-          <SelectTrigger class="w-full h-9">
-            <div class="flex items-center gap-2">
-              <div
-                class="w-5 h-5 rounded-full flex items-center justify-center shrink-0"
-                :style="{ background: bgColor }"
-              >
-                <component :is="routeTypeIcon" class="h-3 w-3" :style="{ color: textColor }" />
-              </div>
-              <SelectValue :placeholder="t('place.transit.selectVehicle', { type: t(`place.transit.vehicleType.${vehicleTypeKey}`, 1) })" />
-            </div>
-          </SelectTrigger>
-          <SelectContent>
-            <SelectItem
-              v-for="vr in vehiclesOnRoute"
-              :key="vr.vehicleId"
-              :value="vr.vehicleId"
-            >
-              <span class="truncate">{{ vehicleLabel(vr) }}</span>
-            </SelectItem>
-          </SelectContent>
-        </Select>
-      </div>
 
       <Separator class="mb-3" />
 
@@ -620,7 +623,10 @@ onUnmounted(() => {
       <div>
         <div class="text-sm font-semibold mb-2">{{ t('place.transit.stops') }}</div>
 
-        <div ref="listEl" class="relative" style="padding-left: 32px">
+        <!-- `isolate`: the markers below stack above the spine and the dots,
+             but the pinned header outranks the whole timeline — without a
+             stacking context of its own a train rode over it. -->
+        <div ref="listEl" class="relative isolate" style="padding-left: 32px">
           <!-- The route line, one segment per gap between stops, so the
                stretch behind the selected vehicle can grey out. -->
           <div
@@ -662,8 +668,8 @@ onUnmounted(() => {
                with bullets simply takes the room it needs. -->
           <div
             v-for="(stop, i) in displayStops"
-            :ref="el => { if (el) rowEls[i] = el as HTMLElement }"
             :key="stop.stopId"
+            data-stop-row
             class="relative flex items-start justify-between gap-2 py-0.5 min-h-[32px]"
           >
             <!-- Stop dot, on this row rather than placed by index -->

--- a/web/src/stores/route-detail.store.ts
+++ b/web/src/stores/route-detail.store.ts
@@ -137,19 +137,27 @@ export const useRouteDetailStore = defineStore('route-detail', () => {
   /** Stop times for the selected vehicle's trip (from TripUpdate data). */
   interface TripStopTime {
     stopId: string
+    /** GTFS parent station, when the run predicts against a platform. */
+    parentStation?: string
     arrivalTime?: string
     departureTime?: string
   }
   const tripStopTimes = ref<TripStopTime[]>([])
 
-  /** Map of stopId → time string for the selected vehicle's trip. */
+  /**
+   * stopId → time for the selected vehicle's trip.
+   *
+   * Filed under the platform AND its station: the MTA predicts against
+   * `250N`, while this route's stop list — like every station-level view —
+   * carries `250`, so keying on one id alone showed no times at all.
+   */
   const stopTimeMap = computed(() => {
     const map = new Map<string, string>()
     for (const st of tripStopTimes.value) {
       const time = st.departureTime || st.arrivalTime
-      if (time && st.stopId) {
-        map.set(st.stopId, time)
-      }
+      if (!time) continue
+      if (st.stopId) map.set(st.stopId, time)
+      if (st.parentStation) map.set(st.parentStation, time)
     }
     return map
   })
@@ -541,7 +549,7 @@ export const useRouteDetailStore = defineStore('route-detail', () => {
   async function fetchTripStopTimes(feedId: string, tripId: string, forVehicleId: string) {
     const fetchId = tripStopFetchId
     try {
-      const { data } = await api.get<{ stops: Array<{ stopId: string; arrivalTime?: string; departureTime?: string }> }>(
+      const { data } = await api.get<{ stops: TripStopTime[] }>(
         '/transit/trip-stops',
         { params: { feedId, tripId } },
       )


### PR DESCRIPTION
### Fixed

* Live trains sit where they are on a route's timeline. They were pinned to
  the top of the stop list, and the line ran on past the last stop, whenever
  the list shortened under the panel
* A route's map shows only that line's own trains. The 4 drew the 5s and 6s
  too, since all three are the same green
* Picking a train fills the stop list with its times again
* The train picker sits with the direction picker in the pinned header, and a
  train no longer rides over that header while scrolling