### PR TITLE
Fix mobile POI gesture handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,9 @@
 
 ### Fixed
 
-* One-finger double-tap zoom no longer opens a place underneath the gesture,
-  and points of interest stay inactive throughout canvas editing
+* One-finger double-tap-and-drag zoom no longer opens a place or jumps an
+  extra level when released, and points of interest stay inactive throughout
+  canvas editing
 
 ## [0.11.3] - 2026-09-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 
 ### Fixed
 
+* One-finger double-tap zoom no longer opens a place underneath the gesture,
+  and points of interest stay inactive throughout canvas editing
+
 ## [0.11.3] - 2026-09-08
 
 ### Added

--- a/web/src/components/map/map-providers/map.strategy.test.ts
+++ b/web/src/components/map/map-providers/map.strategy.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it, vi } from 'vitest'
+import { MapStrategy } from './map.strategy'
+
+class TestMapStrategy extends MapStrategy {
+  setup(map: unknown) {
+    this.mapInstance = map
+    this.setupPoiClickHandling()
+  }
+
+  teardown() {
+    this.destroyPoiClickHandling()
+  }
+}
+
+function setup() {
+  const element = document.createElement('div')
+  const listeners = new Map<string, (event: unknown) => void>()
+  let enabled = true
+  const doubleClickZoom = {
+    disable: vi.fn(() => {
+      enabled = false
+    }),
+    enable: vi.fn(() => {
+      enabled = true
+    }),
+    isEnabled: vi.fn(() => enabled),
+  }
+  const map = {
+    doubleClickZoom,
+    getCanvasContainer: () => element,
+    on: vi.fn((name: string, listener: (event: unknown) => void) => {
+      listeners.set(name, listener)
+    }),
+    off: vi.fn((name: string, listener: (event: unknown) => void) => {
+      if (listeners.get(name) === listener) listeners.delete(name)
+    }),
+  }
+  const strategy = new TestMapStrategy(element, {} as never)
+  strategy.setup(map)
+
+  return { doubleClickZoom, listeners, map, strategy }
+}
+
+describe('MapStrategy touch zoom handling', () => {
+  it('resets double-tap zoom when one-finger drag zoom starts', () => {
+    const { doubleClickZoom, listeners, strategy } = setup()
+
+    listeners.get('zoomstart')?.({
+      originalEvent: { type: 'touchmove', touches: { length: 1 } },
+    })
+
+    expect(doubleClickZoom.disable).toHaveBeenCalledOnce()
+    expect(doubleClickZoom.enable).toHaveBeenCalledOnce()
+    strategy.teardown()
+  })
+
+  it('preserves ordinary double-tap and multi-touch zoom', () => {
+    const { doubleClickZoom, listeners, strategy } = setup()
+    const zoomStart = listeners.get('zoomstart')
+
+    zoomStart?.({
+      originalEvent: { type: 'touchend', touches: { length: 0 } },
+    })
+    zoomStart?.({
+      originalEvent: { type: 'touchmove', touches: { length: 2 } },
+    })
+
+    expect(doubleClickZoom.disable).not.toHaveBeenCalled()
+    expect(doubleClickZoom.enable).not.toHaveBeenCalled()
+    strategy.teardown()
+  })
+
+  it('does not enable double-tap zoom when it was disabled', () => {
+    const { doubleClickZoom, listeners, strategy } = setup()
+    doubleClickZoom.disable()
+    doubleClickZoom.disable.mockClear()
+
+    listeners.get('zoomstart')?.({
+      originalEvent: { type: 'touchmove', touches: { length: 1 } },
+    })
+
+    expect(doubleClickZoom.disable).not.toHaveBeenCalled()
+    expect(doubleClickZoom.enable).not.toHaveBeenCalled()
+    strategy.teardown()
+  })
+
+  it('detaches the zoom listener during teardown', () => {
+    const { listeners, map, strategy } = setup()
+
+    strategy.teardown()
+
+    expect(map.off).toHaveBeenCalledWith('zoomstart', expect.any(Function))
+    expect(listeners.has('zoomstart')).toBe(false)
+  })
+})

--- a/web/src/components/map/map-providers/map.strategy.ts
+++ b/web/src/components/map/map-providers/map.strategy.ts
@@ -16,6 +16,11 @@ import { Component } from 'vue'
 import { destroyVueMarkerElement } from '@/lib/vue-marker.utils'
 import { mapEventBus } from '@/lib/eventBus'
 import { impactFeedback } from '@tauri-apps/plugin-haptics'
