### PR TITLE
Fix layer sheet padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
   first only wiped the route off the map
 * Switching the Transit layer off clears its lines and stations from the map,
   and switching it back on draws them again without waiting for a pan
+* The layer picker's tabs sit just under the drag handle on mobile, instead of
+  a band of empty space above them
 
 ## [0.11.2] - 2026-09-07
 

--- a/web/src/components/map/controls/LayerControl.vue
+++ b/web/src/components/map/controls/LayerControl.vue
@@ -13,7 +13,7 @@ import ResponsiveHoverCard from '@/components/responsive/ResponsiveHoverCard.vue
     align="end"
     :side-offset="12"
     desktop-content-class="w-[380px] max-w-[calc(100vw-3.75rem)] max-h-[min(460px,calc(100vh-10rem))] overflow-y-auto rounded-md p-0 shadow-xl"
-    mobile-content-class="p-0 pt-11"
+    mobile-content-class="p-0"
     :custom-snap-points="['400px', 1]"
     dynamic-peek
   >


### PR DESCRIPTION
## What

The mobile layer picker opened with ~88px of dead space above its tab row.

## Why

The dock offset was applied twice. `358304cc` pinned the tab row with `SheetHeader` and put `pt-11` (2.75rem) on the sheet's content wrapper to clear the drag handle. Then `1cf75f62` ("Start sheet layouts on the pinned header's dock line") added `pt-[var(--sheet-sticky-top,0px)]` to `LayersSelector`'s root — the same 2.75rem, since a mounted `SheetHeader` is what sets `--sheet-sticky-top` to `2.75rem` in the first place. Nothing removed the older `pt-11`.

Shipped in v0.11.0.

## The change

`LayerControl.vue`: `mobile-content-class="p-0 pt-11"` → `"p-0"`.

The selector now owns its own dock offset, which is the point of the variable: it resolves to 0 in the desktop hover card and to the chrome bar height inside the sheet.

## Verified

On the slot-2 preview at iPhone 12 Pro width, the tab row sits 55px below the sheet top (44px chrome bar + the header's own 10px padding), down from 99px. The content wrapper reports `padding-top: 0px`, with the selector root supplying a single 44px.