### PR TITLE
Stops as places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Picking your current location as a stop shows it as a chip in the field,
   so it reads as a value rather than typed-in text
 * "Details" and "Advanced" toggles are big enough to tap on a phone
+* A trip's duration and times stay pinned while its timeline scrolls
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,10 @@
 
 ### Changed
 
-* Stops in a trip's timeline show as place cards — the place's own icon,
-  category and hours, with the scheduled time beside the name
-* Route stops on the map wear their own POI icon instead of a numbered dot
+* A trip's timeline draws each stop as the place it is — the POI's own icon on
+  the route line, its name and type beside it, and the scheduled time
+* Route stops on the map wear their own POI icon and name instead of a
+  numbered dot
 * Picking your current location as a stop shows it as a chip in the field,
   so it reads as a value rather than typed-in text
 * "Details" and "Advanced" toggles are big enough to tap on a phone

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,17 @@
 
 ### Changed
 
+* Stops in a trip's timeline show as place cards — the place's own icon,
+  category and hours, with the scheduled time beside the name
+* Route stops on the map wear their own POI icon instead of a numbered dot
+* Picking your current location as a stop shows it as a chip in the field,
+  so it reads as a value rather than typed-in text
+* "Details" and "Advanced" toggles are big enough to tap on a phone
+
 ### Fixed
+
+* A shared directions link keeps what each stop actually is. Reloading one
+  used to leave every stop as a bare name
 
 ## [0.11.2] - 2026-09-07
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 * A trip's timeline draws each stop as the place it is — the POI's own icon on
   the route line, its name and type beside it, and the scheduled time
-* Route stops on the map wear their own POI icon and name instead of a
-  numbered dot
+* Route stops wear their own POI icon everywhere they appear — the waypoint
+  fields, the timeline and the map — instead of a numbered dot. The map shows
+  each stop's name beside it too
 * Picking your current location as a stop shows it as a chip in the field,
   so it reads as a value rather than typed-in text
 * "Details" and "Advanced" toggles are big enough to tap on a phone

--- a/server/src/types/unified-routing.types.ts
+++ b/server/src/types/unified-routing.types.ts
@@ -1,6 +1,8 @@
 // Unified Routing Types for Parchment
 // Supports: Valhalla, OSRM, GraphHopper, OpenRouteService, OpenTripPlanner, Google Maps
 
