### PR TITLE
Escape closes trip details

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Fixed
 
+* Escape closes a trip's details on the first press. It used to take two — the
+  first only wiped the route off the map
+
 ## [0.11.2] - 2026-09-07
 
 ### Fixed

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -869,14 +869,24 @@ watch(
 
 onBeforeRouteLeave(to => {
   mapService.setRouteProfile(null)
-  if (to.name === AppRoute.DIRECTIONS) {
-    if (tripId.value) {
-      mapService.setVisibleTrips([tripId.value])
-    }
-  } else {
-    directionsService.clearWaypoints()
-    directionsStore.unsetTrips()
+  // Going back to the results list: keep this trip drawn beneath it.
+  if (to.name === AppRoute.DIRECTIONS && tripId.value) {
+    mapService.setVisibleTrips([tripId.value])
   }
+})
+
+// Tear down on unmount rather than in the leave guard: the guard runs
+// mid-navigation while the route is still /directions/trip, so clearing
+// waypoints there fires the service's syncUrl watcher, whose router.replace
+// cancels the outgoing navigation — esc wiped the route off the map but left
+// the panel open until a second press. By onUnmounted the route has committed,
+// so syncUrl bails on its /directions path guard. Unmount also skips a
+// same-route id swap (the canonicalising replace above), which the guard did
+// not. `route.name` is the committed destination here.
+onUnmounted(() => {
+  if (route.name === AppRoute.DIRECTIONS) return
+  directionsService.clearWaypoints()
+  directionsStore.unsetTrips()
 })
 
 function onInstructionHover(

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -869,20 +869,14 @@ watch(
 
 onBeforeRouteLeave(to => {
   mapService.setRouteProfile(null)
-  // Going back to the results list: keep this trip drawn beneath it.
   if (to.name === AppRoute.DIRECTIONS && tripId.value) {
     mapService.setVisibleTrips([tripId.value])
   }
 })
 
-// Tear down on unmount rather than in the leave guard: the guard runs
-// mid-navigation while the route is still /directions/trip, so clearing
-// waypoints there fires the service's syncUrl watcher, whose router.replace
-// cancels the outgoing navigation — esc wiped the route off the map but left
-// the panel open until a second press. By onUnmounted the route has committed,
-// so syncUrl bails on its /directions path guard. Unmount also skips a
-// same-route id swap (the canonicalising replace above), which the guard did
-// not. `route.name` is the committed destination here.
+// Tear down on unmount, not in the leave guard: clearing waypoints there fires
+// the service's syncUrl watcher, whose router.replace cancels the outgoing
+// navigation. `route.name` is the committed destination here.
 onUnmounted(() => {
   if (route.name === AppRoute.DIRECTIONS) return
   directionsService.clearWaypoints()


### PR DESCRIPTION
Pressing escape on a trip detail view took two presses to close: the first only wiped the route off the map, the second closed the panel.

## Cause

Escape asks `LeftSheet`/`BottomSheet` to close, which pushes to the map root. That navigation ran `TripDetail`'s `onBeforeRouteLeave`, which cleared the waypoints and trips **mid-navigation**. Clearing the waypoints trips the directions service's `syncUrl` watcher, and its `router.replace({ query })` — still on `/directions/trip/...`, so it passes the path guard — cancels the in-flight push. The trip layers were gone (`unsetTrips`), but the URL and the panel never moved. The second press worked only because the waypoints were already empty, so no replace fired.

Instrumented in the browser: press 1 produced a lone `replaceState` back to the trip URL with `wp` stripped; press 2 produced the `pushState` to `/`.

`Directions.vue` already carries this fix (b0faff7e, "Fix directions close button requiring two clicks"); `TripDetail.vue` was never updated.

## Change

- The leave guard keeps only map-visual work — no store mutation, so nothing can fire a competing navigation.
- Plan teardown moves to `onUnmounted`, where the route has committed and `syncUrl` bails on its `/directions` path guard.

This also fixes a second bug: `onBeforeRouteLeave` fires on a same-route id change too, so the canonicalising `router.replace({ params: { id } })` for signature-matched shared links was clearing the waypoints and trips it had just resolved. `onUnmounted` doesn't fire for a param swap.

## Verification

On the preview: one escape lands on `/`, drops the trip layers and slides the panel out. Back-navigation from a trip to the results list still keeps the trip drawn. `vue-tsc` clean; directions + hotkey suites pass.