### PR TITLE
Controls ride the sheet

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,9 @@
 
 ### Fixed
 
+* On mobile, the layer and locate buttons stay reachable when a sheet is open —
+  they ride its top edge instead of hiding behind it
+
 * A shared directions link keeps what each stop actually is. Reloading one
   used to leave every stop as a bare name
 * Escape closes a trip's details on the first press. It used to take two — the

--- a/web/src/views/Map.vue
+++ b/web/src/views/Map.vue
@@ -208,6 +208,30 @@ const streetPeekStyle = computed<CSSProperties>(() => {
   const bottom = Math.max(PEEK_INSET, window.innerHeight - sheetTop + PEEK_INSET)
   return { position: 'fixed', left: `${PEEK_INSET}px`, bottom: `${bottom}px` }
 })
+// Keep the bottom-right controls reachable while the mobile sheet is up:
+// ride its top edge (live bounds update each frame during drags), and once
+// the sheet covers most of the screen fade them out — the map is hidden, so
+// stacking them mid-screen would only add noise.
+const mapFabsHidden = computed(() => {
+  if (!isMobileScreen.value) return false
+  const sheet = appStore.componentDimensions.get('map-content-sheet')
+  if (!sheet) return false
+  return window.innerHeight - sheet.y > window.innerHeight * 0.7
+})
+
+// 4.5rem = the cluster's resting offset (overlay p-2 + mb-16); min() keeps
+// the transform from pushing the buttons down when the sheet sits below it.
+const mapFabsLiftStyle = computed<CSSProperties>(() => {
+  if (!isMobileScreen.value) return {}
+  const sheet = appStore.componentDimensions.get('map-content-sheet')
+  if (!sheet) return {}
+  const visible = Math.round(window.innerHeight - sheet.y)
+  if (visible <= 0) return {}
+  return {
+    transform: `translateY(min(0px, calc(4.5rem + env(safe-area-inset-bottom) - ${visible + PEEK_INSET}px)))`,
+  }
+})
+
 // Canvases the user has switched on render over the basemap for as long as
 // they are on. Which ones those are comes from the layer store's projection
 // rather than straight off the canvases store, so the "Canvases" group's
@@ -552,8 +576,14 @@ defineExpose({
 
               <!-- Right bottom -->
               <div
-                class="pointer-events-auto flex flex-col gap-2"
-                :class="{ 'mb-16': isMobileScreen }"
+                class="flex flex-col gap-2 transition-opacity duration-200"
+                :class="[
+                  isMobileScreen && 'mb-16',
+                  mapFabsHidden
+                    ? 'opacity-0 pointer-events-none'
+                    : 'pointer-events-auto',
+                ]"
+                :style="mapFabsLiftStyle"
               >
                 <StreetViewControl />
                 <LayerControl />


### PR DESCRIPTION
## What

On mobile, the bottom-right map controls (street view, layers, locate) were covered whenever a bottom sheet was open — searching the map meant losing the geolocate button entirely.

## The change

The control cluster in `Map.vue` now reads the sheet's live bounds (the same `map-content-sheet` entry the street-imagery peek uses) and translates up to sit 8px above the sheet's top edge. The bounds publish every frame during drags, so the buttons track the sheet in real time. Once the sheet covers more than 70% of the screen the map is effectively hidden, so the cluster fades out and stops accepting taps.

Desktop is untouched; with no sheet open the buttons sit exactly where they did before.

## Verified

On the slot-1 preview at iPhone 12 Pro size (390×844):

- Search results sheet at half height (top y=422): buttons lift to y=266–414, bottom edge 8px above the sheet, and an `elementFromPoint` hit test on the locate button resolves to the button.
- Sheet dragged to full height: the cluster's opacity settles at 0 with `pointer-events: none`.
- Sheet closed: buttons back at their resting spot (y=624–772) with no inline styles left over.