+import type { Place } from './place.types'
+
 export interface Coordinate {
   lng: number
   lat: number
@@ -30,6 +32,12 @@ export interface RouteWaypoint {
   coordinate: Coordinate
   type: WaypointType
   name?: string
+  /**
+   * The place this stop stands for, when it is one. Carried through the plan
+   * so the trip timeline and the map markers can render the stop the way the
+   * rest of the app renders a place, rather than as a numbered dot.
+   */
+  place?: Partial<Place> | null
 
   // Time constraints
   arrivalTime?: Date

--- a/web/src/components/directions/ElevationChart.vue
+++ b/web/src/components/directions/ElevationChart.vue
@@ -482,10 +482,13 @@ const activeSummary = computed(() =>
     </div>
 
     <!-- Chart area -->
+    <!-- `isolate`: the badges and the hover rule inside stack against the
+         chart, not against the page. Without it their z-20 tied with the
+         sheet's sticky header and painted over it. -->
     <div
       v-if="hasElevationData"
       ref="chartContainerRef"
-      class="relative cursor-crosshair select-none rounded-lg bg-muted/30 overflow-hidden"
+      class="relative isolate cursor-crosshair select-none rounded-lg bg-muted/30 overflow-hidden"
       @mousemove="onMouseMove"
       @mouseleave="onMouseLeave"
     >

--- a/web/src/components/directions/timeline/SegmentDetails.vue
+++ b/web/src/components/directions/timeline/SegmentDetails.vue
@@ -94,12 +94,13 @@ const instructionKey = (index: number) => `${props.segmentIndex}-${index}`
     v-slot="{ open }"
     class="mt-2"
   >
-    <!-- A pill rather than a line of text: on a phone this is the control that
+    <!-- A full-width control rather than a line of text: on a phone this is what
          opens the turn-by-turn, and a 16px-tall run of words is not something
-         you can reliably hit. The negative margin keeps the label sitting where
-         it did — the target grows around it rather than pushing it over. -->
+         you can reliably hit. It takes the card surface so the target is
+         visible before you reach for it, but no elevation — it's a control
+         between the stops, not another stop. -->
     <CollapsibleTrigger
-      class="flex items-center gap-1.5 -mx-2 px-2 min-h-8 pointer-coarse:min-h-11 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 active:bg-muted transition-colors cursor-pointer select-none"
+      class="flex w-full items-center gap-1.5 px-2.5 min-h-9 pointer-coarse:min-h-11 rounded-md border bg-card text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-secondary/40 transition-colors cursor-pointer select-none"
     >
       <ChevronDownIcon class="size-3.5 transition-transform" :class="open && 'rotate-180'" />
       <span>{{ open ? 'Hide details' : 'Details' }}</span>

--- a/web/src/components/directions/timeline/SegmentDetails.vue
+++ b/web/src/components/directions/timeline/SegmentDetails.vue
@@ -94,10 +94,14 @@ const instructionKey = (index: number) => `${props.segmentIndex}-${index}`
     v-slot="{ open }"
     class="mt-2"
   >
+    <!-- A pill rather than a line of text: on a phone this is the control that
+         opens the turn-by-turn, and a 16px-tall run of words is not something
+         you can reliably hit. The negative margin keeps the label sitting where
+         it did — the target grows around it rather than pushing it over. -->
     <CollapsibleTrigger
-      class="flex items-center gap-1 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
+      class="flex items-center gap-1.5 -mx-2 px-2 min-h-8 pointer-coarse:min-h-11 rounded-md text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 active:bg-muted transition-colors cursor-pointer select-none"
     >
-      <ChevronDownIcon class="size-3 transition-transform" :class="open && 'rotate-180'" />
+      <ChevronDownIcon class="size-3.5 transition-transform" :class="open && 'rotate-180'" />
       <span>{{ open ? 'Hide details' : 'Details' }}</span>
       <span
         v-if="!open && segment.instructions?.length"

--- a/web/src/components/map/WaypointMapIcon.vue
+++ b/web/src/components/map/WaypointMapIcon.vue
@@ -7,9 +7,10 @@ import {
   getSearchResultIconName,
   getSearchResultIconPack,
   getSearchResultCategory,
+  getSearchResultName,
 } from '@/lib/search.utils'
 import { categoryMarkerPaint } from '@/lib/place-colors'
-import { markerCss } from '@/lib/map-marker'
+import { markerCss, MARKER_HALO, MARKER_PLATE_SIZE } from '@/lib/map-marker'
 import { useThemeStore } from '@/stores/theme.store'
 import type { Place } from '@/types/place.types'
 
@@ -21,6 +22,11 @@ import type { Place } from '@/types/place.types'
  * cafe and a hardware store reads as those two things rather than as "1" and
  * "2". Stops with nothing to draw (a dropped pin, the origin, an unresolved
  * coordinate) keep the plain dot, which is still what says "start here".
+ *
+ * Named stops carry that name under the mark, lettered exactly as the map's own
+ * POI labels are — the icon's glyph colour on the basemap's halo, Geist Medium
+ * at 13px, 1.1em below the icon's centre. A stop is a POI, so it should not be
+ * possible to tell which of the two labels the style drew.
  */
 const props = defineProps<{
   index: number
@@ -41,17 +47,43 @@ const iconPack = computed(() =>
   poi.value ? getSearchResultIconPack(poi.value) : 'lucide',
 )
 
-const css = computed(() =>
+/**
+ * The stop's name, when it has one worth showing. An unnamed pin falls back to
+ * its formatted address, which is long and says little at a glance — the mark
+ * itself already says "a stop is here", so that gets no label.
+ */
+const label = computed(() => {
+  const place = props.place
+  if (!place?.name?.value && !place?.bookmark) return ''
+  return getSearchResultName(place as Place)
+})
+
+const paint = computed(() =>
   poi.value
-    ? markerCss(
-        categoryMarkerPaint(
-          getSearchResultCategory(poi.value),
-          themeStore.isDark,
-        ),
-        'disc',
-      )
+    ? categoryMarkerPaint(getSearchResultCategory(poi.value), themeStore.isDark)
     : null,
 )
+
+const css = computed(() => (paint.value ? markerCss(paint.value, 'disc') : null))
+
+/**
+ * `text-color` is the badge's glyph colour and `text-halo-color` the basemap's
+ * `poi_halo`, at width 1 — the same pair `convert-basemap-style` gives the POI
+ * symbol layer. A stop with no category (the origin, a dropped pin) has no
+ * glyph colour to borrow, so its name is lettered in the text colour instead.
+ *
+ * `-webkit-text-stroke` centres its stroke on the glyph edge, so it takes twice
+ * the width to put 1px of halo outside the letter.
+ */
+const labelStyle = computed(() => ({
+  color: paint.value?.ink ?? 'var(--color-foreground)',
+  paintOrder: 'stroke fill',
+  WebkitTextStrokeWidth: '2px',
+  WebkitTextStrokeColor: themeStore.isDark ? MARKER_HALO.dark : MARKER_HALO.light,
+}))
+
+/** 1.1em of a 13px label below the icon's centre, as `text-offset` states. */
+const LABEL_TOP = `${MARKER_PLATE_SIZE / 2 + 13 * 1.1}px`
 
 const lucideIcon = computed(() => {
   if (iconPack.value === 'maki') return null
@@ -88,6 +120,18 @@ const lucideIcon = computed(() => {
       class="size-5 rounded-full bg-primary border-[1.5px] border-white flex items-center justify-center shadow-md"
     >
       <span class="text-[10px] font-bold text-white">{{ index }}</span>
+    </div>
+
+    <!-- Out of flow, so the mark stays centred on the coordinate however long
+         the name is, and inert, so it never swallows a drag meant for the
+         marker. It wraps at 8em rather than truncating, as `text-max-width`
+         does. -->
+    <div
+      v-if="label"
+      class="absolute left-1/2 -translate-x-1/2 max-w-[104px] w-max text-center text-[13px] font-medium leading-tight pointer-events-none"
+      :style="{ top: LABEL_TOP, ...labelStyle }"
+    >
+      {{ label }}
     </div>
   </div>
 </template>

--- a/web/src/components/map/WaypointMapIcon.vue
+++ b/web/src/components/map/WaypointMapIcon.vue
@@ -3,14 +3,9 @@ import { computed } from 'vue'
 import * as LucideIcons from 'lucide-vue-next'
 import { MapPinIcon } from 'lucide-vue-next'
 import MakiIcon from '@/components/ui/item-icon/MakiIcon.vue'
-import {
-  getSearchResultIconName,
-  getSearchResultIconPack,
-  getSearchResultCategory,
-  getSearchResultName,
-} from '@/lib/search.utils'
-import { categoryMarkerPaint } from '@/lib/place-colors'
-import { markerCss, MARKER_HALO, MARKER_PLATE_SIZE } from '@/lib/map-marker'
+import { useI18n } from 'vue-i18n'
+import { waypointToDisplay } from '@/lib/place-display'
+import { markerPaint, markerCss, MARKER_HALO, MARKER_PLATE_SIZE } from '@/lib/map-marker'
 import { useThemeStore } from '@/stores/theme.store'
 import type { Place } from '@/types/place.types'
 
@@ -36,16 +31,24 @@ const props = defineProps<{
 }>()
 
 const themeStore = useThemeStore()
+const { t } = useI18n()
 
-/** Only a place with a resolved category icon has a marker worth drawing. */
-const poi = computed(() => (props.place?.icon ? (props.place as Place) : null))
+/**
+ * The same derivation the waypoint fields and the trip timeline read, so a
+ * stop is the same mark wherever it is drawn — including when it has no place
+ * of its own and falls back to the pin.
+ */
+const mark = computed(() =>
+  waypointToDisplay(props.place, { isDark: themeStore.isDark, t }),
+)
 
-const iconName = computed(() =>
-  poi.value ? getSearchResultIconName(poi.value) : '',
+/** The origin is the one stop that isn't a place; the rest all draw a plate. */
+const drawsPlate = computed(
+  () => mark.value.ownIcon || (props.index > 0 && props.type !== 'origin'),
 )
-const iconPack = computed(() =>
-  poi.value ? getSearchResultIconPack(poi.value) : 'lucide',
-)
+
+const iconName = computed(() => mark.value.display.icon)
+const iconPack = computed(() => mark.value.display.iconPack)
 
 /**
  * The stop's name, when it has one worth showing. An unnamed pin falls back to
@@ -55,16 +58,17 @@ const iconPack = computed(() =>
 const label = computed(() => {
   const place = props.place
   if (!place?.name?.value && !place?.bookmark) return ''
-  return getSearchResultName(place as Place)
+  return mark.value.display.title
 })
 
-const paint = computed(() =>
-  poi.value
-    ? categoryMarkerPaint(getSearchResultCategory(poi.value), themeStore.isDark)
+const css = computed(() =>
+  drawsPlate.value && mark.value.display.customColor
+    ? markerCss(
+        markerPaint(mark.value.display.customColor, 'disc', themeStore.isDark),
+        'disc',
+      )
     : null,
 )
-
-const css = computed(() => (paint.value ? markerCss(paint.value, 'disc') : null))
 
 /**
  * `text-color` is the badge's glyph colour and `text-halo-color` the basemap's
@@ -76,7 +80,7 @@ const css = computed(() => (paint.value ? markerCss(paint.value, 'disc') : null)
  * the width to put 1px of halo outside the letter.
  */
 const labelStyle = computed(() => ({
-  color: paint.value?.ink ?? 'var(--color-foreground)',
+  color: css.value ? css.value.glyph.color : 'var(--color-foreground)',
   paintOrder: 'stroke fill',
   WebkitTextStrokeWidth: '2px',
   WebkitTextStrokeColor: themeStore.isDark ? MARKER_HALO.dark : MARKER_HALO.light,
@@ -109,18 +113,11 @@ const lucideIcon = computed(() => {
       />
       <component v-else :is="lucideIcon" :style="css.glyph" />
     </div>
-    <!-- Origin: hollow circle -->
-    <div
-      v-else-if="index === 0 || type === 'origin'"
-      class="size-4 rounded-full bg-background border-2 border-foreground/70 shadow-md"
-    />
-    <!-- Stops: primary circle with number -->
+    <!-- Where the trip starts, drawn as the fields and the timeline draw it -->
     <div
       v-else
-      class="size-5 rounded-full bg-primary border-[1.5px] border-white flex items-center justify-center shadow-md"
-    >
-      <span class="text-[10px] font-bold text-white">{{ index }}</span>
-    </div>
+      class="size-4 rounded-full bg-background border-[1.5px] border-foreground/60 shadow-md"
+    />
 
     <!-- Out of flow, so the mark stays centred on the coordinate however long
          the name is, and inert, so it never swallows a drag meant for the

--- a/web/src/components/map/WaypointMapIcon.vue
+++ b/web/src/components/map/WaypointMapIcon.vue
@@ -1,16 +1,85 @@
 <script setup lang="ts">
+import { computed } from 'vue'
+import * as LucideIcons from 'lucide-vue-next'
+import { MapPinIcon } from 'lucide-vue-next'
+import MakiIcon from '@/components/ui/item-icon/MakiIcon.vue'
+import {
+  getSearchResultIconName,
+  getSearchResultIconPack,
+  getSearchResultCategory,
+} from '@/lib/search.utils'
+import { categoryMarkerPaint } from '@/lib/place-colors'
+import { markerCss } from '@/lib/map-marker'
+import { useThemeStore } from '@/stores/theme.store'
+import type { Place } from '@/types/place.types'
+
+/**
+ * A directions stop on the map.
+ *
+ * A stop that is a real place wears that place's own marker — the same plate,
+ * glyph and ring a search result or a saved place gets, so a route through a
+ * cafe and a hardware store reads as those two things rather than as "1" and
+ * "2". Stops with nothing to draw (a dropped pin, the origin, an unresolved
+ * coordinate) keep the plain dot, which is still what says "start here".
+ */
 const props = defineProps<{
   index: number
   totalWaypoints: number
   type?: 'origin' | 'destination' | 'waypoint'
+  place?: Partial<Place> | null
 }>()
+
+const themeStore = useThemeStore()
+
+/** Only a place with a resolved category icon has a marker worth drawing. */
+const poi = computed(() => (props.place?.icon ? (props.place as Place) : null))
+
+const iconName = computed(() =>
+  poi.value ? getSearchResultIconName(poi.value) : '',
+)
+const iconPack = computed(() =>
+  poi.value ? getSearchResultIconPack(poi.value) : 'lucide',
+)
+
+const css = computed(() =>
+  poi.value
+    ? markerCss(
+        categoryMarkerPaint(
+          getSearchResultCategory(poi.value),
+          themeStore.isDark,
+        ),
+        'disc',
+      )
+    : null,
+)
+
+const lucideIcon = computed(() => {
+  if (iconPack.value === 'maki') return null
+  const fullName = iconName.value.endsWith('Icon')
+    ? iconName.value
+    : `${iconName.value}Icon`
+  return (
+    (LucideIcons[fullName as keyof typeof LucideIcons] as unknown) ?? MapPinIcon
+  )
+})
 </script>
 
 <template>
   <div class="relative size-8 shrink-0 cursor-move flex items-center justify-center">
+    <!-- The place's own marker -->
+    <div v-if="css" class="shadow-md select-none" :style="css.plate">
+      <MakiIcon
+        v-if="iconPack === 'maki'"
+        :name="iconName"
+        size="xs"
+        class="fill-current"
+        :style="css.glyph"
+      />
+      <component v-else :is="lucideIcon" :style="css.glyph" />
+    </div>
     <!-- Origin: hollow circle -->
     <div
-      v-if="index === 0 || type === 'origin'"
+      v-else-if="index === 0 || type === 'origin'"
       class="size-4 rounded-full bg-background border-2 border-foreground/70 shadow-md"
     />
     <!-- Stops: primary circle with number -->

--- a/web/src/components/map/layers/waypoints-layer.ts
+++ b/web/src/components/map/layers/waypoints-layer.ts
@@ -40,6 +40,9 @@ export class WaypointsLayer extends BaseMarkerLayer {
               : index === waypoints.length - 1
               ? 'destination'
               : 'waypoint',
+            // The marker draws the place's own icon when it has one, so the
+            // record has to reach it.
+            place: waypoint.place ?? null,
           },
           dragOptions: {
             onDragEnd: (lngLat) => {
@@ -60,7 +63,17 @@ export class WaypointsLayer extends BaseMarkerLayer {
       const fullId = `${this.idPrefix}${markerData.id}`
       newMarkerIds.add(fullId)
 
-      const snapshot = `${markerData.props.index}|${markerData.props.totalWaypoints}|${markerData.props.type}`
+      // Includes the place identity: a waypoint's record is filled in after
+      // the fact (reverse geocode, background lookup), and the marker has to
+      // be rebuilt when it is, or it keeps the numbered dot it was born with.
+      const place = markerData.props.place
+      const snapshot = [
+        markerData.props.index,
+        markerData.props.totalWaypoints,
+        markerData.props.type,
+        place?.id ?? '',
+        place?.icon?.icon ?? '',
+      ].join('|')
       const previous = this.markerSnapshots.get(fullId)
 
       if (this.mapAPI.hasMarker(fullId) && previous === snapshot) {

--- a/web/src/components/map/layers/waypoints-layer.ts
+++ b/web/src/components/map/layers/waypoints-layer.ts
@@ -73,6 +73,8 @@ export class WaypointsLayer extends BaseMarkerLayer {
         markerData.props.type,
         place?.id ?? '',
         place?.icon?.icon ?? '',
+        place?.name?.value ?? '',
+        place?.placeType?.value ?? '',
       ].join('|')
       const previous = this.markerSnapshots.get(fullId)
 

--- a/web/src/components/place/card/PlaceCard.vue
+++ b/web/src/components/place/card/PlaceCard.vue
@@ -23,6 +23,7 @@ import { ItemRow, ITEM_ROW_SIZES } from '@/components/ui/item-row'
  *  - `row`    full-width card; search results, saved lists, related places
  *  - `tile`   fixed-width card for horizontal scrollers (set the width via `class`)
  *  - `inline` borderless, for embedding inside another card (trip timelines)
+ *  - `plain`  no surface at all, for lists that draw their own structure
  *  - `chip`   single-line pill
  *
  * `size` scales the icon, type and padding together; `density` decides how many
@@ -36,7 +37,7 @@ const props = withDefaults(
     /** Pre-adapted record, for sources that are neither a Place nor a Bookmark. */
     display?: PlaceDisplay
 
-    variant?: 'row' | 'tile' | 'inline' | 'chip'
+    variant?: 'row' | 'tile' | 'inline' | 'plain' | 'chip'
     size?: 'xs' | 'sm' | 'md' | 'lg'
     /**
      * How much detail to show.
@@ -202,15 +203,19 @@ function onClick() {
       />
     </template>
 
-    <!-- Rating sits opposite the title rather than in the detail stack -->
-    <template v-if="showRating" #title-trailing>
-      <div class="flex items-center gap-1 shrink-0">
-        <StarIcon :class="scale.detailIcon" class="text-amber-500 fill-amber-500" />
-        <span class="text-xs font-medium text-foreground">{{ formattedRating }}</span>
-        <span v-if="item.reviewCount" class="text-xs text-muted-foreground">
-          ({{ item.reviewCount.toLocaleString() }})
-        </span>
-      </div>
+    <!-- Opposite the title rather than in the detail stack. The rating is what
+         normally sits here; a caller can claim the spot for something the card
+         can't derive — a trip timeline puts the arrival time there. -->
+    <template v-if="showRating || $slots['title-trailing']" #title-trailing>
+      <slot name="title-trailing">
+        <div class="flex items-center gap-1 shrink-0">
+          <StarIcon :class="scale.detailIcon" class="text-amber-500 fill-amber-500" />
+          <span class="text-xs font-medium text-foreground">{{ formattedRating }}</span>
+          <span v-if="item.reviewCount" class="text-xs text-muted-foreground">
+            ({{ item.reviewCount.toLocaleString() }})
+          </span>
+        </div>
+      </slot>
     </template>
 
     <template #details>

--- a/web/src/components/ui/item-row/ItemRow.vue
+++ b/web/src/components/ui/item-row/ItemRow.vue
@@ -57,7 +57,9 @@ const isLink = computed(() => !!props.to)
 
 const hoverClass = computed(() => {
   if (!isLink.value && !props.interactive) return ''
-  return props.variant === 'inline'
+  // Surfaceless rows tint toward the muted well rather than the secondary
+  // fill, so hovering one doesn't look like a card appearing under the cursor.
+  return props.variant === 'inline' || props.variant === 'plain'
     ? 'hover:bg-muted/70 cursor-pointer'
     : 'hover:bg-secondary/40 cursor-pointer'
 })

--- a/web/src/components/ui/item-row/scale.ts
+++ b/web/src/components/ui/item-row/scale.ts
@@ -7,7 +7,7 @@
  */
 
 export type ItemRowSize = 'xs' | 'sm' | 'md' | 'lg'
-export type ItemRowVariant = 'row' | 'tile' | 'inline' | 'chip'
+export type ItemRowVariant = 'row' | 'tile' | 'inline' | 'plain' | 'chip'
 
 export interface ItemRowScale {
   /** ItemIcon size for a title-only row. */
@@ -88,10 +88,16 @@ export const ITEM_ROW_SIZES: Record<ItemRowSize, ItemRowScale> = {
  * drop shadow — and is what `components/ui/card` applies. Every free-standing
  * surface takes it. `inline` is the exception: it's a well nested inside
  * another card, and lighting it would read as a card floating on a card.
+ *
+ * `plain` has no surface of its own. It's for rows sitting in a list that
+ * already draws the structure — a trip timeline's rail, a combobox's own
+ * highlight — where a second background reads as a box inside a box. It still
+ * takes the shared scale and hover, so it stays the same row as the others.
  */
 export const ITEM_ROW_SURFACES: Record<ItemRowVariant, string> = {
   row: 'w-full rounded-lg border bg-card depth',
   tile: 'shrink-0 rounded-lg border bg-card depth',
   inline: 'w-full rounded-md bg-muted/40',
+  plain: 'w-full rounded-md',
   chip: 'rounded-full border bg-card depth',
 }

--- a/web/src/lib/directions-url.test.ts
+++ b/web/src/lib/directions-url.test.ts
@@ -3,6 +3,7 @@ import {
   serializeDirectionsQuery,
   parseDirectionsQuery,
   directionsQueryEquals,
+  shareableWaypointId,
 } from './directions-url'
 
 describe('directions-url', () => {
@@ -64,5 +65,62 @@ describe('directions-url', () => {
     expect(
       directionsQueryEquals(q, { wp: '1.000000,2.000000', mode: 'driving' } as never),
     ).toBe(false)
+  })
+
+  it('carries place ids alongside the waypoints they belong to', () => {
+    const q = serializeDirectionsQuery({
+      waypoints: [
+        { lat: 40.6702, lng: -73.955, label: 'Current Location' },
+        { lat: 40.684397, lng: -73.97644, label: 'Target', id: 'osm/node/6308438190' },
+      ],
+    })
+    expect(q.wpid).toEqual(['', 'osm/node/6308438190'])
+
+    const parsed = parseDirectionsQuery(q as never)!
+    expect(parsed.waypoints[0].id).toBeUndefined()
+    expect(parsed.waypoints[1].id).toBe('osm/node/6308438190')
+  })
+
+  it('omits the id list when no waypoint has one', () => {
+    const q = serializeDirectionsQuery({
+      waypoints: [
+        { lat: 40.6702, lng: -73.955 },
+        { lat: 40.684397, lng: -73.97644 },
+      ],
+    })
+    expect(q.wpid).toBeUndefined()
+  })
+
+  // A malformed wp is dropped but still holds its slot, so the ids after it
+  // stay attached to the right stops.
+  it('keeps ids aligned when a waypoint is unparseable', () => {
+    const parsed = parseDirectionsQuery({
+      wp: ['not-a-coord', '40.684397,-73.976440,Target'],
+      wpid: ['osm/node/1', 'osm/node/2'],
+    } as never)!
+    expect(parsed.waypoints).toHaveLength(1)
+    expect(parsed.waypoints[0].id).toBe('osm/node/2')
+  })
+
+  it('treats the id list as part of the query when comparing', () => {
+    const q = serializeDirectionsQuery({
+      waypoints: [{ lat: 1, lng: 2, id: 'osm/node/1' }],
+    })
+    expect(directionsQueryEquals(q, { wp: q.wp } as never)).toBe(false)
+    expect(directionsQueryEquals(q, q as never)).toBe(true)
+  })
+})
+
+describe('shareableWaypointId', () => {
+  it('shares ids that name a source', () => {
+    expect(shareableWaypointId({ id: 'osm/node/6308438190' })).toBe('osm/node/6308438190')
+  })
+
+  it('withholds ids that mean nothing on another device', () => {
+    expect(shareableWaypointId(null)).toBeUndefined()
+    expect(shareableWaypointId({ id: 'current-location' })).toBeUndefined()
+    expect(shareableWaypointId({ id: 'shared-wp-0' })).toBeUndefined()
+    // A bookmark id is a bare uuid — private to the user who saved it.
+    expect(shareableWaypointId({ id: 'vAzo3WtqLXuZu7Oe4FW6ok6a' })).toBeUndefined()
   })
 })

--- a/web/src/lib/directions-url.ts
+++ b/web/src/lib/directions-url.ts
@@ -6,10 +6,18 @@ import type { LocationQuery, LocationQueryValue } from 'vue-router'
  * Format (all optional except wp):
  *   ?wp=35.217123,-80.820206,Current%20Location
  *   &wp=35.225773,-80.852785,Bank%20of%20America%20Stadium
+ *   &wpid=&wpid=osm/way/12345
  *   &mode=multi&sort=cheapest&depart=2026-06-12T18:00:00Z
  *
  * `wp` repeats in order (first = origin, last = destination); the third
  * comma-field onward is the label (labels may themselves contain commas).
+ *
+ * `wpid` repeats alongside it, one entry per `wp`, holding that waypoint's
+ * place id where it has one — a label alone can't be looked back up, so
+ * without it a reloaded link knows a stop is called "Target" but nothing
+ * else about it. Empty entries are placeholders keeping the two lists in
+ * step, and the whole param is omitted when no waypoint has an id.
+ *
  * Shareable: pasting the URL reproduces the same directions request.
  */
 
@@ -17,6 +25,8 @@ export interface DirectionsUrlWaypoint {
   lat: number
   lng: number
   label?: string
+  /** Composite place id ("osm/node/123"), when the waypoint resolves to one. */
+  id?: string
 }
 
 export interface DirectionsUrlState {
@@ -37,6 +47,9 @@ export function serializeDirectionsQuery(
       const base = `${w.lat.toFixed(COORD_PRECISION)},${w.lng.toFixed(COORD_PRECISION)}`
       return w.label ? `${base},${w.label}` : base
     })
+    if (state.waypoints.some((w) => w.id)) {
+      query.wpid = state.waypoints.map((w) => w.id ?? '')
+    }
   }
   if (state.mode) query.mode = state.mode
   if (state.sort) query.sort = state.sort
@@ -63,15 +76,20 @@ export function parseDirectionsQuery(
   query: LocationQuery,
 ): DirectionsUrlState | null {
   const waypoints: DirectionsUrlWaypoint[] = []
-  for (const raw of asArray(query.wp)) {
+  // Ids are matched to `wp` by position, so index into the raw list rather
+  // than the accepted one — a malformed `wp` is skipped but still consumes
+  // its slot in `wpid`.
+  const ids = asArray(query.wpid)
+  asArray(query.wp).forEach((raw, i) => {
     const [latS, lngS, ...rest] = raw.split(',')
     const lat = parseFloat(latS)
     const lng = parseFloat(lngS)
-    if (!Number.isFinite(lat) || !Number.isFinite(lng)) continue
-    if (Math.abs(lat) > 90 || Math.abs(lng) > 180) continue
+    if (!Number.isFinite(lat) || !Number.isFinite(lng)) return
+    if (Math.abs(lat) > 90 || Math.abs(lng) > 180) return
     const label = rest.join(',').trim()
-    waypoints.push({ lat, lng, ...(label ? { label } : {}) })
-  }
+    const id = ids[i]?.trim()
+    waypoints.push({ lat, lng, ...(label ? { label } : {}), ...(id ? { id } : {}) })
+  })
   if (waypoints.length === 0) return null
   return {
     waypoints,
@@ -86,7 +104,7 @@ export function directionsQueryEquals(
   a: Record<string, string | string[]>,
   b: LocationQuery,
 ): boolean {
-  const keys = ['wp', 'mode', 'sort', 'depart'] as const
+  const keys = ['wp', 'wpid', 'mode', 'sort', 'depart'] as const
   for (const k of keys) {
     const av = a[k]
     const bv = b[k]

--- a/web/src/lib/directions-url.ts
+++ b/web/src/lib/directions-url.ts
@@ -38,6 +38,22 @@ export interface DirectionsUrlState {
 
 const COORD_PRECISION = 6
 
+/**
+ * The place id worth putting in a link, or nothing.
+ *
+ * Ids minted locally — current location, a bookmark row, an earlier link's own
+ * stub — mean nothing on another device, so they are left out rather than
+ * shared as dead references. A real one always names its source first
+ * ("osm/node/123").
+ */
+export function shareableWaypointId(
+  place: { id?: string } | null | undefined,
+): string | undefined {
+  const id = place?.id
+  if (!id || !id.includes('/') || id.startsWith('shared-wp-')) return undefined
+  return id
+}
+
 export function serializeDirectionsQuery(
   state: DirectionsUrlState,
 ): Record<string, string | string[]> {

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -739,6 +739,8 @@
     "planRoute": "Plan route",
     "to": "To",
     "from": "From",
+    "currentLocation": "Current Location",
+    "useCurrentLocation": "Use your current location",
     "addStop": "Add stop",
     "modes": {
       "walking": "Walking",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -720,6 +720,8 @@
     "planRoute": "Planificar ruta",
     "to": "A",
     "from": "Desde",
+    "currentLocation": "Ubicación actual",
+    "useCurrentLocation": "Usar tu ubicación actual",
     "addStop": "Añadir parada"
   },
   "library": {

--- a/web/src/lib/map-marker/index.ts
+++ b/web/src/lib/map-marker/index.ts
@@ -23,7 +23,7 @@ export {
   markerGlyphSizeForRadius,
 } from './marker-metrics.mjs'
 
-export { markerPaint, type MarkerPaint } from './marker-paint'
+export { markerPaint, MARKER_HALO, type MarkerPaint } from './marker-paint'
 export { markerCss, type MarkerCss } from './marker-css'
 export {
   markerLayers,

--- a/web/src/lib/map-marker/marker-paint.ts
+++ b/web/src/lib/map-marker/marker-paint.ts
@@ -45,8 +45,12 @@ const VARIANT: Record<MarkerShape, 'solid' | 'ghost'> = {
   glyph: 'ghost',
 }
 
-/** The halo behind a bare glyph, per flavor — the basemap's own `poi_halo`. */
-const GLYPH_HALO = { light: '#FFFFFF', dark: '#0D0D0D' }
+/**
+ * The halo behind a bare glyph or a marker's label, per flavor — the basemap's
+ * own `poi_halo`. Exported because a DOM label has to draw the same halo the
+ * style layer does, and two copies of it drift.
+ */
+export const MARKER_HALO = { light: '#FFFFFF', dark: '#0D0D0D' }
 
 /**
  * The plate, glyph and ring a colour tints to for a given marker shape.
@@ -60,7 +64,7 @@ export function markerPaint(
   shape: MarkerShape,
   isDark: boolean,
 ): MarkerPaint {
-  const halo = isDark ? GLYPH_HALO.dark : GLYPH_HALO.light
+  const halo = isDark ? MARKER_HALO.dark : MARKER_HALO.light
   const tint = getCustomColorTint(color, VARIANT[shape], isDark)
 
   if (shape === 'glyph') {

--- a/web/src/lib/place-display.test.ts
+++ b/web/src/lib/place-display.test.ts
@@ -7,6 +7,7 @@ import {
   recentSearchToDisplay,
   recentSearchRoute,
   makePlaceDisplay,
+  autocompleteToDisplay,
 } from './place-display'
 import type { Place } from '@/types/place.types'
 import type { Bookmark } from '@/types/library.types'
@@ -243,5 +244,55 @@ describe('recentSearchToDisplay', () => {
     )
     expect(d.imageUrl).toBe('https://example.com/target.svg')
     expect(d.icon).toBe('Store')
+  })
+})
+
+describe('autocompleteToDisplay', () => {
+  it('keeps the row’s own glyph and icon pack', () => {
+    const d = autocompleteToDisplay(
+      {
+        id: 'osm/node/6308438190',
+        type: 'place',
+        title: 'Target',
+        description: 'Department Store · 139 Flatbush Avenue',
+        icon: 'shop',
+        iconPack: 'maki',
+        iconCategory: 'store',
+        lat: 40.684397,
+        lng: -73.97644,
+      },
+      { isDark: false },
+    )
+    expect(d.title).toBe('Target')
+    expect(d.icon).toBe('shop')
+    expect(d.iconPack).toBe('maki')
+    expect(d.address).toBe('Department Store · 139 Flatbush Avenue')
+    expect(d.customColor).toBeTruthy()
+  })
+
+  it('gives current location the locate glyph rather than a pin', () => {
+    const d = autocompleteToDisplay(
+      { id: 'current-location', type: 'current_location', title: 'Current Location' },
+      { isDark: false },
+    )
+    expect(d.icon).toBe('Locate')
+  })
+
+  // A bookmark's colour is chosen by the user, so it wins over its category.
+  it('keeps a bookmark’s own colour', () => {
+    const d = autocompleteToDisplay(
+      {
+        id: 'bk1',
+        type: 'bookmark',
+        title: 'Home',
+        icon: 'Home',
+        color: 'cobalt',
+        lat: 1,
+        lng: 2,
+      },
+      { isDark: false },
+    )
+    expect(d.color).toBe('cobalt')
+    expect(d.customColor).toBeUndefined()
   })
 })

--- a/web/src/lib/place-display.ts
+++ b/web/src/lib/place-display.ts
@@ -289,6 +289,67 @@ export function autocompleteToDisplay(
 }
 
 /**
+ * Place types that name a point rather than a place: a plain address, a
+ * dropped pin, a coordinate, a link's own stub. They have no identity to draw
+ * an icon from — the surface showing them says "a stop is here" some other
+ * way, with a start ring or an ordinal.
+ */
+const POINT_PLACE_TYPES = new Set([
+  'area',
+  'address',
+  'coordinates',
+  'shared_location',
+  'current_location',
+])
+
+/**
+ * A directions waypoint.
+ *
+ * Every surface that draws a stop — the waypoint inputs, the trip timeline,
+ * the map markers — has to make the same three-way call: does this stop have
+ * an icon of its own, is it your current position, or is it just a point? They
+ * used to each decide separately, and drifted: a stop drawn as a restaurant on
+ * the map was a numbered disc in the input.
+ *
+ * `ownIcon` says whether `display.icon` is the stop's own, so a caller can
+ * fall back to its own start/stop marks rather than draw a generic pin.
+ */
+export function waypointToDisplay(
+  place: Partial<Place> | null | undefined,
+  { isDark, t, fallbackTitle = '' }: PlaceDisplayOptions & { fallbackTitle?: string },
+): { display: PlaceDisplay; ownIcon: boolean } {
+  if (place?.id === 'current-location') {
+    return {
+      display: makePlaceDisplay({
+        title: place.name?.value || t('directions.currentLocation'),
+        icon: 'Locate',
+      }),
+      ownIcon: true,
+    }
+  }
+
+  const type = place?.placeType?.value?.toLowerCase?.().trim()
+  const isPoint = !place?.id || (!!type && POINT_PLACE_TYPES.has(type))
+
+  if (isPoint) {
+    return {
+      display: makePlaceDisplay({
+        title:
+          (place ? getSearchResultName(place as Place) : '') || fallbackTitle,
+        icon: 'MapPin',
+      }),
+      ownIcon: false,
+    }
+  }
+
+  const display = placeToDisplay(place as Place, { isDark, t })
+  return {
+    display: display.title ? display : { ...display, title: fallbackTitle },
+    ownIcon: true,
+  }
+}
+
+/**
  * A saved bookmark. Frequents (Home/Work/School and user-named ones) render
  * with the look fixed by their type; everything else keeps the saved POI's own
  * icon and colour.

--- a/web/src/lib/place-display.ts
+++ b/web/src/lib/place-display.ts
@@ -337,6 +337,12 @@ export function waypointToDisplay(
         title:
           (place ? getSearchResultName(place as Place) : '') || fallbackTitle,
         icon: 'MapPin',
+        // Spelled out rather than left to whatever each surface defaults to:
+        // `ItemIcon` falls back to cobalt, so an unstyled pin came out blue in
+        // the timeline while the same stop was a neutral plate on the map. The
+        // uncategorised colour is what the marker system already paints a
+        // place it can't categorise.
+        customColor: getCategoryColor('default', isDark),
       }),
       ownIcon: false,
     }

--- a/web/src/lib/place-display.ts
+++ b/web/src/lib/place-display.ts
@@ -2,6 +2,7 @@ import type { RouteLocationRaw } from 'vue-router'
 import type { Place, PlaceCategory } from '@/types/place.types'
 import type { Bookmark } from '@/types/library.types'
 import type { RecentPlaceEntry, RecentSearchEntry } from '@/lib/recents'
+import type { AutocompleteResult } from '@/types/search.types'
 import type { ThemeColor } from '@/lib/utils'
 import { AppRoute } from '@/router'
 import { getPlaceRoute, getPlaceRouteFromExternalIds, getTransitStopRoute, formatAddress } from '@/lib/place.utils'
@@ -251,6 +252,39 @@ export function recentSearchToDisplay(
     ),
     imageUrl: entry.brandLogoUrl ?? null,
     route: recentSearchRoute(entry),
+  })
+}
+
+/**
+ * An autocomplete suggestion. Thin by design — a title, a description and an
+ * icon — so most detail lines are simply unavailable; the description is the
+ * one subtitle the row carries.
+ *
+ * Adapting here rather than at the call site is what lets the directions
+ * waypoint picker draw the same rows as search: a maki glyph stays a maki
+ * glyph, and a category keeps its colour.
+ */
+export function autocompleteToDisplay(
+  result: AutocompleteResult,
+  { isDark }: Pick<PlaceDisplayOptions, 'isDark'>,
+): PlaceDisplay {
+  const isCurrentLocation = result.type === 'current_location'
+
+  return makePlaceDisplay({
+    title: result.title,
+    icon: isCurrentLocation ? 'Locate' : result.icon || 'MapPin',
+    iconPack: result.iconPack ?? 'lucide',
+    // A bookmark's colour is fixed by its type and set on the row itself;
+    // everything else takes its category's colour, as search results do.
+    ...(result.color && result.type === 'bookmark'
+      ? { color: result.color as ThemeColor }
+      : {
+          customColor: getCategoryColor(
+            (result.iconCategory || 'default') as PlaceCategory,
+            isDark,
+          ),
+        }),
+    address: result.description ?? null,
   })
 }
 

--- a/web/src/lib/search.utils.ts
+++ b/web/src/lib/search.utils.ts
@@ -200,22 +200,55 @@ export function getSearchResultTypeIcon(type: SearchResultType): Component {
 }
 
 /**
+ * Everything an autocomplete row knows that a `Place` can hold.
+ *
+ * Autocomplete rows are deliberately thin — the server sends only what a
+ * suggestion list needs — but the record they become is what downstream
+ * surfaces render from, so anything the row does carry (its resolved icon,
+ * category colour, transit refs) has to survive the conversion. Dropping
+ * them here is what left a waypoint picked from the directions input with a
+ * grey pin instead of its own POI glyph.
+ */
+function autocompleteIcon(result: AutocompleteResult) {
+  if (!result.icon) return undefined
+  return {
+    icon: result.icon,
+    iconPack: result.iconPack ?? 'lucide',
+    category: (result.iconCategory as PlaceCategory) ?? 'default',
+  }
+}
+
+/** Transit refs, present only on GTFS line / stop suggestions. */
+function autocompleteTransit(result: AutocompleteResult) {
+  return {
+    ...(result.transitLine ? { transitLine: result.transitLine } : {}),
+    ...(result.transitStop ? { transitStop: result.transitStop } : {}),
+  }
+}
+
+/**
  * Convert an AutocompleteResult object to a legacy Place object for compatibility
  */
 export function autocompleteResultToPlace(result: AutocompleteResult): Place {
-  if (result.type === 'bookmark') {
-    return {
-      id: result.id,
-      name: { value: result.title },
-      geometry: {
-        value: {
-          type: 'point',
-          center: {
-            lat: result.lat,
-            lng: result.lng,
-          },
+  const shared = {
+    geometry: {
+      value: {
+        type: 'point',
+        center: {
+          lat: result.lat,
+          lng: result.lng,
         },
       },
+    },
+    icon: autocompleteIcon(result),
+    ...autocompleteTransit(result),
+  }
+
+  if (result.type === 'bookmark') {
+    return {
+      ...shared,
+      id: result.id,
+      name: { value: result.title },
       externalIds: {},
       address: result.description
         ? { value: { formatted: result.description } }
@@ -232,36 +265,33 @@ export function autocompleteResultToPlace(result: AutocompleteResult): Place {
 
   if (result.type === 'current_location') {
     return {
+      ...shared,
       id: 'current-location',
       name: { value: result.title },
-      geometry: {
-        value: {
-          type: 'point',
-          center: {
-            lat: result.lat,
-            lng: result.lng,
-          },
-        },
-      },
       externalIds: {},
       address: null,
       placeType: { value: 'current_location' },
     } as unknown as Place
   }
 
+  if (result.type === 'transit_stop' || result.type === 'transit_route') {
+    return {
+      ...shared,
+      id: result.id,
+      name: { value: result.title },
+      externalIds: {},
+      address: result.description
+        ? { value: { formatted: result.description } }
+        : null,
+      placeType: { value: result.type },
+    } as unknown as Place
+  }
+
   // Default for 'place' type and fallback
   return {
+    ...shared,
     id: result.id,
     name: { value: result.title },
-    geometry: {
-      value: {
-        type: 'point',
-        center: {
-          lat: result.lat,
-          lng: result.lng,
-        },
-      },
-    },
     externalIds: {},
     address: result.description
       ? { value: { formatted: result.description } }

--- a/web/src/services/directions.service.ts
+++ b/web/src/services/directions.service.ts
@@ -13,6 +13,7 @@ import type { Place } from '@/types/place.types'
 import { useGeocodingService } from './geocoding.service'
 import { getSearchResultName } from '@/lib/search.utils'
 import { useVehiclesStore } from '@/stores/vehicles.store'
+import { usePlaceService } from '@/services/place.service'
 import {
   serializeDirectionsQuery,
   parseDirectionsQuery,
@@ -366,6 +367,39 @@ function directionsService() {
   }
 
   /**
+   * Fill in everything a waypoint's place record is missing.
+   *
+   * A waypoint arrives holding whatever the surface that set it happened to
+   * know: an autocomplete row carries a name, coordinates and an icon; a
+   * shared link carries a name and an id. The trip timeline and the map
+   * markers render from that record, so a thin one shows a grey pin and a
+   * bare name where the place has a category, hours and a rating. Look the
+   * full record up in the background and swap it in — the place cache makes
+   * a repeat lookup free.
+   */
+  async function hydrateWaypointPlace(index: number, placeId: string) {
+    const { lookupPlaceById } = usePlaceService()
+    const full = await lookupPlaceById(placeId)
+    if (!full) return
+
+    const current = waypoints.value[index]
+    // The waypoint may have moved on while the lookup was in flight.
+    if (current?.place?.id !== placeId) return
+
+    // The waypoint's own coordinates win: the user picked that point, and a
+    // POI's canonical centre can sit metres away from it.
+    store.setWaypoint(index, { ...current, place: full })
+
+    // Patch an already-planned trip in place so the timeline it is currently
+    // rendering picks the richer record up without a re-plan.
+    const requestWaypoint = store.trips?.request?.waypoints?.[index]
+    if (requestWaypoint) {
+      requestWaypoint.name = getSearchResultName(full)
+      requestWaypoint.place = full
+    }
+  }
+
+  /**
    * Helper function to set a waypoint and reverse geocode if needed
    * This ensures consistent behavior across all waypoint-setting functions
    */
@@ -404,6 +438,7 @@ function directionsService() {
           const trips = store.trips
           if (trips?.request?.waypoints?.[index]) {
             trips.request.waypoints[index].name = getSearchResultName(place as Place)
+            trips.request.waypoints[index].place = place
           }
         } else {
           console.log('[Directions] No reverse geocoding results found')
@@ -412,8 +447,8 @@ function directionsService() {
         console.error('[Directions] Failed to reverse geocode waypoint:', error)
         // Continue without place info if geocoding fails
       })
-    } else if (waypoint.place) {
-      console.log('[Directions] Waypoint already has place info:', waypoint.place.name?.value)
+    } else if (waypoint.place?.id) {
+      hydrateWaypointPlace(index, waypoint.place.id)
     }
   }
 
@@ -540,12 +575,15 @@ function directionsService() {
     const state = parseDirectionsQuery(route.query)
     if (!state) return false
 
+    // A shared link carries a label and, where the waypoint had one, a place
+    // id. The stub renders immediately; the id (when present) then fetches the
+    // real record so a reloaded trip looks like the one that was planned.
     const wps = state.waypoints.map((w, i) => ({
       lngLat: new LngLat(w.lng, w.lat),
-      place: w.label
+      place: w.label || w.id
         ? ({
-            id: `shared-wp-${i}`,
-            name: { value: w.label },
+            id: w.id || `shared-wp-${i}`,
+            name: { value: w.label ?? '' },
             geometry: {
               value: { type: 'point', center: { lat: w.lat, lng: w.lng } },
             },
@@ -561,7 +599,23 @@ function directionsService() {
     if (state.sort) store.sortPreference = state.sort as typeof sortPreference.value
     if (state.depart) store.departureTime = state.depart
     store.setWaypoints(wps)
+    state.waypoints.forEach((w, i) => {
+      if (w.id) hydrateWaypointPlace(i, w.id)
+    })
     return true
+  }
+
+  /**
+   * The waypoint's place id, when it is one a recipient of the link can look
+   * up. Ids minted locally — current location, a bookmark row, an earlier
+   * link's own stub — mean nothing on another device, so they are left out
+   * rather than shared as dead references.
+   */
+  function shareableWaypointId(place: Partial<Place> | null | undefined) {
+    const id = place?.id
+    if (!id || !id.includes('/')) return undefined
+    if (id.startsWith('shared-wp-')) return undefined
+    return id
   }
 
   /** Reflect the current inputs into the URL (replace — no history spam). */
@@ -574,13 +628,14 @@ function directionsService() {
           lat: w.lngLat!.lat,
           lng: w.lngLat!.lng,
           label: (w.place ? getSearchResultName(w.place as Place) : '') || undefined,
+          id: shareableWaypointId(w.place),
         })),
       mode: selectedMode.value,
       sort: sortPreference.value || undefined,
       depart: departureTime.value || undefined,
     })
     if (directionsQueryEquals(q, route.query)) return
-    const { wp: _wp, mode: _mode, sort: _sort, depart: _depart, ...rest } = route.query
+    const { wp: _wp, wpid: _wpid, mode: _mode, sort: _sort, depart: _depart, ...rest } = route.query
     router.replace({ query: { ...rest, ...q } }).catch(() => {})
   }
 

--- a/web/src/services/directions.service.ts
+++ b/web/src/services/directions.service.ts
@@ -18,6 +18,7 @@ import {
   serializeDirectionsQuery,
   parseDirectionsQuery,
   directionsQueryEquals,
+  shareableWaypointId,
 } from '@/lib/directions-url'
 
 const MIN_WAYPOINTS = 2
@@ -153,17 +154,20 @@ function directionsService() {
       const serverWaypoints: Array<{ label?: string }> = data.request?.waypoints ?? []
       const response: TripsResponse = {
         request: {
-          waypoints: validWaypoints.map((wp, i) => ({
-            id: `wp-${i}`,
-            coordinate: { lat: wp.lngLat!.lat, lng: wp.lngLat!.lng },
-            type:
-              i === 0 || i === validWaypoints.length - 1
-                ? WaypointType.STOP
-                : WaypointType.VIA,
-            name: (wp.place ? getSearchResultName(wp.place as Place) : '') || serverWaypoints[i]?.label || '',
-            // Pass through the full Place for POI rendering in the trip timeline
-            ...(wp.place ? { place: wp.place } : {}),
-          })),
+          waypoints: validWaypoints.map((wp, i) => {
+            const place = wp.place
+            return {
+              id: `wp-${i}`,
+              coordinate: { lat: wp.lngLat!.lat, lng: wp.lngLat!.lng },
+              type:
+                i === 0 || i === validWaypoints.length - 1
+                  ? WaypointType.STOP
+                  : WaypointType.VIA,
+              name: (place ? getSearchResultName(place as Place) : '') || serverWaypoints[i]?.label || '',
+              // Pass through the full Place for POI rendering in the trip timeline
+              ...(place ? { place } : {}),
+            }
+          }),
           availableVehicles: availableVehicles.map(v => v.type),
           maxOptions: 5,
           includeWalking: true,
@@ -377,6 +381,14 @@ function directionsService() {
    * full record up in the background and swap it in — the place cache makes
    * a repeat lookup free.
    */
+  /**
+   * Ids already looked up. A waypoint's record is replaced by the lookup's
+   * result, which triggers the watcher again — and the surfaces that set
+   * waypoints do so on every keystroke-driven selection, so without this the
+   * same place would be fetched over and over.
+   */
+  const hydratedPlaceIds = new Set<string>()
+
   async function hydrateWaypointPlace(index: number, placeId: string) {
     const { lookupPlaceById } = usePlaceService()
     const full = await lookupPlaceById(placeId)
@@ -389,14 +401,6 @@ function directionsService() {
     // The waypoint's own coordinates win: the user picked that point, and a
     // POI's canonical centre can sit metres away from it.
     store.setWaypoint(index, { ...current, place: full })
-
-    // Patch an already-planned trip in place so the timeline it is currently
-    // rendering picks the richer record up without a re-plan.
-    const requestWaypoint = store.trips?.request?.waypoints?.[index]
-    if (requestWaypoint) {
-      requestWaypoint.name = getSearchResultName(full)
-      requestWaypoint.place = full
-    }
   }
 
   /**
@@ -433,13 +437,6 @@ function directionsService() {
             place: place,
           }
           store.setWaypoint(index, updatedWaypoint)
-
-          // Patch the stored trip response if it already exists
-          const trips = store.trips
-          if (trips?.request?.waypoints?.[index]) {
-            trips.request.waypoints[index].name = getSearchResultName(place as Place)
-            trips.request.waypoints[index].place = place
-          }
         } else {
           console.log('[Directions] No reverse geocoding results found')
         }
@@ -447,8 +444,8 @@ function directionsService() {
         console.error('[Directions] Failed to reverse geocode waypoint:', error)
         // Continue without place info if geocoding fails
       })
-    } else if (waypoint.place?.id) {
-      hydrateWaypointPlace(index, waypoint.place.id)
+    } else if (waypoint.place) {
+      console.log('[Directions] Waypoint already has place info:', waypoint.place.name?.value)
     }
   }
 
@@ -564,6 +561,49 @@ function directionsService() {
     await setWaypointWithGeocoding(1, waypoint)
   }
 
+  // Every surface that sets a waypoint — the picker, a map click, a shared
+  // link, the place page's Directions button — routes through the store, so
+  // hydration hangs off the store rather than off each of them remembering to
+  // ask for it.
+  watch(
+    waypoints,
+    wps => {
+      wps.forEach((wp, index) => {
+        const id = wp.place?.id
+        if (!id || hydratedPlaceIds.has(id)) return
+        hydratedPlaceIds.add(id)
+        hydrateWaypointPlace(index, id)
+      })
+    },
+    { deep: true, immediate: true },
+  )
+
+  /**
+   * Keep the planned trip's stops pointing at the places the store now holds.
+   *
+   * A plan echoes back the waypoints it was built from, but a waypoint's place
+   * record keeps improving after the fact — reverse geocoding a dropped pin,
+   * looking up a stop restored from a link, filling in a thin autocomplete
+   * row. Whether that lands before the plan, during it, or against a cached
+   * plan restored whole, the trip has to end up rendering the record the user
+   * would see anywhere else, without re-planning the route to get it.
+   */
+  watch(
+    [waypoints, () => store.trips],
+    () => {
+      const planned = store.trips?.request?.waypoints
+      if (!planned) return
+      const settled = waypoints.value.filter(wp => wp.lngLat)
+      planned.forEach((entry, i) => {
+        const place = settled[i]?.place
+        if (!place || entry.place === place) return
+        entry.place = place
+        entry.name = getSearchResultName(place as Place)
+      })
+    },
+    { deep: true, immediate: true },
+  )
+
   // ── Shareable URL state ─────────────────────────────────────────────
   // Directions inputs live in the query string (?wp=lat,lng,label&mode=…)
   // so links can be bookmarked, shared, and reproduced exactly.
@@ -599,23 +639,7 @@ function directionsService() {
     if (state.sort) store.sortPreference = state.sort as typeof sortPreference.value
     if (state.depart) store.departureTime = state.depart
     store.setWaypoints(wps)
-    state.waypoints.forEach((w, i) => {
-      if (w.id) hydrateWaypointPlace(i, w.id)
-    })
     return true
-  }
-
-  /**
-   * The waypoint's place id, when it is one a recipient of the link can look
-   * up. Ids minted locally — current location, a bookmark row, an earlier
-   * link's own stub — mean nothing on another device, so they are left out
-   * rather than shared as dead references.
-   */
-  function shareableWaypointId(place: Partial<Place> | null | undefined) {
-    const id = place?.id
-    if (!id || !id.includes('/')) return undefined
-    if (id.startsWith('shared-wp-')) return undefined
-    return id
   }
 
   /** Reflect the current inputs into the URL (replace — no history spam). */

--- a/web/src/services/place.service.ts
+++ b/web/src/services/place.service.ts
@@ -58,6 +58,54 @@ function placeService() {
   }
 
   /**
+   * Fetch a place record without adopting it as the place the user is looking
+   * at — no `currentPlace`, no recents entry, no loading spinner.
+   *
+   * Background enrichment (a directions waypoint filling in its own type,
+   * hours and rating) needs the record but must not disturb the place view or
+   * write a view the user never made.
+   */
+  async function lookupPlace(
+    queryParams: Record<string, string>,
+    signal?: AbortSignal,
+  ): Promise<Place | null> {
+    const cacheKey = buildPlaceCacheKey(queryParams)
+    const cached = placeCache.get(cacheKey)
+    if (cached) return cached.data
+
+    try {
+      return await fetchPlaceFromApi(cacheKey, queryParams, signal)
+    } catch (e) {
+      if (!axios.isCancel(e)) console.warn('Place lookup failed:', e)
+      return null
+    }
+  }
+
+  /**
+   * Look up a place by the composite id the app routes on ("osm/node/123",
+   * "coords/35.2/-80.8", "google/<id>"). Mirrors `getPlaceRoute`'s parsing:
+   * everything before the first slash is the source, the rest is the id.
+   * Returns null for ids nothing can be fetched for (current location,
+   * bookmarks, locally-minted stubs).
+   */
+  const UNFETCHABLE_ID_PREFIXES = ['current-location', 'shared-wp-', 'coords/']
+
+  async function lookupPlaceById(
+    placeId: string,
+    signal?: AbortSignal,
+  ): Promise<Place | null> {
+    if (UNFETCHABLE_ID_PREFIXES.some(prefix => placeId.startsWith(prefix))) {
+      return null
+    }
+    const slash = placeId.indexOf('/')
+    if (slash <= 0) return null
+    return lookupPlace(
+      { source: placeId.slice(0, slash), id: placeId.slice(slash + 1) },
+      signal,
+    )
+  }
+
+  /**
    * Stale-while-revalidate fetch shared by both the source/id and
    * coordinate lookup paths.
    *
@@ -280,6 +328,8 @@ function placeService() {
     currentPlace,
     loading,
     fetchPlaceDetails,
+    lookupPlace,
+    lookupPlaceById,
     fetchPlaceDetailsByName,
     fetchPlaceDetailsByCoordinates,
     setPartialPlace,

--- a/web/src/views/directions/RoutingPreferences.vue
+++ b/web/src/views/directions/RoutingPreferences.vue
@@ -621,7 +621,7 @@ const customModelError = computed(() => {
     <Separator />
 
     <Collapsible v-model:open="advancedOpen" class="px-4 py-3">
-      <CollapsibleTrigger class="flex items-center gap-2 w-full text-sm font-medium text-muted-foreground hover:text-foreground transition-colors">
+      <CollapsibleTrigger class="flex items-center gap-2 w-full -mx-2 px-2 min-h-8 pointer-coarse:min-h-11 rounded-md text-sm font-medium text-muted-foreground hover:text-foreground hover:bg-muted/60 active:bg-muted transition-colors cursor-pointer select-none">
         <ChevronRightIcon
           class="size-4 transition-transform duration-200"
           :class="advancedOpen && 'rotate-90'"

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -987,8 +987,14 @@ interface RouteWaypointDisplay {
   displayName: string
   time: Date | null
   place?: Partial<Place> | null
-  /** What the timeline's place card renders from. */
+  /** What the timeline renders the stop from. */
   display: PlaceDisplay
+  /**
+   * Whether `display.icon` is the stop's own — a POI's glyph, the locate mark
+   * for current location. False for a stop that is just a point on the map,
+   * which keeps the rail's start/stop marks instead.
+   */
+  ownIcon: boolean
 }
 
 /**
@@ -1007,26 +1013,35 @@ interface RouteWaypointDisplay {
 function waypointDisplay(
   place: Partial<Place> | null | undefined,
   fallbackName: string,
-): PlaceDisplay {
+): { display: PlaceDisplay; ownIcon: boolean } {
   if (place?.id === 'current-location') {
-    return makePlaceDisplay({
-      title: place.name?.value || translate('directions.currentLocation'),
-      icon: 'Locate',
-    })
+    return {
+      display: makePlaceDisplay({
+        title: place.name?.value || translate('directions.currentLocation'),
+        icon: 'Locate',
+      }),
+      ownIcon: true,
+    }
   }
 
   if (!place || !isPoiCard(place)) {
-    return makePlaceDisplay({
-      title: place ? getSearchResultName(place as Place) || fallbackName : fallbackName,
-      icon: 'MapPin',
-    })
+    return {
+      display: makePlaceDisplay({
+        title: place ? getSearchResultName(place as Place) || fallbackName : fallbackName,
+        icon: 'MapPin',
+      }),
+      ownIcon: false,
+    }
   }
 
   const display = placeToDisplay(place as Place, {
     isDark: themeStore.isDark,
     t: translate,
   })
-  return display.title ? display : { ...display, title: fallbackName }
+  return {
+    display: display.title ? display : { ...display, title: fallbackName },
+    ownIcon: true,
+  }
 }
 
 const routeWaypoints = computed<RouteWaypointDisplay[]>(() => {
@@ -1055,7 +1070,7 @@ const routeWaypoints = computed<RouteWaypointDisplay[]>(() => {
       displayName: wp.name?.trim() || fallbackName,
       time: isOrigin ? t.startTime : isDestination ? t.endTime : null,
       place,
-      display: waypointDisplay(place, wp.name?.trim() || fallbackName),
+      ...waypointDisplay(place, wp.name?.trim() || fallbackName),
     }
   })
 })
@@ -1101,7 +1116,7 @@ const timelineEntries = computed<TimelineEntry[]>(() => {
       role: 'origin',
       displayName: '',
       time: segs[0]?.startTime ?? t.startTime,
-      display: waypointDisplay(null, 'Origin'),
+      ...waypointDisplay(null, 'Origin'),
     },
   })
 
@@ -1140,7 +1155,7 @@ const timelineEntries = computed<TimelineEntry[]>(() => {
       role: 'destination',
       displayName: '',
       time: segs[segs.length - 1]?.endTime ?? t.endTime,
-      display: waypointDisplay(null, 'Destination'),
+      ...waypointDisplay(null, 'Destination'),
     },
   })
 
@@ -1330,36 +1345,52 @@ function showSegmentChart(segment: any): boolean {
           >
 
             <!-- ── Waypoint rail ── -->
+            <!-- The stop's own glyph is the rail node. A stop is a place, and
+                 drawing a dot on the rail *and* an icon beside it made two
+                 marks for one thing. Sized to the segment icons so the rail
+                 keeps one rhythm down the trip. -->
             <template v-if="entry.kind === 'waypoint'">
-              <!-- Line above dot: from top of entry (with 2px overlap) to dot center -->
+              <!-- Line above the node: from the top of the entry (2px overlap)
+                   to the node's centre at 18px. -->
               <div
                 v-if="i > 0"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[26px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[20px]"
                 :class="getRailColor(i, 'above')"
               />
-              <!-- Line below dot: from dot center to bottom of entry (with 2px overlap) -->
+              <!-- Line below the node -->
               <div
                 v-if="i < timelineEntries.length - 1"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[24px] bottom-[-2px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[18px] bottom-[-2px]"
                 :class="getRailColor(i, 'above')"
               />
-              <!-- Dot — centred on the place card's icon (8px of card padding
-                   plus half of a 32px icon), so the rail runs through the row
-                   rather than clipping its top edge. Origin: open ring.
-                   Destination: filled with a flag. Intermediate vias: number. -->
+              <ItemIcon
+                v-if="entry.wp.ownIcon"
+                :icon="entry.wp.display.icon"
+                :icon-pack="entry.wp.display.iconPack"
+                :color="entry.wp.display.color"
+                :custom-color="entry.wp.display.customColor"
+                :image-url="entry.wp.display.imageUrl ?? undefined"
+                size="sm"
+                variant="solid"
+                shape="circle"
+                class="relative z-10 mt-1 !size-7 shrink-0 ring-2 ring-muted-light"
+              />
+              <!-- Nothing to draw: a plain point still has to say where the
+                   trip starts, ends and stops along the way. -->
               <div
-                class="relative z-10 mt-4 size-4 rounded-full flex items-center justify-center shrink-0"
+                v-else
+                class="relative z-10 mt-1 size-7 rounded-full flex items-center justify-center shrink-0 ring-2 ring-muted-light"
                 :class="entry.waypointIndex === 0
                   ? 'bg-background border-[1.5px] border-foreground/60'
                   : 'bg-primary'"
               >
                 <FlagIcon
                   v-if="entry.wp.role === 'destination'"
-                  class="size-2.5 text-primary-foreground"
+                  class="size-3.5 text-primary-foreground"
                 />
                 <span
                   v-else-if="entry.waypointIndex > 0"
-                  class="text-[9px] font-bold text-primary-foreground"
+                  class="text-xs font-bold text-primary-foreground"
                 >
                   {{ entry.waypointIndex }}
                 </span>
@@ -1368,25 +1399,26 @@ function showSegmentChart(segment: any): boolean {
 
             <!-- ── Place stop rail (parking, etc.) ── -->
             <template v-else-if="entry.kind === 'place-stop'">
-              <!-- Aligned to the card's icon centre, like the waypoint rail -->
               <div
                 v-if="i > 0"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[25px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[20px]"
                 :class="getRailColor(i, 'above')"
                 :style="getRailStyle(i, 'above')"
               />
               <div
                 v-if="i < timelineEntries.length - 1"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[23px] bottom-[-2px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[18px] bottom-[-2px]"
                 :class="getRailColor(i, 'below')"
                 :style="getRailStyle(i, 'below')"
               />
-              <!-- A node rather than the POI glyph: the card beside it already
-                   carries the place's own icon. -->
-              <div
-                class="relative z-10 mt-[18px] size-2.5 rounded-full shrink-0 ring-2 ring-background"
-                :class="getRailColor(i, 'above')"
-                :style="getRailStyle(i, 'above')"
+              <ItemIcon
+                :icon="getSearchResultIconName(entry.place)"
+                :icon-pack="getSearchResultIconPack(entry.place)"
+                :custom-color="getCategoryColor(getSearchResultCategory(entry.place), themeStore.isDark)"
+                size="sm"
+                variant="solid"
+                shape="circle"
+                class="relative z-10 mt-1 !size-7 shrink-0 ring-2 ring-muted-light"
               />
             </template>
 
@@ -1427,19 +1459,22 @@ function showSegmentChart(segment: any): boolean {
             class="flex-1 min-w-0"
             :class="isTransitCard(entry)
               ? 'pb-5'
-              : entry.kind === 'segment' ? 'pl-2.5 pb-5' : 'pl-3 pb-4'"
+              : entry.kind === 'segment' ? 'pl-2.5 pb-5' : 'pl-2.5 pb-4'"
           >
             <!-- ═══ Waypoint content ═══ -->
-            <!-- A stop is a place, so it renders as one: the same card the app
-                 uses for a search hit or a saved place, with the scheduled time
-                 in the slot a rating would otherwise take. -->
+            <!-- The name and type a place card derives, without the card: the
+                 rail already carries the icon, and a box around every stop
+                 fought the segments between them. `plain` keeps the hover and
+                 the link; the negative inset lets the highlight run the width
+                 of the row while the text still lines up with the segments. -->
             <template v-if="entry.kind === 'waypoint'">
               <PlaceCard
                 :display="entry.wp.display"
-                variant="inline"
+                variant="plain"
                 size="sm"
                 density="compact"
-                icon-variant="ghost"
+                :show-icon="false"
+                class="-mx-2"
               >
                 <template v-if="entry.wp.time" #title-trailing>
                   <span class="text-xs font-medium tabular-nums text-muted-foreground shrink-0">
@@ -1454,10 +1489,11 @@ function showSegmentChart(segment: any): boolean {
               <PlaceCard
                 :place="entry.place"
                 :title="entry.label || undefined"
-                variant="inline"
+                variant="plain"
                 size="sm"
                 density="compact"
-                icon-variant="ghost"
+                :show-icon="false"
+                class="-mx-2"
               >
                 <template v-if="entry.time" #title-trailing>
                   <span class="text-xs font-medium tabular-nums text-muted-foreground shrink-0">
@@ -1655,11 +1691,12 @@ function showSegmentChart(segment: any): boolean {
                       v-slot="{ open }"
                       class="relative"
                     >
-                      <!-- Same pill treatment as the leg's Details toggle, offset
-                           past the rail column so the label keeps its place. -->
-                      <CollapsibleTrigger class="group/stops flex w-full text-xs text-muted-foreground transition-colors cursor-pointer select-none">
+                      <!-- Same full-width control as the leg's Details toggle,
+                           offset past the rail column so it lines up with the
+                           cards above and below it. -->
+                      <CollapsibleTrigger class="group/stops flex w-full transition-colors cursor-pointer select-none">
                         <div class="w-7 shrink-0" />
-                        <span class="flex items-center gap-1.5 ml-0.5 px-2 min-h-8 pointer-coarse:min-h-11 rounded-md group-hover/stops:text-foreground group-hover/stops:bg-muted/60 transition-colors">
+                        <span class="flex flex-1 items-center gap-1.5 ml-2.5 px-2.5 min-h-9 pointer-coarse:min-h-11 rounded-md border bg-card text-xs font-medium text-muted-foreground group-hover/stops:text-foreground group-hover/stops:bg-secondary/40 transition-colors">
                           <ChevronDownIcon class="size-3.5 transition-transform" :class="open && 'rotate-180'" />
                           <span>{{ entry.segment.intermediateStops.length }} stops · {{ formatDurationCompact(entry.segment.duration) }}</span>
                         </span>

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -47,11 +47,17 @@ import {
   getSearchResultIconName,
   getSearchResultIconPack,
   getSearchResultCategory,
+  getSearchResultName,
 } from '@/lib/search.utils'
 import { getCategoryColor } from '@/lib/place-colors'
 import { useThemeStore } from '@/stores/theme.store'
 import { ItemIcon } from '@/components/ui/item-icon'
 import { PlaceCard } from '@/components/place/card'
+import {
+  placeToDisplay,
+  makePlaceDisplay,
+  type PlaceDisplay,
+} from '@/lib/place-display'
 import SegmentDetails from '@/components/directions/timeline/SegmentDetails.vue'
 import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
 import RouteBullet from '@/components/transit/RouteBullet.vue'
@@ -64,6 +70,7 @@ import type { ServiceAlert } from '@/types/transit.types'
 import PanelLayout from '@/components/layouts/PanelLayout.vue'
 import { useUnits } from '@/composables/useUnits'
 import { formatDurationCompact } from '@/lib/time.utils'
+import { useI18n } from 'vue-i18n'
 
 const route = useRoute()
 const router = useRouter()
@@ -71,6 +78,7 @@ const directionsStore = useDirectionsStore()
 const directionsService = useDirectionsService()
 const mapService = useMapService()
 const themeStore = useThemeStore()
+const { t: translate } = useI18n()
 // Live position, so the approach walk on the departure board decays as the
 // rider actually closes on the stop.
 const geo = useGeolocationService()
@@ -979,6 +987,46 @@ interface RouteWaypointDisplay {
   displayName: string
   time: Date | null
   place?: Partial<Place> | null
+  /** What the timeline's place card renders from. */
+  display: PlaceDisplay
+}
+
+/**
+ * A stop rendered the way the rest of the app renders a place.
+ *
+ * Every stop goes through `PlaceDisplay` so the timeline gets the same icon,
+ * category colour and detail lines a search result or a bookmark would — a
+ * waypoint is a place, and used to be the one surface that spelled that out
+ * itself. The two cases the place adapter can't cover:
+ *
+ *  - current location, which is a position rather than a record, so it takes
+ *    the locate glyph and goes nowhere when tapped
+ *  - a stop with no place at all (a dropped pin, a link with only a label),
+ *    which gets a pin and, likewise, no destination
+ */
+function waypointDisplay(
+  place: Partial<Place> | null | undefined,
+  fallbackName: string,
+): PlaceDisplay {
+  if (place?.id === 'current-location') {
+    return makePlaceDisplay({
+      title: place.name?.value || translate('directions.currentLocation'),
+      icon: 'Locate',
+    })
+  }
+
+  if (!place || !isPoiCard(place)) {
+    return makePlaceDisplay({
+      title: place ? getSearchResultName(place as Place) || fallbackName : fallbackName,
+      icon: 'MapPin',
+    })
+  }
+
+  const display = placeToDisplay(place as Place, {
+    isDark: themeStore.isDark,
+    t: translate,
+  })
+  return display.title ? display : { ...display, title: fallbackName }
 }
 
 const routeWaypoints = computed<RouteWaypointDisplay[]>(() => {
@@ -1000,12 +1048,14 @@ const routeWaypoints = computed<RouteWaypointDisplay[]>(() => {
       : isDestination
         ? 'Destination'
         : `Stop ${++viaCounter}`
+    const place = wp.place ?? null
     return {
       id: wp.id || `wp-${i}`,
       role,
       displayName: wp.name?.trim() || fallbackName,
       time: isOrigin ? t.startTime : isDestination ? t.endTime : null,
-      place: (wp as any).place ?? null,
+      place,
+      display: waypointDisplay(place, wp.name?.trim() || fallbackName),
     }
   })
 })
@@ -1051,6 +1101,7 @@ const timelineEntries = computed<TimelineEntry[]>(() => {
       role: 'origin',
       displayName: '',
       time: segs[0]?.startTime ?? t.startTime,
+      display: waypointDisplay(null, 'Origin'),
     },
   })
 
@@ -1089,6 +1140,7 @@ const timelineEntries = computed<TimelineEntry[]>(() => {
       role: 'destination',
       displayName: '',
       time: segs[segs.length - 1]?.endTime ?? t.endTime,
+      display: waypointDisplay(null, 'Destination'),
     },
   })
 
@@ -1282,19 +1334,21 @@ function showSegmentChart(segment: any): boolean {
               <!-- Line above dot: from top of entry (with 2px overlap) to dot center -->
               <div
                 v-if="i > 0"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[12px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[26px]"
                 :class="getRailColor(i, 'above')"
               />
               <!-- Line below dot: from dot center to bottom of entry (with 2px overlap) -->
               <div
                 v-if="i < timelineEntries.length - 1"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[10px] bottom-[-2px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[24px] bottom-[-2px]"
                 :class="getRailColor(i, 'above')"
               />
-              <!-- Dot — top-aligned with text via pt-0.5. Origin: open ring.
+              <!-- Dot — centred on the place card's icon (8px of card padding
+                   plus half of a 32px icon), so the rail runs through the row
+                   rather than clipping its top edge. Origin: open ring.
                    Destination: filled with a flag. Intermediate vias: number. -->
               <div
-                class="relative z-10 mt-0.5 size-4 rounded-full flex items-center justify-center shrink-0"
+                class="relative z-10 mt-4 size-4 rounded-full flex items-center justify-center shrink-0"
                 :class="entry.waypointIndex === 0
                   ? 'bg-background border-[1.5px] border-foreground/60'
                   : 'bg-primary'"
@@ -1314,29 +1368,25 @@ function showSegmentChart(segment: any): boolean {
 
             <!-- ── Place stop rail (parking, etc.) ── -->
             <template v-else-if="entry.kind === 'place-stop'">
-              <!-- Line above icon: from top (overlap) to icon center (mt-0.5=2px + 10px half of 20px = 12px) -->
+              <!-- Aligned to the card's icon centre, like the waypoint rail -->
               <div
                 v-if="i > 0"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[14px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[-2px] h-[25px]"
                 :class="getRailColor(i, 'above')"
                 :style="getRailStyle(i, 'above')"
               />
-              <!-- Line below icon -->
               <div
                 v-if="i < timelineEntries.length - 1"
-                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[12px] bottom-[-2px]"
+                class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[23px] bottom-[-2px]"
                 :class="getRailColor(i, 'below')"
                 :style="getRailStyle(i, 'below')"
               />
-              <!-- POI icon -->
-              <ItemIcon
-                :icon="getSearchResultIconName(entry.place)"
-                :icon-pack="getSearchResultIconPack(entry.place)"
-                :custom-color="getCategoryColor(getSearchResultCategory(entry.place), themeStore.isDark)"
-                size="xs"
-                variant="solid"
-                shape="circle"
-                class="relative z-10 mt-0.5 !size-5 shrink-0"
+              <!-- A node rather than the POI glyph: the card beside it already
+                   carries the place's own icon. -->
+              <div
+                class="relative z-10 mt-[18px] size-2.5 rounded-full shrink-0 ring-2 ring-background"
+                :class="getRailColor(i, 'above')"
+                :style="getRailStyle(i, 'above')"
               />
             </template>
 
@@ -1380,83 +1430,41 @@ function showSegmentChart(segment: any): boolean {
               : entry.kind === 'segment' ? 'pl-2.5 pb-5' : 'pl-3 pb-4'"
           >
             <!-- ═══ Waypoint content ═══ -->
+            <!-- A stop is a place, so it renders as one: the same card the app
+                 uses for a search hit or a saved place, with the scheduled time
+                 in the slot a rating would otherwise take. -->
             <template v-if="entry.kind === 'waypoint'">
-              <div class="flex items-baseline gap-2 min-h-5 mt-px">
-                <span
-                  v-if="entry.wp.time"
-                  class="text-sm font-medium tabular-nums shrink-0"
-                >
-                  {{ formatTime(entry.wp.time) }}
-                </span>
-                <span
-                  v-if="entry.wp.displayName && entry.wp.displayName !== 'Origin' && entry.wp.displayName !== 'Destination'"
-                  class="text-sm text-foreground truncate"
-                >
-                  {{ entry.wp.displayName }}
-                </span>
-                <span
-                  v-else-if="entry.wp.role === 'destination' && entry.wp.displayName === 'Destination'"
-                  class="text-sm text-muted-foreground"
-                >
-                  Destination
-                </span>
-                <span
-                  v-else-if="entry.wp.role === 'via'"
-                  class="text-sm text-muted-foreground"
-                >
-                  {{ entry.wp.displayName }}
-                </span>
-              </div>
-              <!-- Place info card — only for a real POI worth opening, not a
-                   plain address / shared location (those just repeat the title).
-                   The waypoint row above already carries the name, so the card
-                   leads with the type instead of repeating it. -->
               <PlaceCard
-                v-if="isPoiCard(entry.wp.place)"
-                :place="entry.wp.place as Place"
+                :display="entry.wp.display"
                 variant="inline"
-                size="xs"
+                size="sm"
                 density="compact"
                 icon-variant="ghost"
-                :title="entry.wp.place!.placeType?.value || undefined"
-                :subtitle="entry.wp.place!.summary ?? ''"
-                class="mt-1.5"
-              />
+              >
+                <template v-if="entry.wp.time" #title-trailing>
+                  <span class="text-xs font-medium tabular-nums text-muted-foreground shrink-0">
+                    {{ formatTime(entry.wp.time) }}
+                  </span>
+                </template>
+              </PlaceCard>
             </template>
 
             <!-- ═══ Place stop content (parking, etc.) ═══ -->
             <template v-else-if="entry.kind === 'place-stop'">
-              <div class="flex items-baseline gap-2 min-h-5 mt-px">
-                <span
-                  v-if="entry.time"
-                  class="text-sm font-medium tabular-nums shrink-0"
-                >
-                  {{ formatTime(entry.time) }}
-                </span>
-                <router-link
-                  :to="getPlaceRoute(entry.place.id)"
-                  class="text-sm text-primary hover:underline truncate"
-                >
-                  {{ entry.label }}
-                </router-link>
-              </div>
-              <div
-                v-if="entry.place.summary || entry.place.placeType?.value"
-                class="mt-0.5 flex flex-col gap-0.5"
+              <PlaceCard
+                :place="entry.place"
+                :title="entry.label || undefined"
+                variant="inline"
+                size="sm"
+                density="compact"
+                icon-variant="ghost"
               >
-                <span
-                  v-if="entry.place.placeType?.value && entry.place.placeType.value !== entry.label"
-                  class="text-xs text-muted-foreground"
-                >
-                  {{ entry.place.placeType.value }}
-                </span>
-                <span
-                  v-if="entry.place.summary"
-                  class="text-xs text-muted-foreground"
-                >
-                  {{ entry.place.summary }}
-                </span>
-              </div>
+                <template v-if="entry.time" #title-trailing>
+                  <span class="text-xs font-medium tabular-nums text-muted-foreground shrink-0">
+                    {{ formatTime(entry.time) }}
+                  </span>
+                </template>
+              </PlaceCard>
             </template>
 
             <!-- ═══ Segment content ═══ -->
@@ -1647,10 +1655,12 @@ function showSegmentChart(segment: any): boolean {
                       v-slot="{ open }"
                       class="relative"
                     >
-                      <CollapsibleTrigger class="flex w-full text-xs text-muted-foreground hover:text-foreground transition-colors cursor-pointer">
+                      <!-- Same pill treatment as the leg's Details toggle, offset
+                           past the rail column so the label keeps its place. -->
+                      <CollapsibleTrigger class="group/stops flex w-full text-xs text-muted-foreground transition-colors cursor-pointer select-none">
                         <div class="w-7 shrink-0" />
-                        <span class="flex items-center gap-1 pl-2.5">
-                          <ChevronDownIcon class="size-3 transition-transform" :class="open && 'rotate-180'" />
+                        <span class="flex items-center gap-1.5 ml-0.5 px-2 min-h-8 pointer-coarse:min-h-11 rounded-md group-hover/stops:text-foreground group-hover/stops:bg-muted/60 transition-colors">
+                          <ChevronDownIcon class="size-3.5 transition-transform" :class="open && 'rotate-180'" />
                           <span>{{ entry.segment.intermediateStops.length }} stops · {{ formatDurationCompact(entry.segment.duration) }}</span>
                         </span>
                       </CollapsibleTrigger>

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -1376,24 +1376,31 @@ function showSegmentChart(segment: any): boolean {
                 class="relative z-10 mt-1 !size-7 shrink-0 ring-2 ring-muted-light"
               />
               <!-- Nothing to draw: a plain point still has to say where the
-                   trip starts, ends and stops along the way. -->
+                   trip starts, ends and stops along the way. It stays a small
+                   mark — the box around it only exists to put its centre on
+                   the rail where a glyph's would be. Blown up to glyph size an
+                   empty ring is just a large hole. -->
               <div
                 v-else
-                class="relative z-10 mt-1 size-7 rounded-full flex items-center justify-center shrink-0 ring-2 ring-muted-light"
-                :class="entry.waypointIndex === 0
-                  ? 'bg-background border-[1.5px] border-foreground/60'
-                  : 'bg-primary'"
+                class="relative z-10 mt-1 size-7 flex items-center justify-center shrink-0"
               >
-                <FlagIcon
-                  v-if="entry.wp.role === 'destination'"
-                  class="size-3.5 text-primary-foreground"
-                />
-                <span
-                  v-else-if="entry.waypointIndex > 0"
-                  class="text-xs font-bold text-primary-foreground"
+                <div
+                  class="size-4 rounded-full flex items-center justify-center ring-2 ring-muted-light"
+                  :class="entry.waypointIndex === 0
+                    ? 'bg-background border-[1.5px] border-foreground/60'
+                    : 'bg-primary'"
                 >
-                  {{ entry.waypointIndex }}
-                </span>
+                  <FlagIcon
+                    v-if="entry.wp.role === 'destination'"
+                    class="size-2.5 text-primary-foreground"
+                  />
+                  <span
+                    v-else-if="entry.waypointIndex > 0"
+                    class="text-[9px] font-bold text-primary-foreground"
+                  >
+                    {{ entry.waypointIndex }}
+                  </span>
+                </div>
               </div>
             </template>
 

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -52,11 +52,7 @@ import { getCategoryColor } from '@/lib/place-colors'
 import { useThemeStore } from '@/stores/theme.store'
 import { ItemIcon } from '@/components/ui/item-icon'
 import { PlaceCard } from '@/components/place/card'
-import {
-  placeToDisplay,
-  makePlaceDisplay,
-  type PlaceDisplay,
-} from '@/lib/place-display'
+import { waypointToDisplay, type PlaceDisplay } from '@/lib/place-display'
 import SegmentDetails from '@/components/directions/timeline/SegmentDetails.vue'
 import RealtimeIndicator from '@/components/transit/RealtimeIndicator.vue'
 import RouteBullet from '@/components/transit/RouteBullet.vue'
@@ -747,23 +743,6 @@ function entrancePhrase(
   return ''
 }
 
-/** Generic, non-POI place types — a plain address or shared pin just repeats
- *  the waypoint title, so it gets no tap-to-open place card. */
-const GENERIC_PLACE_TYPES = new Set([
-  'area',
-  'address',
-  'coordinates',
-  'shared_location',
-  'current_location',
-])
-
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isPoiCard(place: any): boolean {
-  if (!place?.id) return false
-  const type = place.placeType?.value?.toLowerCase?.().trim()
-  return !type || !GENERIC_PLACE_TYPES.has(type)
-}
-
 const hoveredInstructionKey = ref<string | null>(null)
 
 const tripId = computed(() => route.params.id as string)
@@ -997,53 +976,6 @@ interface RouteWaypointDisplay {
   ownIcon: boolean
 }
 
-/**
- * A stop rendered the way the rest of the app renders a place.
- *
- * Every stop goes through `PlaceDisplay` so the timeline gets the same icon,
- * category colour and detail lines a search result or a bookmark would — a
- * waypoint is a place, and used to be the one surface that spelled that out
- * itself. The two cases the place adapter can't cover:
- *
- *  - current location, which is a position rather than a record, so it takes
- *    the locate glyph and goes nowhere when tapped
- *  - a stop with no place at all (a dropped pin, a link with only a label),
- *    which gets a pin and, likewise, no destination
- */
-function waypointDisplay(
-  place: Partial<Place> | null | undefined,
-  fallbackName: string,
-): { display: PlaceDisplay; ownIcon: boolean } {
-  if (place?.id === 'current-location') {
-    return {
-      display: makePlaceDisplay({
-        title: place.name?.value || translate('directions.currentLocation'),
-        icon: 'Locate',
-      }),
-      ownIcon: true,
-    }
-  }
-
-  if (!place || !isPoiCard(place)) {
-    return {
-      display: makePlaceDisplay({
-        title: place ? getSearchResultName(place as Place) || fallbackName : fallbackName,
-        icon: 'MapPin',
-      }),
-      ownIcon: false,
-    }
-  }
-
-  const display = placeToDisplay(place as Place, {
-    isDark: themeStore.isDark,
-    t: translate,
-  })
-  return {
-    display: display.title ? display : { ...display, title: fallbackName },
-    ownIcon: true,
-  }
-}
-
 const routeWaypoints = computed<RouteWaypointDisplay[]>(() => {
   const waypoints = directionsStore.trips?.request?.waypoints
   const t = trip.value
@@ -1070,7 +1002,11 @@ const routeWaypoints = computed<RouteWaypointDisplay[]>(() => {
       displayName: wp.name?.trim() || fallbackName,
       time: isOrigin ? t.startTime : isDestination ? t.endTime : null,
       place,
-      ...waypointDisplay(place, wp.name?.trim() || fallbackName),
+      ...waypointToDisplay(place, {
+        isDark: themeStore.isDark,
+        t: translate,
+        fallbackTitle: wp.name?.trim() || fallbackName,
+      }),
     }
   })
 })
@@ -1116,7 +1052,7 @@ const timelineEntries = computed<TimelineEntry[]>(() => {
       role: 'origin',
       displayName: '',
       time: segs[0]?.startTime ?? t.startTime,
-      ...waypointDisplay(null, 'Origin'),
+      ...waypointToDisplay(null, { isDark: themeStore.isDark, t: translate, fallbackTitle: 'Origin' }),
     },
   })
 
@@ -1155,7 +1091,7 @@ const timelineEntries = computed<TimelineEntry[]>(() => {
       role: 'destination',
       displayName: '',
       time: segs[segs.length - 1]?.endTime ?? t.endTime,
-      ...waypointDisplay(null, 'Destination'),
+      ...waypointToDisplay(null, { isDark: themeStore.isDark, t: translate, fallbackTitle: 'Destination' }),
     },
   })
 

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -29,7 +29,6 @@ import {
   ChevronDownIcon,
   ClockIcon,
   ExternalLinkIcon,
-  FlagIcon,
   AccessibilityIcon,
   LogInIcon,
   LogOutIcon,
@@ -68,6 +67,7 @@ import { useTransitAlertsStore } from '@/stores/transit-alerts.store'
 import { splitFeedId, isInEffect, sortByRelevance } from '@/lib/transit-alerts'
 import type { ServiceAlert } from '@/types/transit.types'
 import PanelLayout from '@/components/layouts/PanelLayout.vue'
+import { SheetHeader } from '@/components/sheet'
 import { useUnits } from '@/composables/useUnits'
 import { formatDurationCompact } from '@/lib/time.utils'
 import { useI18n } from 'vue-i18n'
@@ -1257,9 +1257,23 @@ function showSegmentChart(segment: any): boolean {
 
     <!-- Trip content -->
     <div v-else-if="trip">
-      <!-- Hero. Actions sit at the BOTTOM of the block (items-end) so they
-           clear the sheet's back/close nav, which occupies the top-right
-           chrome zone; the stats stay at the top. -->
+      <!-- Hero, pinned. How long the trip takes and when it leaves is what the
+           rest of the panel is read against, so it stays on screen while the
+           timeline scrolls under it — the same contract the transit route
+           detail uses. The margin cancels PanelLayout's inset and re-adds the
+           dock line, so the header's natural position IS where it sticks; see
+           `RouteDetailPage` for why any other value breaks. -->
+      <SheetHeader
+        v-slot="{ stuck }"
+        class="-mx-3 mb-3 mt-[calc(var(--sheet-sticky-top,0px)_-_var(--panel-inset-top,0px))]"
+      >
+      <div
+        class="px-3 md:pt-4 pb-3 border-b transition-colors duration-200"
+        :class="stuck ? 'border-border/60' : 'border-transparent'"
+      >
+      <!-- Actions sit at the BOTTOM of the block (items-end) so they clear the
+           sheet's back/close nav, which occupies the top-right chrome zone;
+           the stats stay at the top. -->
       <div class="flex items-end justify-between gap-4">
         <div>
           <div class="flex items-baseline gap-2">
@@ -1306,6 +1320,8 @@ function showSegmentChart(segment: any): boolean {
           </Button>
         </div>
       </div>
+      </div>
+      </SheetHeader>
 
       <!-- Timezone warning -->
       <div
@@ -1363,8 +1379,13 @@ function showSegmentChart(segment: any): boolean {
                 class="absolute left-1/2 -translate-x-1/2 w-0.5 top-[18px] bottom-[-2px]"
                 :class="getRailColor(i, 'above')"
               />
+              <!-- Every stop but the start wears a marker: its own POI glyph
+                   where it has one, the marker system's pin where it doesn't.
+                   The end of a trip is a place like any other — it does not
+                   need a flag of its own to say so, and the arrival time
+                   beside it already does. -->
               <ItemIcon
-                v-if="entry.wp.ownIcon"
+                v-if="entry.waypointIndex > 0 || entry.wp.ownIcon"
                 :icon="entry.wp.display.icon"
                 :icon-pack="entry.wp.display.iconPack"
                 :color="entry.wp.display.color"
@@ -1375,32 +1396,17 @@ function showSegmentChart(segment: any): boolean {
                 shape="circle"
                 class="relative z-10 mt-1 !size-7 shrink-0 ring-2 ring-muted-light"
               />
-              <!-- Nothing to draw: a plain point still has to say where the
-                   trip starts, ends and stops along the way. It stays a small
-                   mark — the box around it only exists to put its centre on
-                   the rail where a glyph's would be. Blown up to glyph size an
-                   empty ring is just a large hole. -->
+              <!-- The start of a trip is the one point that isn't a place —
+                   it's where you are. It keeps the open ring, small: the box
+                   around it only exists to put its centre on the rail where a
+                   glyph's would be. -->
               <div
                 v-else
                 class="relative z-10 mt-1 size-7 flex items-center justify-center shrink-0"
               >
                 <div
-                  class="size-4 rounded-full flex items-center justify-center ring-2 ring-muted-light"
-                  :class="entry.waypointIndex === 0
-                    ? 'bg-background border-[1.5px] border-foreground/60'
-                    : 'bg-primary'"
-                >
-                  <FlagIcon
-                    v-if="entry.wp.role === 'destination'"
-                    class="size-2.5 text-primary-foreground"
-                  />
-                  <span
-                    v-else-if="entry.waypointIndex > 0"
-                    class="text-[9px] font-bold text-primary-foreground"
-                  >
-                    {{ entry.waypointIndex }}
-                  </span>
-                </div>
+                  class="size-4 rounded-full bg-background border-[1.5px] border-foreground/60 ring-2 ring-muted-light"
+                />
               </div>
             </template>
 

--- a/web/src/views/directions/TripsList.vue
+++ b/web/src/views/directions/TripsList.vue
@@ -5,7 +5,7 @@ import { useRouter } from 'vue-router'
 import type { TripsResponse, TripOption } from '@/types/directions.types'
 import TripItem from './TripItem.vue'
 import { useDirectionsStore } from '@/stores/directions.store'
-import { serializeDirectionsQuery } from '@/lib/directions-url'
+import { serializeDirectionsQuery, shareableWaypointId } from '@/lib/directions-url'
 import { tripSignature } from '@/lib/trip-signature'
 import { api } from '@/lib/api'
 
@@ -179,6 +179,7 @@ function navigateToTripDetail(trip: TripOption) {
         lat: wp.coordinate.lat,
         lng: wp.coordinate.lng,
         label: wp.name || undefined,
+        id: shareableWaypointId(wp.place),
       })),
       mode: directionsStore.selectedMode,
       sort: directionsStore.sortPreference || undefined,

--- a/web/src/views/directions/WaypointInput.vue
+++ b/web/src/views/directions/WaypointInput.vue
@@ -436,7 +436,7 @@ defineExpose({
             >
               <ComboboxAnchor>
                 <ComboboxInput
-                  :placeholder="index === 0 ? $t('directions.from') : $t('directions.to')"
+                  :placeholder="isCurrentLocationChip(index) ? '' : index === 0 ? $t('directions.from') : $t('directions.to')"
                   :model-value="inputTexts[index] || ''"
                   :class="blurPhase[index] === 'out' ? 'animate-blur-out' : blurPhase[index] === 'wipe' ? 'animate-wipe-in' : ''"
                   hide-search-icon

--- a/web/src/views/directions/WaypointInput.vue
+++ b/web/src/views/directions/WaypointInput.vue
@@ -41,7 +41,9 @@ import { PlaceCard } from '@/components/place/card'
 import {
   autocompleteToDisplay,
   makePlaceDisplay,
+  waypointToDisplay,
 } from '@/lib/place-display'
+import { ItemIcon } from '@/components/ui/item-icon'
 import { useThemeStore } from '@/stores/theme.store'
 import { fuzzyFilter } from '@/lib/utils'
 import { useBookmarksStore } from '@/stores/library/bookmarks.store'
@@ -341,6 +343,26 @@ function isCurrentLocationChip(index: number): boolean {
   )
 }
 
+/**
+ * The mark in front of each field: the stop's own POI glyph where it has one,
+ * so a field holding a restaurant looks like the restaurant it will be on the
+ * map and in the trip. Current location is the exception — the chip inside the
+ * field already carries that mark, and drawing it twice on one row reads as
+ * two different things.
+ */
+const waypointMarks = computed(() =>
+  waypoints.value.map(waypoint => {
+    const { display, ownIcon } = waypointToDisplay(waypoint.place, {
+      isDark: themeStore.isDark,
+      t,
+    })
+    return {
+      display,
+      showGlyph: ownIcon && waypoint.place?.id !== 'current-location',
+    }
+  }),
+)
+
 const currentLocationDisplay = computed(() =>
   makePlaceDisplay({
     title: t('directions.currentLocation', 'Current Location'),
@@ -425,7 +447,7 @@ defineExpose({
             <!-- Connecting line between icons -->
             <div
               v-if="index < waypoints.length - 1"
-              class="absolute left-[1.19rem] top-full w-px h-2 bg-border z-0"
+              class="absolute left-[1.375rem] top-full w-px h-2 bg-border z-0"
             />
 
             <Combobox
@@ -456,8 +478,21 @@ defineExpose({
                   "
                 >
                   <template #prefix>
-                    <div class="shrink-0 flex items-center justify-center handle cursor-grab active:cursor-grabbing relative">
+                    <div class="shrink-0 size-5 flex items-center justify-center handle cursor-grab active:cursor-grabbing relative">
+                      <ItemIcon
+                        v-if="waypointMarks[index]?.showGlyph"
+                        :icon="waypointMarks[index].display.icon"
+                        :icon-pack="waypointMarks[index].display.iconPack"
+                        :color="waypointMarks[index].display.color"
+                        :custom-color="waypointMarks[index].display.customColor"
+                        :image-url="waypointMarks[index].display.imageUrl ?? undefined"
+                        size="xs"
+                        variant="solid"
+                        shape="circle"
+                        class="group-hover:opacity-0 transition-opacity"
+                      />
                       <div
+                        v-else
                         class="size-4 rounded-full flex items-center justify-center group-hover:opacity-0 transition-opacity"
                         :class="index === 0 ? 'bg-background border-[1.5px] border-foreground/60' : 'bg-primary border-[1.5px] border-white'"
                       >

--- a/web/src/views/directions/WaypointInput.vue
+++ b/web/src/views/directions/WaypointInput.vue
@@ -351,14 +351,18 @@ function isCurrentLocationChip(index: number): boolean {
  * two different things.
  */
 const waypointMarks = computed(() =>
-  waypoints.value.map(waypoint => {
+  waypoints.value.map((waypoint, index) => {
     const { display, ownIcon } = waypointToDisplay(waypoint.place, {
       isDark: themeStore.isDark,
       t,
     })
     return {
       display,
-      showGlyph: ownIcon && waypoint.place?.id !== 'current-location',
+      // The origin is the one field that isn't a place; everything else shows
+      // a mark, its own glyph or the pin. Current location is the exception:
+      // the chip inside the field already carries that mark.
+      showGlyph:
+        (ownIcon || index > 0) && waypoint.place?.id !== 'current-location',
     }
   }),
 )
@@ -491,13 +495,12 @@ defineExpose({
                         shape="circle"
                         class="group-hover:opacity-0 transition-opacity"
                       />
+                      <!-- Where the trip starts. Every other field holds a
+                           place, and shows it. -->
                       <div
                         v-else
-                        class="size-4 rounded-full flex items-center justify-center group-hover:opacity-0 transition-opacity"
-                        :class="index === 0 ? 'bg-background border-[1.5px] border-foreground/60' : 'bg-primary border-[1.5px] border-white'"
-                      >
-                        <span v-if="index > 0" class="text-[9px] font-bold text-white">{{ index }}</span>
-                      </div>
+                        class="size-4 rounded-full bg-background border-[1.5px] border-foreground/60 group-hover:opacity-0 transition-opacity"
+                      />
                       <GripVerticalIcon class="size-4 text-muted-foreground absolute opacity-0 group-hover:opacity-100 transition-opacity" />
                     </div>
                     <!-- Current location isn't typed text, so it sits in the

--- a/web/src/views/directions/WaypointInput.vue
+++ b/web/src/views/directions/WaypointInput.vue
@@ -31,11 +31,19 @@ import { useAbortController } from '@/composables/useAbortController'
 import { cn, useResponsive } from '@/lib/utils'
 import { useDebounceFn } from '@vueuse/core'
 import { Spinner } from '@/components/ui/spinner'
-import { getSearchResultName } from '@/lib/search.utils'
+import {
+  getSearchResultName,
+  autocompleteResultToPlace,
+} from '@/lib/search.utils'
 import { useGeolocationService } from '@/services/geolocation.service'
 import { useI18n } from 'vue-i18n'
-import { ItemIcon } from '@/components/ui/item-icon'
-import { type ThemeColor, fuzzyFilter } from '@/lib/utils'
+import { PlaceCard } from '@/components/place/card'
+import {
+  autocompleteToDisplay,
+  makePlaceDisplay,
+} from '@/lib/place-display'
+import { useThemeStore } from '@/stores/theme.store'
+import { fuzzyFilter } from '@/lib/utils'
 import { useBookmarksStore } from '@/stores/library/bookmarks.store'
 import { frequentChipMeta, type FrequentType } from '@/lib/frequents'
 import type { Bookmark } from '@/types/library.types'
@@ -47,6 +55,7 @@ const { t } = useI18n()
 
 const directionsService = useDirectionsService()
 const bookmarksStore = useBookmarksStore()
+const themeStore = useThemeStore()
 const { isMobileScreen } = useResponsive()
 
 // Home / Work / School as quick destinations. A category can hold several
@@ -188,6 +197,9 @@ function updateTimeConstraint(index: number, constraint: WaypointTimeConstraint 
 }
 
 function getWaypointName(waypoint: Waypoint) {
+  // Current location renders as a chip beside the caret, so the field itself
+  // stays empty — see `isCurrentLocationChip`.
+  if (waypoint.place?.id === 'current-location') return ''
   if (waypoint.place) {
     const placeName = getSearchResultName(waypoint.place as Place)
     // If place exists but has no name, fall back to coordinates
@@ -204,7 +216,7 @@ function getWaypointName(waypoint: Waypoint) {
   return ''
 }
 
-function selectPlace(index: number, place: Place, result?: AutocompleteResult) {
+function selectPlace(index: number, place: Place) {
   const newWaypoints = [...waypoints.value]
 
   // Create waypoint with place and coordinates - all place types follow the same pattern
@@ -220,7 +232,7 @@ function selectPlace(index: number, place: Place, result?: AutocompleteResult) {
   emit('update:modelValue', newWaypoints)
 
   // Update input text to show the selected place name
-  inputTexts.value[index] = result ? result.title : getSearchResultName(place)
+  inputTexts.value[index] = getWaypointName(newWaypoints[index])
 
   // Clear user-modified flag since we're setting a system value
   userModifiedInputs.value.delete(index)
@@ -314,92 +326,32 @@ const getAutocomplete = useDebounceFn(async (index: number, value: string) => {
   }
 }, 150)
 
-// Convert AutocompleteResult to Place object
-function autocompleteResultToPlace(result: AutocompleteResult): Place {
-  if (result.type === 'current_location') {
-    return {
-      id: 'current-location',
-      name: { value: result.title },
-      geometry: {
-        value: {
-          type: 'point',
-          center: {
-            lat: result.lat,
-            lng: result.lng,
-          },
-        },
-      },
-      externalIds: {},
-      address: null,
-      placeType: { value: 'current_location' },
-    } as unknown as Place // TODO: Fix this
-  }
-
-  if (result.type === 'bookmark') {
-    return {
-      id: result.id,
-      name: { value: result.title },
-      geometry: {
-        value: {
-          type: 'point',
-          center: {
-            lat: result.lat,
-            lng: result.lng,
-          },
-        },
-      },
-      externalIds: {},
-      address: result.description
-        ? { value: { formatted: result.description } }
-        : null,
-      placeType: { value: 'bookmark' },
-      bookmark: {
-        id: result.id,
-        name: result.title,
-        icon: result.icon || 'map-pin',
-        iconColor: result.color || 'magenta',
-      },
-    } as unknown as Place
-  }
-
-  // Default for 'place' type and fallback
-  return {
-    id: result.id,
-    name: { value: result.title },
-    geometry: {
-      value: {
-        type: 'point',
-        center: {
-          lat: result.lat,
-          lng: result.lng,
-        },
-      },
-    },
-    externalIds: {},
-    address: result.description
-      ? { value: { formatted: result.description } }
-      : null,
-    placeType: { value: 'place' },
-  } as unknown as Place
+/**
+ * Current location is not a place you can type, so the field shows it as a
+ * chip rather than as text: a value the user chose, not a query they wrote.
+ *
+ * The chip stands in for the input's contents, so it holds only while the
+ * field is empty — the first keystroke is the user replacing it, and the chip
+ * gives way to what they are typing.
+ */
+function isCurrentLocationChip(index: number): boolean {
+  return (
+    waypoints.value[index]?.place?.id === 'current-location' &&
+    !inputTexts.value[index]
+  )
 }
 
-// Check if current location is already used in any waypoint that hasn't been edited
-const isCurrentLocationUsed = computed(() => {
-  return waypoints.value.some((waypoint, index) => {
-    // Current location is considered "used" only if:
-    // 1. The waypoint has current location as its place
-    // 2. The input text matches the current location name (user hasn't started editing)
-    if (waypoint.place?.id === 'current-location') {
-      const currentLocationName = t(
-        'directions.currentLocation',
-        'Current Location',
-      )
-      const inputText = inputTexts.value[index] || ''
-      return inputText === currentLocationName
-    }
-    return false
-  })
-})
+const currentLocationDisplay = computed(() =>
+  makePlaceDisplay({
+    title: t('directions.currentLocation', 'Current Location'),
+    icon: 'Locate',
+  }),
+)
+
+// Don't offer current location again while a field is already holding it.
+const isCurrentLocationUsed = computed(() =>
+  waypoints.value.some((_, index) => isCurrentLocationChip(index)),
+)
 
 // Create current location autocomplete result
 const createCurrentLocationResult = (): AutocompleteResult | null => {
@@ -449,7 +401,7 @@ function locateUser(index: number) {
   if (!isGeolocationSupported.value || !coords.value.latitude || !coords.value.longitude) return
   const result = createCurrentLocationResult()
   if (result) {
-    selectPlace(index, autocompleteResultToPlace(result), result)
+    selectPlace(index, autocompleteResultToPlace(result))
   }
 }
 
@@ -513,6 +465,19 @@ defineExpose({
                       </div>
                       <GripVerticalIcon class="size-4 text-muted-foreground absolute opacity-0 group-hover:opacity-100 transition-opacity" />
                     </div>
+                    <!-- Current location isn't typed text, so it sits in the
+                         field as a chip rather than as a value that looks
+                         editable. Typing replaces it; the caret is already
+                         waiting after it. -->
+                    <PlaceCard
+                      v-if="isCurrentLocationChip(index)"
+                      :display="currentLocationDisplay"
+                      variant="chip"
+                      size="xs"
+                      icon-variant="ghost"
+                      :navigate="false"
+                      class="shrink-0 -ml-0.5 pointer-events-none"
+                    />
                   </template>
                   <template #postfix>
                     <!-- Desktop: icon buttons hidden until row hover -->
@@ -615,32 +580,22 @@ defineExpose({
                   <ComboboxItem
                     v-for="result in combinedResults"
                     :key="result.id"
+                    class="p-0"
                     :value="autocompleteResultToPlace(result)"
-                    @select="selectPlace(index, autocompleteResultToPlace(result), result)"
+                    @select="selectPlace(index, autocompleteResultToPlace(result))"
                   >
-                    <div class="flex items-center gap-2 flex-1">
-                      <ItemIcon
-                        :icon="
-                          result.type === 'current_location'
-                            ? 'Locate'
-                            : result.type === 'bookmark'
-                              ? result.icon || 'MapPin'
-                              : 'MapPin'
-                        "
-                        :color="(result.color as ThemeColor) || 'parchment'"
-                        size="sm"
-                        class="size-4"
-                      />
-                      <div class="flex flex-col flex-1">
-                        <span>{{ result.title }}</span>
-                        <span v-if="result.description" class="text-sm text-muted-foreground">
-                          {{ result.description }}
-                        </span>
-                      </div>
-                    </div>
+                    <PlaceCard
+                      :display="autocompleteToDisplay(result, { isDark: themeStore.isDark })"
+                      variant="plain"
+                      size="sm"
+                      density="compact"
+                      icon-variant="ghost"
+                      :navigate="false"
+                      class="flex-1 min-w-0"
+                    />
 
                     <ComboboxItemIndicator>
-                      <Check :class="cn('ml-auto h-4 w-4')" />
+                      <Check :class="cn('mr-2 h-4 w-4')" />
                     </ComboboxItemIndicator>
                   </ComboboxItem>
                 </ComboboxGroup>


### PR DESCRIPTION
A directions stop is a place, and now looks like one everywhere it appears — with the metadata to back that up.

### One derivation, three surfaces
`waypointToDisplay` (in `lib/place-display.ts`) is the single answer to "what mark does this stop get": its own POI glyph, the locate mark for current location, or the pin for a plain point. The waypoint fields, the trip timeline and the map markers all read it. They used to each decide separately and drifted — a stop drawn as a restaurant on the map was a numbered disc in the input, and an uncoloured fallback pin came out cobalt in the timeline against a neutral plate on the map.

Numbered discs and the destination flag are gone. The origin keeps an open ring, since it's the one stop that isn't a place.

### Trip timeline
The stop's glyph **is** the rail node — drawing a dot on the rail *and* an icon beside it was two marks for one thing. Stops are plain rows (name, type, arrival time), no boxes: a muted card on a muted panel had no edge to see, and boxes fought the segments between them. Still `PlaceCard` (`plain`, no icon), so icon/type/colour/link derivation stays shared.

The hero is pinned via `SheetHeader`, same contract as the transit route detail.

### Map
Stops wear the place's own marker — same plate, glyph and ring as a search result — and carry the stop's name, lettered exactly as the map's own POI labels are: the icon's glyph colour on the basemap's `poi_halo`, Geist Medium at 13px, 1.1em below the icon's centre. `MARKER_HALO` moved out of `marker-paint.ts` so the DOM label and the style layer read one value.

### Metadata through the flow
- `autocompleteResultToPlace` no longer drops the row's resolved icon, icon pack, category or transit refs — and `WaypointInput`'s duplicate copy of it is gone.
- Waypoints hydrate in the background off a store watcher, so every path gets it — the picker, a map click, a shared link, the place page's Directions button.
- Shared links carry a `wpid` per waypoint, so a reload restores what each stop *is*, not just its label.
- `RouteWaypoint.place` is a declared field rather than an `as any` the client wrote in anyway.

### Touch targets
"Details · N steps", "N stops · 12m" and "Advanced" are full-width controls on the card surface — 36px on a mouse, 44px under `pointer-coarse`.

### Also
- `PlaceCard`/`ItemRow` gain a `plain` variant (no surface, for lists that draw their own structure) and a `title-trailing` slot.
- The waypoint picker's dropdown rows are `PlaceCard`s, so a maki glyph stays a maki glyph.
- Current location shows as a chip in the field rather than editable-looking text.
- `ElevationChart` gets `isolate` — its internal `z-20` badges were tying with the sticky header and painting over it.

Tests: added coverage for the `wpid` round-trip, `shareableWaypointId` and `autocompleteToDisplay`. `vue-tsc` clean, 2243 pass.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)