### PR TITLE
Transit off clears the map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Fixed
 
+* Switching the Transit layer off clears its lines and stations from the map,
+  and switching it back on draws them again without waiting for a pan
+
 ## [0.11.2] - 2026-09-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,12 @@
 - If a Linear ticket was linked for the relevant work, update the status of the ticket as work progresses.
 - Use `bun` over `npm` for package management.
 - Commit messages: short (5-20 words), distinct logical commits.
-- Keep code structure clean, modular, and dry. Use concise, straightforward naming conventions and move code to appropriate modules when it isn't in the correct place. Add comments ONLY when the code is not intuitive at a glance or to convey important context/information. Do not write paragraphs of comments explaning each iterative change.
+- Keep code structure clean, modular, and dry. Use concise, straightforward naming conventions and move code to appropriate modules when it isn't in the correct place.
+- Comments are a last resort, not a deliverable. Default to none: clear names and small functions carry the meaning. Write one only when the code cannot say it itself — a non-obvious constraint, a gotcha in an external API, a why that the how doesn't show.
+  - Hard cap: one or two lines. If it needs a paragraph, the code needs the work instead.
+  - Never narrate the change: no "used to be X", no bug history, no explaining the fix to a reviewer. That belongs in the commit message and the PR body, which are the durable record. A comment that only makes sense next to the diff is dead the moment the diff lands.
+  - Never restate the code, the test name, or the function name in prose.
+  - Do not match the comment density of a heavily-commented file. Some existing files over-comment; that is not the standard to copy.
 - "Modules" represent all code components for a single entity. Users, directions, search, settings, etc are all modules. These module identities are represented throught the codebase and should contain related UI, data, and business logic for that entity. Make sure to keep new and old code nicely modularized.
 - Offer to refactor malformed code when we come across any. This is anything that doesn't follow our normal conventions or industry practices.
 - When we add new features, integrations, modules, etc, update the relevant documentation in the sibiling `parchment-docs` repo.

--- a/web/src/services/layers/features/portolan/portolan-transit.service.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.test.ts
@@ -1,13 +1,7 @@
 /**
- * Switching the Transit group off has to take the network off the map, and
- * switching it back on has to put it there again.
- *
- * Both halves used to hang on one misreading of `isStyleLoaded()`, which is
- * a claim about every source cache in the style and so reads false whenever
- * any one of ninety pyramids has a tile in flight — which is exactly the
- * moment a rider touches the switch. Teardown skipped its removal and left
- * the whole network painted; the rebuild deferred itself to an `idle` event
- * that a map with nothing left to draw never fires.
+ * Switching the Transit group off takes the network off the map, and
+ * switching it back on puts it there again — both while isStyleLoaded() is
+ * false, which it is whenever any pyramid has a tile in flight.
  */
 
 import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
