### PR TITLE
Link setup warning to settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 ### Changed
 
+* The "set up your encryption keys" warning on an integration now links
+  straight to the setup screen
+
 ### Fixed
 
 * Dragging the bottom sheet upward and releasing now lands on the next

--- a/web/src/components/identity/IdentitySettings.vue
+++ b/web/src/components/identity/IdentitySettings.vue
@@ -168,6 +168,7 @@ function handleSetupComplete() {
     <!-- Needs Import (has server keys but no local) -->
     <SettingsSection
       v-else-if="needsImport"
+      id="identity"
       :title="t('friends.identity.title')"
       :description="t('friends.identity.description')"
     >
@@ -188,6 +189,7 @@ function handleSetupComplete() {
     <!-- Needs Setup -->
     <SettingsSection
       v-else-if="!isSetupComplete"
+      id="identity"
       :title="t('friends.identity.title')"
       :description="t('friends.identity.description')"
     >

--- a/web/src/components/integration/IntegrationTile.vue
+++ b/web/src/components/integration/IntegrationTile.vue
@@ -12,6 +12,7 @@ import {
   IntegrationScope,
 } from '@/types/integrations.types'
 import { computed, h } from 'vue'
+import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { Button } from '@/components/ui/button'
 import { useIntegrationsStore } from '@/stores/integrations.store'
@@ -30,6 +31,7 @@ import {
 } from '@/components/ui/tooltip'
 
 const { t } = useI18n()
+const router = useRouter()
 const integrationsStore = useIntegrationsStore()
 const identityStore = useIdentityStore()
 const { isSetupComplete } = storeToRefs(identityStore)
@@ -249,7 +251,13 @@ async function handleClick() {
   const integration = props.integration
 
   if (requiresSetup.value) {
-    toast.warning(t('settings.integrations.scheme.setupRequired'))
+    toast.warning(t('settings.integrations.scheme.setupRequired'), {
+      action: {
+        label: t('settings.integrations.scheme.setupRequiredAction'),
+        onClick: () =>
+          router.push({ path: '/settings/account', hash: '#identity' }),
+      },
+    })
     return
   }
 

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -2064,7 +2064,8 @@
         "endToEnd": {
           "formNote": "End-to-end encrypted. Your URL and API token are encrypted on this device before upload — the Parchment server never sees them."
         },
-        "setupRequired": "Set up your encryption keys in Settings → Encryption keys before configuring this integration."
+        "setupRequired": "Set up your encryption keys before configuring this integration.",
+          "setupRequiredAction": "Set up"
       },
       "osm": {
         "connected": "OpenStreetMap account connected successfully",

--- a/web/src/lib/i18n/es-ES.json
+++ b/web/src/lib/i18n/es-ES.json
@@ -1955,7 +1955,8 @@
         "endToEnd": {
           "formNote": "Cifrado de extremo a extremo. Tu URL y token de API se cifran en este dispositivo antes de subirse — el servidor de Parchment nunca los ve."
         },
-        "setupRequired": "Configura tus claves de cifrado en Configuración → Claves de cifrado antes de configurar esta integración."
+        "setupRequired": "Configura tus claves de cifrado antes de configurar esta integración.",
+          "setupRequiredAction": "Configurar"
       },
       "osm": {
         "connected": "Cuenta de OpenStreetMap conectada exitosamente",


### PR DESCRIPTION
## Problem

Clicking a `user-e2ee` integration tile (Dawarich) before identity setup is done shows a warning toast that names the destination in prose — "Set up your encryption keys in Settings → Encryption keys before configuring this integration." — but gives no way to get there. The user has to read the path, dismiss the toast, and navigate by hand.

This is also exactly what a user sees right after an identity reset, when their keys are gone and every e2ee integration needs reconnecting.

## Change

- The toast gets a **Set up** action that routes to `/settings/account#identity`, following the existing pattern in `Passkeys.vue` (`refreshKeysTitle` → `requestRotateKeys`).
- The message drops the now-redundant path: "Set up your encryption keys before configuring this integration." Both `en-US` and `es-ES` updated, plus a new `setupRequiredAction` label.
- `IdentitySettings.vue`: the two pre-setup branches (`needsImport`, `!isSetupComplete`) had no `id`, so only the *configured* layout carried anchors. Added `id="identity"` to both — without it the hash lands nowhere, which is precisely the state a user in this toast is in.

## Verification

Reproduced on the preview (identity not yet imported on that device, so the Dawarich tile is in the `requiresSetup` state):

- Toast renders as `Set up your encryption keys before configuring this integration.` + `Set up`.
- Clicking the action lands on `/settings/account#identity` with the Federation Identity section resolved and scrolled to ("Your identity exists on this server, but you need to import…").

Standard sonner action layout — 356×73 toast, 53×24 button — matching the existing action-toast precedent. `vue-tsc` clean; `integrations.store.test.ts` green.

No screenshot attached: the toast only appears in the pre-setup state, which is easiest to see live on the preview link below.