+import {
+  mapPoiClickPolicy,
+  PoiTapController,
+  type PoiPointerEvent,
+} from '@/lib/map-poi-interaction'
 
 export class MapStrategy {
   mapInstance: any
@@ -25,6 +30,8 @@ export class MapStrategy {
   markers: Map<string, any> = new Map() // Track active markers
   protected longPressTimer: ReturnType<typeof setTimeout> | null = null
   protected touchStartPoint: { x: number; y: number } | null = null
+  protected clickDebounceTimer: number | null = null
+  private poiTapController: PoiTapController | null = null
 
   constructor(container, options: MapSettings, accessToken?: string) {
     this.container = container
@@ -112,6 +119,45 @@ export class MapStrategy {
     canvas.addEventListener('touchmove', handleTouchMove)
     canvas.addEventListener('touchend', handleTouchEnd)
     canvas.addEventListener('touchcancel', handleTouchEnd)
+  }
+
+  /** Attach the shared single/double/drag tap recognizer after map creation. */
+  protected setupPoiClickHandling() {
+    this.poiTapController?.destroy()
+    const element = this.mapInstance.getCanvasContainer?.()
+      ?? this.mapInstance.getCanvas()
+    this.poiTapController = new PoiTapController(element)
+  }
+
+  /**
+   * Run a place-like map action through the shared policy and tap recognizer.
+   * False leaves the generic map click available to a drawing/capture tool.
+   */
+  dispatchPoiClick(
+    event: PoiPointerEvent,
+    action: () => void,
+    prefetch?: () => void,
+  ) {
+    if (!mapPoiClickPolicy.enabled) return false
+    if (!this.poiTapController) {
+      action()
+      this.cancelPendingMapClick()
+      return true
+    }
+    const accepted = this.poiTapController.handle(event, action, prefetch)
+    if (accepted) this.cancelPendingMapClick()
+    return accepted
+  }
+
+  protected destroyPoiClickHandling() {
+    this.cancelPendingMapClick()
+    this.poiTapController?.destroy()
+    this.poiTapController = null
+  }
+
+  private cancelPendingMapClick() {
+    if (this.clickDebounceTimer) clearTimeout(this.clickDebounceTimer)
+    this.clickDebounceTimer = null
   }
 
   resize() {}

--- a/web/src/components/map/map-providers/map.strategy.ts
+++ b/web/src/components/map/map-providers/map.strategy.ts
@@ -32,6 +32,20 @@ export class MapStrategy {
   protected touchStartPoint: { x: number; y: number } | null = null
   protected clickDebounceTimer: number | null = null
   private poiTapController: PoiTapController | null = null
+  private cancelPendingDoubleTapZoom = (event: {
+    originalEvent?: { type?: string; touches?: { length: number } }
+  }) => {
+    const touchEvent = event.originalEvent
+    if (touchEvent?.type !== 'touchmove' || touchEvent.touches?.length !== 1) {
+      return
+    }
+
+    const doubleClickZoom = this.mapInstance?.doubleClickZoom
+    if (!doubleClickZoom?.isEnabled?.()) return
+
+    doubleClickZoom.disable()
+    doubleClickZoom.enable()
+  }
 
   constructor(container, options: MapSettings, accessToken?: string) {
     this.container = container
@@ -124,9 +138,11 @@ export class MapStrategy {
   /** Attach the shared single/double/drag tap recognizer after map creation. */
   protected setupPoiClickHandling() {
     this.poiTapController?.destroy()
+    this.mapInstance.off?.('zoomstart', this.cancelPendingDoubleTapZoom)
     const element = this.mapInstance.getCanvasContainer?.()
       ?? this.mapInstance.getCanvas()
     this.poiTapController = new PoiTapController(element)
+    this.mapInstance.on?.('zoomstart', this.cancelPendingDoubleTapZoom)
   }
 
   /**
@@ -151,6 +167,7 @@ export class MapStrategy {
 
   protected destroyPoiClickHandling() {
     this.cancelPendingMapClick()
+    this.mapInstance?.off?.('zoomstart', this.cancelPendingDoubleTapZoom)
     this.poiTapController?.destroy()
     this.poiTapController = null
   }

--- a/web/src/components/map/map-providers/mapbox.strategy.ts
+++ b/web/src/components/map/map-providers/mapbox.strategy.ts
@@ -56,6 +56,7 @@ import { calculateFitPadding, toContainerRect } from '@/lib/map-padding'
 import { useThemeStore } from '@/stores/theme.store'
 import { useMapToolsStore } from '@/stores/map-tools.store'
 import { getPrimaryThemeHex, adjustLightness, cssHslToHex } from '@/lib/utils'
+import { mapPoiClickPolicy } from '@/lib/map-poi-interaction'
 
 /**
  * The zoom at which the globe has finished becoming a flat map.
@@ -141,7 +142,6 @@ export class MapboxStrategy extends MapStrategy {
   mapInstance: MapboxMap
   private streetViewLayerIds: Set<string> = new Set()
   private unwatchTheme?: () => void
-  private clickDebounceTimer: number | null = null
   layerGroups: Map<string, MapLayerGroup> = new Map()
   private currentLanguage?: string
   private hdRoadsEnabled: boolean = false
@@ -193,6 +193,7 @@ export class MapboxStrategy extends MapStrategy {
     // makes every rendering question a guess instead of a check.
     if (import.meta.env.DEV) (window as any).__parchmentMap = this.mapInstance
 
+    this.setupPoiClickHandling()
     this.addControls()
     this.configureEventListeners()
 
@@ -279,10 +280,14 @@ export class MapboxStrategy extends MapStrategy {
     // Touch-and-hold for mobile context menu
     this.setupLongPressHandler()
     this.mapInstance.on('click', 'mapillary-image', e => {
-      mapEventBus.emit('click:mapillary-image', {
+      if (useMapToolsStore().rawClickCapture) return
+      const data = {
         lngLat: e.lngLat,
         point: e.point,
         image: (e.features?.[0]?.properties as MapillaryImage) || undefined,
+      }
+      this.dispatchPoiClick(e, () => {
+        mapEventBus.emit('click:mapillary-image', data)
       })
     })
     // Change pointers on hover
@@ -313,7 +318,10 @@ export class MapboxStrategy extends MapStrategy {
    * across a label, which is most of the time in a city.
    */
   private setHoverCursor(cursor: string) {
-    if (useMapToolsStore().rawClickCapture) return
+    if (
+      cursor
+      && (useMapToolsStore().rawClickCapture || !mapPoiClickPolicy.enabled)
+    ) return
     this.mapInstance.getCanvas().style.cursor = cursor
   }
 
@@ -351,20 +359,13 @@ export class MapboxStrategy extends MapStrategy {
         const center = e.feature.properties?.center
 
         if (poiType !== 'unknown') {
-          // Cancel the debounced regular click
-          if (this.clickDebounceTimer) {
-            clearTimeout(this.clickDebounceTimer)
-            this.clickDebounceTimer = null
-          }
-
           // For ways/relations, use center point if available
           const lngLat = center
             ? { lng: center[0], lat: center[1] }
             : { lng: coordinates[0], lat: coordinates[1] }
 
-          // Emit unified click event with POI data
           const poiName = e.feature.properties?.name
-          mapEventBus.emit('click', {
+          const data = {
             lngLat,
             point: e.point,
             poi: {
@@ -372,7 +373,12 @@ export class MapboxStrategy extends MapStrategy {
               poiType,
               name: typeof poiName === 'string' ? poiName : undefined,
             },
-          })
+          }
+          this.dispatchPoiClick(
+            e,
+            () => mapEventBus.emit('click', data),
+            () => mapEventBus.emit('poi:preview', { poi: data.poi }),
+          )
         }
       },
     })
@@ -868,6 +874,7 @@ export class MapboxStrategy extends MapStrategy {
   }
 
   destroy() {
+    this.destroyPoiClickHandling()
     // Clean up theme watcher
     if (this.unwatchTheme) {
       this.unwatchTheme()

--- a/web/src/components/map/map-providers/maplibre.strategy.ts
+++ b/web/src/components/map/map-providers/maplibre.strategy.ts
@@ -49,6 +49,7 @@ import { Directions, TripsResponse } from '@/types/directions.types'
 import { decodeShape } from '@/lib/utils'
 import { palette } from '@/lib/palette'
 import { mapEventBus } from '@/lib/eventBus'
+import { mapPoiClickPolicy } from '@/lib/map-poi-interaction'
 import {
   mapboxLayerToMaplibreLayer,
   parsePlanetilerOsmId,
@@ -248,7 +249,6 @@ export class MaplibreStrategy extends MapStrategy {
   private tileServerUrl?: string
   private tileKey?: string
   private currentBasemap: Basemap = 'standard'
-  private clickDebounceTimer: number | null = null
   private poiHandlerCleanup: (() => void) | null = null
   /** The two switches gating the building lighting; see `applyBuildingShade`. */
   private buildingShade = true
@@ -333,6 +333,7 @@ export class MaplibreStrategy extends MapStrategy {
     // the resolver survives a style swap and every flavor needs it.
     registerPoiBadges(this.mapInstance as unknown as BadgeHost)
 
+    this.setupPoiClickHandling()
     this.addControls()
     this.configureEventListeners()
 
@@ -475,18 +476,27 @@ export class MaplibreStrategy extends MapStrategy {
     // Touch-and-hold for mobile context menu
     this.setupLongPressHandler()
     this.mapInstance.on('click', 'mapillary-image', e => {
-      mapEventBus.emit('click:mapillary-image', {
+      if (useMapToolsStore().rawClickCapture) return
+      const data = {
         lngLat: e.lngLat,
         point: e.point,
         image: (e.features?.[0]?.properties as MapillaryImage) || undefined,
+      }
+      this.dispatchPoiClick(e, () => {
+        mapEventBus.emit('click:mapillary-image', data)
       })
     })
     // Change pointers on hover
     this.mapInstance.on('mouseenter', 'mapillary-image', () => {
-      this.mapInstance.getCanvas().style.cursor = 'pointer'
+      if (
+        !useMapToolsStore().rawClickCapture
+        && mapPoiClickPolicy.enabled
+      ) this.mapInstance.getCanvas().style.cursor = 'pointer'
     })
     this.mapInstance.on('mouseleave', 'mapillary-image', () => {
-      this.mapInstance.getCanvas().style.cursor = ''
+      if (!useMapToolsStore().rawClickCapture) {
+        this.mapInstance.getCanvas().style.cursor = ''
+      }
     })
   }
 
@@ -1344,6 +1354,7 @@ export class MaplibreStrategy extends MapStrategy {
 
   destroy() {
     try {
+      this.destroyPoiClickHandling()
       this.poiHandlerCleanup?.()
       this.poiHandlerCleanup = null
       this.unwatchTheme?.()
@@ -1567,13 +1578,20 @@ export class MaplibreStrategy extends MapStrategy {
     // sets its own for the whole map, and letting a POI hover flip it meant
     // the crosshair vanished whenever you crossed a label.
     const onEnter = () => {
-      if (hoverCount++ === 0 && !useMapToolsStore().rawClickCapture) {
+      if (
+        hoverCount++ === 0
+        && !useMapToolsStore().rawClickCapture
+        && mapPoiClickPolicy.enabled
+      ) {
         canvas.style.cursor = 'pointer'
       }
     }
     const onLeave = () => {
       hoverCount = Math.max(0, hoverCount - 1)
-      if (hoverCount === 0 && !useMapToolsStore().rawClickCapture) {
+      if (
+        hoverCount === 0
+        && !useMapToolsStore().rawClickCapture
+      ) {
         canvas.style.cursor = ''
       }
     }
@@ -1590,14 +1608,8 @@ export class MaplibreStrategy extends MapStrategy {
       const { osmId, poiType } = parsePlanetilerOsmId(feature.id)
       if (poiType === 'unknown') return
 
-      // Cancel the debounced generic click so we don't double-fire
-      if (this.clickDebounceTimer) {
-        clearTimeout(this.clickDebounceTimer)
-        this.clickDebounceTimer = null
-      }
-
       const poiName = feature.properties?.name
-      mapEventBus.emit('click', {
+      const data = {
         lngLat: layerEvent.lngLat,
         point: layerEvent.point,
         poi: {
@@ -1605,7 +1617,12 @@ export class MaplibreStrategy extends MapStrategy {
           poiType,
           name: typeof poiName === 'string' ? poiName : undefined,
         },
-      })
+      }
+      this.dispatchPoiClick(
+        layerEvent,
+        () => mapEventBus.emit('click', data),
+        () => mapEventBus.emit('poi:preview', { poi: data.poi }),
+      )
     }
 
     for (const id of allPoiLayerIds) {

--- a/web/src/composables/useMapPoiClickSuppression.ts
+++ b/web/src/composables/useMapPoiClickSuppression.ts
@@ -1,0 +1,23 @@
+import { onScopeDispose, toValue, watch, type MaybeRefOrGetter } from 'vue'
+import { mapPoiClickPolicy } from '@/lib/map-poi-interaction'
+
+/** Suppress place-like map actions for this component's lifetime. */
+export function useMapPoiClickSuppression(
+  suppressed: MaybeRefOrGetter<boolean> = true,
+) {
+  let release: (() => void) | null = null
+
+  const stop = watch(
+    () => toValue(suppressed),
+    value => {
+      release?.()
+      release = value ? mapPoiClickPolicy.suppress() : null
+    },
+    { immediate: true },
+  )
+
+  onScopeDispose(() => {
+    stop()
+    release?.()
+  })
+}

--- a/web/src/lib/map-poi-interaction.test.ts
+++ b/web/src/lib/map-poi-interaction.test.ts
@@ -1,0 +1,173 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  MapPoiClickPolicy,
+  POI_DOUBLE_TAP_MS,
+  PoiTapController,
+} from './map-poi-interaction'
+
+function touchEvent(
+  type: string,
+  timeStamp: number,
+  points: Array<{ x: number; y: number }>,
+) {
+  const event = new Event(type)
+  Object.defineProperties(event, {
+    timeStamp: { value: timeStamp },
+    touches: {
+      value: points.map((point, identifier) => ({
+        identifier,
+        clientX: point.x,
+        clientY: point.y,
+      })),
+    },
+  })
+  return event
+}
+
+function clickEvent(timeStamp: number) {
+  const event = new Event('click')
+  Object.defineProperties(event, {
+    timeStamp: { value: timeStamp },
+    sourceCapabilities: { value: { firesTouchEvents: true } },
+  })
+  return event
+}
+
+function tap(element: HTMLElement, start: number, x = 20, y = 30) {
+  element.dispatchEvent(touchEvent('touchstart', start, [{ x, y }]))
+  element.dispatchEvent(touchEvent('touchend', start + 20, []))
+}
+
+function setup() {
+  const element = document.createElement('div')
+  const policy = new MapPoiClickPolicy()
+  const controller = new PoiTapController(element, policy)
+  return { element, policy, controller }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('PoiTapController', () => {
+  it('keeps mouse POI clicks immediate', () => {
+    const { controller } = setup()
+    const action = vi.fn()
+    const prefetch = vi.fn()
+
+    controller.handle(
+      { point: { x: 20, y: 30 }, originalEvent: new Event('click') },
+      action,
+      prefetch,
+    )
+
+    expect(action).toHaveBeenCalledOnce()
+    expect(prefetch).not.toHaveBeenCalled()
+    controller.destroy()
+  })
+
+  it('prefetches on the first tap and commits after the gesture window', () => {
+    vi.useFakeTimers()
+    const { element, controller } = setup()
+    const action = vi.fn()
+    const prefetch = vi.fn()
+    tap(element, 0)
+
+    controller.handle(
+      { point: { x: 20, y: 30 }, originalEvent: clickEvent(21) },
+      action,
+      prefetch,
+    )
+
+    expect(prefetch).toHaveBeenCalledOnce()
+    expect(action).not.toHaveBeenCalled()
+    vi.advanceTimersByTime(POI_DOUBLE_TAP_MS)
+    expect(action).toHaveBeenCalledOnce()
+    controller.destroy()
+  })
+
+  it('cancels a POI action when a nearby second tap begins', () => {
+    vi.useFakeTimers()
+    const { element, controller } = setup()
+    const action = vi.fn()
+    tap(element, 0)
+    controller.handle(
+      { point: { x: 20, y: 30 }, originalEvent: clickEvent(21) },
+      action,
+    )
+
+    element.dispatchEvent(touchEvent('touchstart', 100, [{ x: 22, y: 29 }]))
+    element.dispatchEvent(touchEvent('touchend', 130, []))
+    controller.handle(
+      { point: { x: 22, y: 29 }, originalEvent: clickEvent(131) },
+      action,
+    )
+    vi.advanceTimersByTime(POI_DOUBLE_TAP_MS * 2)
+
+    expect(action).not.toHaveBeenCalled()
+    controller.destroy()
+  })
+
+  it('cancels a POI action for double-tap-and-drag zoom', () => {
+    vi.useFakeTimers()
+    const { element, controller } = setup()
+    const action = vi.fn()
+    tap(element, 0)
+    controller.handle(
+      { point: { x: 20, y: 30 }, originalEvent: clickEvent(21) },
+      action,
+    )
+
+    element.dispatchEvent(touchEvent('touchstart', 100, [{ x: 20, y: 30 }]))
+    element.dispatchEvent(touchEvent('touchmove', 120, [{ x: 20, y: 80 }]))
+    element.dispatchEvent(touchEvent('touchend', 160, []))
+    vi.advanceTimersByTime(POI_DOUBLE_TAP_MS * 2)
+
+    expect(action).not.toHaveBeenCalled()
+    controller.destroy()
+  })
+
+  it('leaves generic map handling available while POIs are suppressed', () => {
+    const { policy, controller } = setup()
+    const action = vi.fn()
+    const release = policy.suppress()
+
+    expect(controller.handle({ point: { x: 1, y: 1 } }, action)).toBe(false)
+    expect(action).not.toHaveBeenCalled()
+
+    release()
+    expect(controller.handle({ point: { x: 1, y: 1 } }, action)).toBe(true)
+    expect(action).toHaveBeenCalledOnce()
+    controller.destroy()
+  })
+
+  it('cancels a retained tap when a consumer suppresses POIs', () => {
+    vi.useFakeTimers()
+    const { element, policy, controller } = setup()
+    const action = vi.fn()
+    tap(element, 0)
+    controller.handle(
+      { point: { x: 20, y: 30 }, originalEvent: clickEvent(21) },
+      action,
+    )
+
+    policy.suppress()
+    vi.advanceTimersByTime(POI_DOUBLE_TAP_MS)
+
+    expect(action).not.toHaveBeenCalled()
+    controller.destroy()
+  })
+})
+
+describe('MapPoiClickPolicy', () => {
+  it('requires every nested consumer to release its suppression', () => {
+    const policy = new MapPoiClickPolicy()
+    const releaseEditor = policy.suppress()
+    const releaseTool = policy.suppress()
+
+    releaseEditor()
+    expect(policy.enabled).toBe(false)
+    releaseTool()
+    expect(policy.enabled).toBe(true)
+  })
+})

--- a/web/src/lib/map-poi-interaction.ts
+++ b/web/src/lib/map-poi-interaction.ts
@@ -1,0 +1,214 @@
+/** The gesture window Mapbox and MapLibre use for double-tap zoom. */
+export const POI_DOUBLE_TAP_MS = 500
+
+/** Both map engines require the two taps to land within 30px. */
+export const POI_DOUBLE_TAP_RADIUS_PX = 30
+
+type Point = { x: number; y: number }
+
+export type PoiPointerEvent = {
+  point: Point
+  originalEvent?: Event & {
+    sourceCapabilities?: { firesTouchEvents?: boolean } | null
+  }
+}
+
+type CompletedTouch = {
+  point: Point
+  time: number
+  suppress: boolean
+}
+
+function distance(a: Point, b: Point) {
+  return Math.hypot(a.x - b.x, a.y - b.y)
+}
+
+/**
+ * Reference-counted POI policy. Each consumer receives its own release
+ * function, so nested consumers cannot accidentally re-enable POI actions.
+ */
+export class MapPoiClickPolicy {
+  private blockers = new Set<symbol>()
+  private suppressListeners = new Set<() => void>()
+
+  get enabled() {
+    return this.blockers.size === 0
+  }
+
+  suppress() {
+    const token = Symbol('map-poi-click-suppression')
+    this.blockers.add(token)
+    this.suppressListeners.forEach(listener => listener())
+
+    let released = false
+    return () => {
+      if (released) return
+      released = true
+      this.blockers.delete(token)
+    }
+  }
+
+  onSuppress(listener: () => void) {
+    this.suppressListeners.add(listener)
+    return () => this.suppressListeners.delete(listener)
+  }
+}
+
+export const mapPoiClickPolicy = new MapPoiClickPolicy()
+
+/**
+ * Resolves native POI clicks into mouse clicks or single-finger taps.
+ * Browsers synthesize a click after the first touch ends. We retain that click
+ * for the engines' double-tap window and cancel it when a nearby second touch
+ * begins. Mouse clicks stay immediate.
+ */
+export class PoiTapController {
+  private currentTouch: {
+    point: Point
+    startedAt: number
+    moved: boolean
+    suppress: boolean
+  } | null = null
+  private lastTap: CompletedTouch | null = null
+  private completedTouch: CompletedTouch | null = null
+  private pendingAction: ReturnType<typeof setTimeout> | null = null
+  private handledEvents = new WeakSet<Event>()
+  private removeSuppressListener: () => void
+
+  constructor(
+    private element: HTMLElement,
+    private policy: MapPoiClickPolicy = mapPoiClickPolicy,
+  ) {
+    element.addEventListener('touchstart', this.onTouchStart, { passive: true })
+    element.addEventListener('touchmove', this.onTouchMove, { passive: true })
+    element.addEventListener('touchend', this.onTouchEnd, { passive: true })
+    element.addEventListener('touchcancel', this.onTouchCancel, { passive: true })
+    this.removeSuppressListener = policy.onSuppress(() => this.cancelPending())
+  }
+
+  handle(
+    event: PoiPointerEvent,
+    action: () => void,
+    prefetch?: () => void,
+  ): boolean {
+    if (!this.policy.enabled) {
+      this.cancelPending()
+      return false
+    }
+
+    const originalEvent = event.originalEvent
+    if (originalEvent && this.handledEvents.has(originalEvent)) return true
+
+    const touch = this.touchForClick(event)
+    if (!touch) {
+      action()
+      if (originalEvent) this.handledEvents.add(originalEvent)
+      return true
+    }
+
+    if (originalEvent) this.handledEvents.add(originalEvent)
+    if (touch.suppress) return true
+
+    prefetch?.()
+    this.cancelPending()
+    const elapsed = Math.max(
+      0,
+      (originalEvent?.timeStamp ?? touch.time) - touch.time,
+    )
+    this.pendingAction = setTimeout(() => {
+      this.pendingAction = null
+      if (this.policy.enabled) action()
+    }, Math.max(0, POI_DOUBLE_TAP_MS - elapsed))
+    return true
+  }
+
+  cancelPending() {
+    if (this.pendingAction) clearTimeout(this.pendingAction)
+    this.pendingAction = null
+  }
+
+  destroy() {
+    this.cancelPending()
+    this.removeSuppressListener()
+    this.element.removeEventListener('touchstart', this.onTouchStart)
+    this.element.removeEventListener('touchmove', this.onTouchMove)
+    this.element.removeEventListener('touchend', this.onTouchEnd)
+    this.element.removeEventListener('touchcancel', this.onTouchCancel)
+  }
+
+  private relativePoint(touch: Touch): Point {
+    const rect = this.element.getBoundingClientRect()
+    return { x: touch.clientX - rect.left, y: touch.clientY - rect.top }
+  }
+
+  private onTouchStart = (event: TouchEvent) => {
+    if (event.touches.length !== 1) {
+      this.cancelPending()
+      this.currentTouch = null
+      this.lastTap = null
+      return
+    }
+
+    const point = this.relativePoint(event.touches[0])
+    const isSecondTap = !!this.lastTap
+      && event.timeStamp - this.lastTap.time < POI_DOUBLE_TAP_MS
+      && distance(point, this.lastTap.point) < POI_DOUBLE_TAP_RADIUS_PX
+
+    if (isSecondTap) this.cancelPending()
+    this.currentTouch = {
+      point,
+      startedAt: event.timeStamp,
+      moved: false,
+      suppress: isSecondTap,
+    }
+  }
+
+  private onTouchMove = (event: TouchEvent) => {
+    if (!this.currentTouch || event.touches.length !== 1) return
+    const point = this.relativePoint(event.touches[0])
+    if (distance(point, this.currentTouch.point) >= POI_DOUBLE_TAP_RADIUS_PX) {
+      this.currentTouch.moved = true
+    }
+  }
+
+  private onTouchEnd = (event: TouchEvent) => {
+    if (!this.currentTouch || event.touches.length !== 0) return
+
+    const validTap = !this.currentTouch.moved
+      && event.timeStamp - this.currentTouch.startedAt <= POI_DOUBLE_TAP_MS
+    const completed: CompletedTouch = {
+      point: this.currentTouch.point,
+      time: event.timeStamp,
+      suppress: this.currentTouch.suppress || !validTap,
+    }
+
+    this.completedTouch = completed
+    this.lastTap = validTap && !completed.suppress ? completed : null
+    this.currentTouch = null
+  }
+
+  private onTouchCancel = () => {
+    this.cancelPending()
+    this.currentTouch = null
+    this.lastTap = null
+    this.completedTouch = null
+  }
+
+  private touchForClick(event: PoiPointerEvent): CompletedTouch | null {
+    const touch = this.completedTouch
+    if (!touch) return null
+
+    const elapsed = (event.originalEvent?.timeStamp ?? touch.time) - touch.time
+    if (elapsed < 0 || elapsed > POI_DOUBLE_TAP_MS) return null
+
+    const explicitlyFromTouch = !!event.originalEvent?.sourceCapabilities
+      ?.firesTouchEvents
+    if (
+      !explicitlyFromTouch
+      && distance(event.point, touch.point) >= POI_DOUBLE_TAP_RADIUS_PX
+    ) {
+      return null
+    }
+    return touch
+  }
+}

--- a/web/src/services/layers/features/bookmarks-layer.service.ts
+++ b/web/src/services/layers/features/bookmarks-layer.service.ts
@@ -26,6 +26,7 @@ import type { Layer } from '@/types/map.types'
 import { ensureIconImages } from '@/lib/map-icon-images'
 import { themeColorToHex } from '@/lib/utils'
 import { getPlaceRouteFromExternalIds } from '@/lib/place.utils'
+import { mapPoiClickPolicy } from '@/lib/map-poi-interaction'
 import {
   selectSavedPlaces,
   buildSavedPlacesGeoJSON,
@@ -150,17 +151,21 @@ export function useBookmarksLayerService() {
     // Hover changes the cursor and nothing else — a dot that grows under the
     // pointer shifts the thing you're aiming at.
     map.on('mouseenter', BOOKMARKS_CIRCLES_LAYER_ID, () => {
-      canvas.style.cursor = 'pointer'
+      if (
+        !useMapToolsStore().rawClickCapture
+        && mapPoiClickPolicy.enabled
+      ) canvas.style.cursor = 'pointer'
     })
 
     map.on('mouseleave', BOOKMARKS_CIRCLES_LAYER_ID, () => {
-      canvas.style.cursor = ''
+      if (!useMapToolsStore().rawClickCapture) canvas.style.cursor = ''
     })
 
     map.on('click', BOOKMARKS_CIRCLES_LAYER_ID, (e: any) => {
       // Measuring takes precedence: a click there is placing a vertex, not
       // opening a place. Mirrors the basemap POI handler.
-      if (useMapToolsStore().activeTool === 'measure') return
+      const mapTools = useMapToolsStore()
+      if (mapTools.activeTool === 'measure' || mapTools.rawClickCapture) return
 
       const id = e.features?.[0]?.properties?.id
       if (typeof id !== 'string') return
@@ -172,9 +177,11 @@ export function useBookmarksLayerService() {
       const target = getPlaceRouteFromExternalIds(place.externalIds)
       if (!target) return
 
-      // Stop the generic map click from also firing and dropping a pin.
-      e.originalEvent?.stopPropagation?.()
-      router.push(target)
+      const accepted = mapStrategy.dispatchPoiClick(e, () => router.push(target))
+      if (accepted) {
+        // Stop the generic map click from also firing and dropping a pin.
+        e.originalEvent?.stopPropagation?.()
+      }
     })
   }
 

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -83,6 +83,8 @@ import { glyphAdvances } from './portolan-glyphs'
 import { TRANSIT_GROUP_ID, stopTargetFor } from './portolan-ui'
 import { firstLabelLayerId } from './portolan-anchors'
 import { resolveRouteRef, routeRefFor } from './portolan-routes'
+import { mapPoiClickPolicy } from '@/lib/map-poi-interaction'
+import { useMapToolsStore } from '@/stores/map-tools.store'
 
 const FLAG_KEY = 'parchment.portolan-transit'
 
@@ -140,6 +142,7 @@ const LABEL_FONT_ITALIC = ['Geist Regular']
 
 // ── module state (one map at a time, like the other layer services) ────
 let map: any = null
+let activeStrategy: MapStrategy | null = null
 
 /**
  * Whether the engine under us can ease `line-offset` along
@@ -798,6 +801,7 @@ function isPortolanTransitEnabled(): boolean {
  *  services re-registered from map.service's onStyleLoad). */
 function initializePortolanTransit(mapStrategy: MapStrategy | undefined) {
   if (!mapStrategy?.mapInstance || !isPortolanTransitEnabled()) return
+  activeStrategy = mapStrategy
   // Both engines render the network; only the fork renders it in full.
   engine = mapStrategy.options.engine
   themeDark = mapStrategy.options.theme === MapTheme.DARK
@@ -855,6 +859,7 @@ function teardownPortolanTransit() {
   // Not gated on isStyleLoaded() — see styleReady.
   if (map?.style) removeAll()
   map = null
+  activeStrategy = null
   isolatedRoute = null
   clearHydration()
   clearMounts()
@@ -967,15 +972,24 @@ function bindListeners() {
   }
 
   const onStopEnter = (e: any) => {
-    if (targetAt(e)) map.getCanvas().style.cursor = 'pointer'
+    if (
+      targetAt(e)
+      && mapPoiClickPolicy.enabled
+      && !useMapToolsStore().rawClickCapture
+    ) {
+      map.getCanvas().style.cursor = 'pointer'
+    }
   }
   const onLeave = () => {
-    if (map) map.getCanvas().style.cursor = ''
+    if (map && !useMapToolsStore().rawClickCapture) {
+      map.getCanvas().style.cursor = ''
+    }
   }
   const onStopClick = (e: any) => {
+    if (useMapToolsStore().rawClickCapture) return
     const target = targetAt(e)
-    if (!target) return
-    router.push(target as any)
+    if (!target || !activeStrategy) return
+    activeStrategy.dispatchPoiClick(e, () => router.push(target as any))
   }
   // Route clicks → the line's own detail, the way tapping a bullet in a
   // station header opens it. The pair that page is keyed by has to be
@@ -2447,4 +2461,3 @@ function isolatedMarkerFeature(f: any, routeId: string): any {
   // ribbon no longer rides its slot (see isolationOffset).
   return { ...f, properties: { ...p, icon: `dots-${hex}@0` } }
 }
-

--- a/web/src/services/layers/features/transit-layers.service.ts
+++ b/web/src/services/layers/features/transit-layers.service.ts
@@ -12,6 +12,8 @@ import { useRouter } from 'vue-router'
 import { AppRoute } from '@/router'
 import { isTransitStopLayer } from '@/lib/transit.utils'
 import { useThemeStore } from '@/stores/theme.store'
+import { mapPoiClickPolicy } from '@/lib/map-poi-interaction'
+import { useMapToolsStore } from '@/stores/map-tools.store'
 
 export function useTransitLayersService() {
   const router = useRouter()
@@ -31,28 +33,35 @@ export function useTransitLayersService() {
     if (!mapStrategy?.mapInstance) return
 
     const handleClick = (event: any) => {
+      if (useMapToolsStore().rawClickCapture) return
       const feature = event.features?.[0]
       if (feature && feature.properties) {
         const onestopId =
           feature.properties.onestop_id || feature.properties.stop_id
         if (onestopId) {
-          router.push({
-            name: AppRoute.PLACE_PROVIDER,
-            params: {
-              provider: 'transitland',
-              placeId: onestopId,
-            },
+          mapStrategy.dispatchPoiClick(event, () => {
+            router.push({
+              name: AppRoute.PLACE_PROVIDER,
+              params: {
+                provider: 'transitland',
+                placeId: onestopId,
+              },
+            })
           })
         }
       }
     }
 
     const handleMouseEnter = () => {
-      mapStrategy.mapInstance.getCanvas().style.cursor = 'pointer'
+      if (mapPoiClickPolicy.enabled && !useMapToolsStore().rawClickCapture) {
+        mapStrategy.mapInstance.getCanvas().style.cursor = 'pointer'
+      }
     }
 
     const handleMouseLeave = () => {
-      mapStrategy.mapInstance.getCanvas().style.cursor = ''
+      if (!useMapToolsStore().rawClickCapture) {
+        mapStrategy.mapInstance.getCanvas().style.cursor = ''
+      }
     }
 
     // Add all handlers

--- a/web/src/services/map.service.ts
+++ b/web/src/services/map.service.ts
@@ -366,6 +366,15 @@ function mapService() {
       }
     })
 
+    // Warm details while a touch action waits through the double-tap window.
+    mapEventBus.on('poi:preview', async ({ poi }) => {
+      const { usePlaceService } = await import('@/services/place.service')
+      void usePlaceService().prefetchPlaceDetails(
+        `${poi.poiType}/${poi.osmId}`,
+        'osm',
+      )
+    })
+
     mapEventBus.on('click', async data => {
       // Only handle POI clicks — ignore empty map clicks
       if (!data.poi) return
@@ -422,6 +431,7 @@ function mapService() {
     mapEventBus.off('moveend')
     mapEventBus.off('rotateend')
     mapEventBus.off('click')
+    mapEventBus.off('poi:preview')
     mapEventBus.off('click:mapillary-image')
   }
 

--- a/web/src/services/place.service.ts
+++ b/web/src/services/place.service.ts
@@ -17,6 +17,7 @@ function placeService() {
   const loading = ref(false)
   const { toast } = useAppService()
   const placeCache = usePlaceCacheStore()
+  const inFlightPlaceRequests = new Map<string, Promise<Place | null>>()
 
   /**
    * Log a foreground place resolve into the user's (encrypted) recents.
@@ -49,12 +50,37 @@ function placeService() {
     queryParams: Record<string, string>,
     signal?: AbortSignal,
   ): Promise<Place | null> {
-    const response = await api.get<Place>('/places/details', {
-      params: queryParams,
-      signal,
-    })
-    placeCache.set(cacheKey, response.data)
-    return response.data
+    const pending = inFlightPlaceRequests.get(cacheKey)
+    if (pending) return pending
+
+    const request = api
+      .get<Place>('/places/details', { params: queryParams, signal })
+      .then(response => {
+        placeCache.set(cacheKey, response.data)
+        return response.data
+      })
+      .finally(() => inFlightPlaceRequests.delete(cacheKey))
+
+    inFlightPlaceRequests.set(cacheKey, request)
+    return request
+  }
+
+  /** Warm place details without changing the visible place or loading state. */
+  async function prefetchPlaceDetails(
+    id: string,
+    source: SourceId = SOURCE.OSM,
+  ) {
+    const queryParams = { source, id }
+    const cacheKey = buildPlaceCacheKey(queryParams)
+    const cached = placeCache.get(cacheKey)
+    if (cached && !placeCache.isStale(cached)) return cached.data
+
+    try {
+      return await fetchPlaceFromApi(cacheKey, queryParams)
+    } catch (error) {
+      if (!axios.isCancel(error)) console.warn('Place prefetch failed:', error)
+      return null
+    }
   }
 
   /**
@@ -329,6 +355,7 @@ function placeService() {
   return {
     currentPlace,
     loading,
+    prefetchPlaceDetails,
     fetchPlaceDetails,
     lookupPlace,
     lookupPlaceById,

--- a/web/src/types/map.types.ts
+++ b/web/src/types/map.types.ts
@@ -184,6 +184,14 @@ export type MapEvents = {
       name?: string
     }
   }
+  /** Emitted while a touch POI action waits for the double-tap window. */
+  'poi:preview': {
+    poi: {
+      osmId: string
+      poiType: 'node' | 'way' | 'relation'
+      name?: string
+    }
+  }
   // TODO: Fold this into 'click' event
   'click:mapillary-image': {
     lngLat: LngLat

--- a/web/src/views/library/canvases/CanvasEditor.vue
+++ b/web/src/views/library/canvases/CanvasEditor.vue
@@ -34,6 +34,7 @@ import { useCanvasDrawStyle } from '@/composables/useCanvasDrawStyle'
 import { useAnnotationEditing } from '@/composables/useAnnotationEditing'
 import { useCanvasHistory } from '@/composables/useCanvasHistory'
 import { useCanvasMapSettings } from '@/composables/useCanvasMapSettings'
+import { useMapPoiClickSuppression } from '@/composables/useMapPoiClickSuppression'
 import type { CanvasMapSettings } from '@/types/canvas.types'
 import CanvasContextMenu from '@/components/library/canvas/CanvasContextMenu.vue'
 import { useDrawOverlay } from '@/composables/useDrawOverlay'
@@ -104,6 +105,10 @@ import {
   ShapesIcon,
   UsersIcon,
 } from 'lucide-vue-next'
+
+// The editor owns map interaction even between drawing tools: basemap and
+// saved-place POIs must never navigate away from the canvas being edited.
+useMapPoiClickSuppression()
 
 const props = defineProps<{ id: string }>()
 


### PR DESCRIPTION
## Summary
- distinguish single-finger POI taps from double-tap and double-tap-drag zoom gestures
- prevent the engines’ ordinary double-tap recognizer from adding a zoom level after a drag zoom
- prefetch OSM place details while a single tap waits for confirmation
- add scoped, reference-counted POI suppression and enable it throughout canvas editing
- apply the shared interaction path to basemap POIs, saved places, transit stops, and street imagery

## Validation
- 42 focused gesture, canvas annotation, and transit UI tests pass
- TypeScript check passes
- production build passes