@@ -37,8 +31,8 @@ function fakeMap(opts: { styleLoaded?: boolean } = {}) {
   return {
     style: {},
     isStyleLoaded: () => opts.styleLoaded ?? false,
-    // Both engines serialize on getStyle(); copies, or removal would be
-    // walking the array it is splicing.
+    // Both engines serialize on getStyle(); copies, or removal walks the
+    // array it is splicing.
     getStyle: () => ({ layers: [...layers], sources: { ...sources } }),
     getLayer: (id: string) => layers.find(l => l.id === id),
     getSource: (id: string) => sources[id],
@@ -71,7 +65,7 @@ const portolanIds = (map: ReturnType<typeof fakeMap>) => ({
 
 describe('portolan teardown', () => {
   beforeEach(() => {
-    // The dev flag is the enablement path that needs no pinia.
+    // The enablement path that needs no pinia.
     localStorage.setItem(FLAG_KEY, '1')
     vi.stubGlobal(
       'fetch',
@@ -125,8 +119,7 @@ describe('portolan rebuild', () => {
   })
 
   test('retries a style that could not take layers instead of waiting for an idle', async () => {
-    // The feed index is probed once per module instance, so this test takes
-    // its own copy of the service rather than inheriting a cached empty one.
+    // The feed index is probed once per module instance — take a fresh one.
     vi.resetModules()
     localStorage.setItem(FLAG_KEY, '1')
     vi.stubGlobal(
@@ -143,7 +136,7 @@ describe('portolan rebuild', () => {
       './portolan-transit.service'
     )
 
-    // A style still being parsed: no layers, so nothing to insert beneath.
+    // Still being parsed: no layers, so nothing to insert beneath.
     const unparsed = { ...fakeMap(), getStyle: vi.fn(() => ({ layers: [], sources: {} })) }
     const service = freshService()
     service.initializePortolanTransit(strategyFor(unparsed))

--- a/web/src/services/layers/features/portolan/portolan-transit.service.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.test.ts
@@ -115,3 +115,45 @@ describe('portolan teardown', () => {
     expect(() => service.teardownPortolanTransit()).not.toThrow()
   })
 })
+
+describe('portolan rebuild', () => {
+  const sleep = (ms: number) => new Promise(r => setTimeout(r, ms))
+
+  afterEach(() => {
+    localStorage.removeItem(FLAG_KEY)
+    vi.unstubAllGlobals()
+  })
+
+  test('retries a style that could not take layers instead of waiting for an idle', async () => {
+    // The feed index is probed once per module instance, so this test takes
+    // its own copy of the service rather than inheriting a cached empty one.
+    vi.resetModules()
+    localStorage.setItem(FLAG_KEY, '1')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() =>
+        Promise.resolve({
+          ok: true,
+          json: () =>
+            Promise.resolve([{ feed: 'nyc', bounds: [-74.3, 40.5, -73.6, 41], maxzoom: 16 }]),
+        }),
+      ),
+    )
+    const { usePortolanTransitService: freshService } = await import(
+      './portolan-transit.service'
+    )
+
+    // A style still being parsed: no layers, so nothing to insert beneath.
+    const unparsed = { ...fakeMap(), getStyle: vi.fn(() => ({ layers: [], sources: {} })) }
+    const service = freshService()
+    service.initializePortolanTransit(strategyFor(unparsed))
+    await sleep(50)
+
+    expect(unparsed.once).not.toHaveBeenCalled()
+    const firstLook = unparsed.getStyle.mock.calls.length
+    await sleep(400)
+    expect(unparsed.getStyle.mock.calls.length).toBeGreaterThan(firstLook)
+
+    service.teardownPortolanTransit()
+  })
+})

--- a/web/src/services/layers/features/portolan/portolan-transit.service.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Switching the Transit group off has to take the network off the map, and
+ * switching it back on has to put it there again.
+ *
+ * Both halves used to hang on one misreading of `isStyleLoaded()`, which is
+ * a claim about every source cache in the style and so reads false whenever
+ * any one of ninety pyramids has a tile in flight — which is exactly the
+ * moment a rider touches the switch. Teardown skipped its removal and left
+ * the whole network painted; the rebuild deferred itself to an `idle` event
+ * that a map with nothing left to draw never fires.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('maplibre-gl', () => ({ getVersion: () => '6.4.1-transit.3' }))
+vi.mock('@/router', () => ({ default: {}, AppRoute: {} }))
+vi.mock('@/lib/api', () => ({ api: { defaults: { baseURL: 'http://test' } } }))
+
+import { usePortolanTransitService } from './portolan-transit.service'
+import { MapEngine, MapTheme } from '@/types/map.types'
+
+const FLAG_KEY = 'parchment.portolan-transit'
+
+/** A map whose style already carries a built portolan network. */
+function fakeMap(opts: { styleLoaded?: boolean } = {}) {
+  const layers = [
+    { id: 'background' },
+    { id: 'road-label' },
+    { id: 'portolan-ribbon-1-steady-nyc' },
+    { id: 'portolan-station-markers' },
+  ]
+  const sources: Record<string, unknown> = {
+    basemap: {},
+    'portolan-tiles-nyc': {},
+    'portolan-stations': {},
+  }
+  return {
+    style: {},
+    isStyleLoaded: () => opts.styleLoaded ?? false,
+    // Both engines serialize on getStyle(); copies, or removal would be
+    // walking the array it is splicing.
+    getStyle: () => ({ layers: [...layers], sources: { ...sources } }),
+    getLayer: (id: string) => layers.find(l => l.id === id),
+    getSource: (id: string) => sources[id],
+    removeLayer: (id: string) => {
+      const i = layers.findIndex(l => l.id === id)
+      if (i >= 0) layers.splice(i, 1)
+    },
+    removeSource: (id: string) => {
+      delete sources[id]
+    },
+    on: () => {},
+    off: () => {},
+    once: vi.fn(),
+    layers,
+    sources,
+  }
+}
+
+function strategyFor(map: unknown) {
+  return {
+    mapInstance: map,
+    options: { engine: MapEngine.MAPLIBRE, theme: MapTheme.LIGHT },
+  } as any
+}
+
+const portolanIds = (map: ReturnType<typeof fakeMap>) => ({
+  layers: map.layers.filter(l => l.id.startsWith('portolan-')).map(l => l.id),
+  sources: Object.keys(map.sources).filter(s => s.startsWith('portolan-')),
+})
+
+describe('portolan teardown', () => {
+  beforeEach(() => {
+    // The dev flag is the enablement path that needs no pinia.
+    localStorage.setItem(FLAG_KEY, '1')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve([]) })),
+    )
+  })
+
+  afterEach(() => {
+    localStorage.removeItem(FLAG_KEY)
+    vi.unstubAllGlobals()
+  })
+
+  test('removes every portolan layer and source while tiles are still in flight', () => {
+    const service = usePortolanTransitService()
+    const map = fakeMap({ styleLoaded: false })
+
+    service.initializePortolanTransit(strategyFor(map))
+    expect(portolanIds(map).layers.length).toBeGreaterThan(0)
+
+    service.teardownPortolanTransit()
+
+    expect(portolanIds(map)).toEqual({ layers: [], sources: [] })
+  })
+
+  test('leaves the basemap alone', () => {
+    const service = usePortolanTransitService()
+    const map = fakeMap({ styleLoaded: true })
+
+    service.initializePortolanTransit(strategyFor(map))
+    service.teardownPortolanTransit()
+
+    expect(map.layers.map(l => l.id)).toEqual(['background', 'road-label'])
+    expect(Object.keys(map.sources)).toEqual(['basemap'])
+  })
+
+  test('is safe on a map with no style at all', () => {
+    const service = usePortolanTransitService()
+    const map = { ...fakeMap(), style: null }
+
+    service.initializePortolanTransit(strategyFor(map))
+    expect(() => service.teardownPortolanTransit()).not.toThrow()
+  })
+})

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -850,6 +850,7 @@ function stopBulletClock() {
 
 function teardownPortolanTransit() {
   stopBulletClock()
+  cancelResync()
   unbindListeners()
   // Removal must NOT wait on isStyleLoaded(): that is a claim about every
   // source cache in the style (see hydrationReady), and with one vector
@@ -1129,9 +1130,59 @@ function buildingLayer(): string | undefined {
 const OCCLUDED_OPACITY = 0.28
 const ghostId = (id: string) => `${id}-ghost`
 
-/** Guards the one deferred re-run sync() schedules when the style is still
- *  loading, so a burst of style.loads cannot stack listeners. */
-let resyncPending = false
+/**
+ * Can this style take layers yet?
+ *
+ * Not `isStyleLoaded()` — that is the whole-style claim hydrationReady
+ * explains away, false while any one of ninety pyramids has a tile in
+ * flight. Building only needs the style PARSED: addLayer throws before
+ * that, and the basemap layers a ribbon is inserted beneath (labels,
+ * buildings) have to be there to insert beneath. A non-empty layer list
+ * is exactly that, and it is public API — serialize() throws while the
+ * stylesheet is still being read, hence the catch.
+ */
+function styleReady(m: any): boolean {
+  try {
+    return !!m.getStyle()?.layers?.length
+  } catch {
+    return false
+  }
+}
+
+/** The one deferred re-run sync() schedules while the style is unusable. */
+let resyncTimer: ReturnType<typeof setTimeout> | null = null
+const RESYNC_MS = 250
+const RESYNC_TRIES = 40
+
+/**
+ * Re-run sync() once the style can take layers.
+ *
+ * The wait used to be `once('idle')`, and an idle is owed to no one: a
+ * map that has already settled — the ordinary case a moment after the
+ * Transit group is switched back on — never fires another one, so the
+ * rebuild never ran and the network stayed dark until the rider panned.
+ * Worse, the guard flag it set was cleared only by that same handler, so
+ * one missed idle latched the feature off for the rest of the session.
+ * Polling briefly cannot miss an edge, and moveend/style.load remain the
+ * long-stop if the style is still unusable when the tries run out.
+ */
+function scheduleResync(m: any) {
+  if (resyncTimer) return
+  let tries = 0
+  const tick = () => {
+    resyncTimer = null
+    if (map !== m) return
+    if (styleReady(m)) return void sync()
+    if (++tries > RESYNC_TRIES) return
+    resyncTimer = setTimeout(tick, RESYNC_MS)
+  }
+  resyncTimer = setTimeout(tick, RESYNC_MS)
+}
+
+function cancelResync() {
+  if (resyncTimer) clearTimeout(resyncTimer)
+  resyncTimer = null
+}
 
 async function sync() {
   const m = map
@@ -1141,17 +1192,10 @@ async function sync() {
   // Those awaits take longer than the style does to load on a cold cache:
   // the index plus one manifest per pyramid, ~90 requests before the first
   // ribbon. Waiting on "the next style.load" is not enough — on a first
-  // paint there isn't one, and the whole feature stayed invisible until
-  // something else happened to reload the style. Finish the job ourselves
-  // when the map next goes idle.
-  if (!m.isStyleLoaded()) {
-    if (!resyncPending) {
-      resyncPending = true
-      m.once('idle', () => {
-        resyncPending = false
-        if (map === m) void sync()
-      })
-    }
+  // paint there isn't one — so finish the job ourselves once the style is
+  // parsed enough to take the layers.
+  if (!styleReady(m)) {
+    scheduleResync(m)
     return
   }
   addSourcesAndLayers(regions)

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -852,12 +852,7 @@ function teardownPortolanTransit() {
   stopBulletClock()
   cancelResync()
   unbindListeners()
-  // Removal must NOT wait on isStyleLoaded(): that is a claim about every
-  // source cache in the style (see hydrationReady), and with one vector
-  // source per pyramid it reads false whenever a tile is in flight — which
-  // is precisely the moment someone switches the group off. Gating on it
-  // left the whole network painted, and `map = null` below meant nothing
-  // could ever come back for it.
+  // Not gated on isStyleLoaded() — see styleReady.
   if (map?.style) removeAll()
   map = null
   isolatedRoute = null
@@ -1131,15 +1126,10 @@ const OCCLUDED_OPACITY = 0.28
 const ghostId = (id: string) => `${id}-ghost`
 
 /**
- * Can this style take layers yet?
- *
- * Not `isStyleLoaded()` — that is the whole-style claim hydrationReady
- * explains away, false while any one of ninety pyramids has a tile in
- * flight. Building only needs the style PARSED: addLayer throws before
- * that, and the basemap layers a ribbon is inserted beneath (labels,
- * buildings) have to be there to insert beneath. A non-empty layer list
- * is exactly that, and it is public API — serialize() throws while the
- * stylesheet is still being read, hence the catch.
+ * Can this style take layers yet? Parsed, not fully fetched: that is all
+ * addLayer and the label/building anchors need, and isStyleLoaded() is
+ * false while any one pyramid has a tile in flight (see hydrationReady).
+ * serialize() throws before the stylesheet is read, hence the catch.
  */
 function styleReady(m: any): boolean {
   try {
@@ -1154,18 +1144,9 @@ let resyncTimer: ReturnType<typeof setTimeout> | null = null
 const RESYNC_MS = 250
 const RESYNC_TRIES = 40
 
-/**
- * Re-run sync() once the style can take layers.
- *
- * The wait used to be `once('idle')`, and an idle is owed to no one: a
- * map that has already settled — the ordinary case a moment after the
- * Transit group is switched back on — never fires another one, so the
- * rebuild never ran and the network stayed dark until the rider panned.
- * Worse, the guard flag it set was cleared only by that same handler, so
- * one missed idle latched the feature off for the rest of the session.
- * Polling briefly cannot miss an edge, and moveend/style.load remain the
- * long-stop if the style is still unusable when the tries run out.
- */
+/** Re-run sync() once the style can take layers. Polls rather than waiting
+ *  on 'idle', which a map that has already settled never fires again;
+ *  moveend and style.load are the long-stop once the tries run out. */
 function scheduleResync(m: any) {
   if (resyncTimer) return
   let tries = 0
@@ -1189,11 +1170,8 @@ async function sync() {
   if (!m) return
   const regions = await ensureRegions()
   if (!regions.length || map !== m) return
-  // Those awaits take longer than the style does to load on a cold cache:
-  // the index plus one manifest per pyramid, ~90 requests before the first
-  // ribbon. Waiting on "the next style.load" is not enough — on a first
-  // paint there isn't one — so finish the job ourselves once the style is
-  // parsed enough to take the layers.
+  // Those awaits outlast the style on a cold cache — ~90 requests before the
+  // first ribbon — and a first paint has no style.load left to wait for.
   if (!styleReady(m)) {
     scheduleResync(m)
     return

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -851,7 +851,13 @@ function stopBulletClock() {
 function teardownPortolanTransit() {
   stopBulletClock()
   unbindListeners()
-  if (map?.style && map.isStyleLoaded()) removeAll()
+  // Removal must NOT wait on isStyleLoaded(): that is a claim about every
+  // source cache in the style (see hydrationReady), and with one vector
+  // source per pyramid it reads false whenever a tile is in flight — which
+  // is precisely the moment someone switches the group off. Gating on it
+  // left the whole network painted, and `map = null` below meant nothing
+  // could ever come back for it.
+  if (map?.style) removeAll()
   map = null
   isolatedRoute = null
   clearHydration()


### PR DESCRIPTION
Switching the Transit layer group off left the whole network painted — every
ribbon, station and label stayed on the map while the switch, the class
toggles and the service-time control all read "off".

## What was wrong

Two bugs, both from reading `isStyleLoaded()` as "the style is usable". It is
not: it is a claim about *every* source cache in the style, and portolan
installs one vector source per pyramid (90 of them), so it reads false
whenever a single tile is in flight — which is exactly the moment someone
touches the switch. The file already documents this trap for hydration
(`hydrationReady`); these two call sites had not learned it.

1. **Teardown skipped its removal.** `teardownPortolanTransit` only called
   `removeAll()` `if (map.isStyleLoaded())`, then set `map = null` — so when
   the guard was false the layers stayed and nothing was left that could come
   back for them. Instrumented in the running app: at the moment of the
   toggle the guard read `false`, `removeLayer` was called 0 times, and all
   99 portolan layers remained.

2. **The rebuild waited for an `idle` that never came.** `sync()` deferred its
   build to `map.once('idle')` when the style was "not loaded". A map that has
   already settled never fires another idle, so switching the group back on
   drew nothing until the rider happened to pan — and the guard flag that
   deferral set was cleared only by that same handler, so one missed idle
   latched the feature off for the rest of the session. This was invisible
   before, because the layers were never removed in the first place.

## The fix

* Teardown removes unconditionally (`removeAll` keeps its own no-style guard).
* Building gates on `styleReady()` — the style *parsed*, which is all
  `addLayer` needs and all that the label/building anchors need — instead of
  fully fetched, and retries on a short bounded timer rather than an event
  that may never arrive.

## Verified

In the running app, driving the group toggle and counting portolan layers and
sources on the style:

| | before fix | after fix |
|---|---|---|
| toggle on | 99 layers / 9 sources | 111 layers / 10 sources |
| toggle off | **99 layers / 9 sources** | **0 / 0** |
| toggle on again | (never removed) | full network back, no pan needed |

Three consecutive cycles on `dev` and two on this preview, clean each time.

New unit tests cover both: they fail against the old service (removal skipped,
`once('idle')` parked) and pass against the new one. Full suite: 2238 passing,
`vue-tsc` clean.