### PR TITLE
Dedupe walk routing

### DIFF
--- a/server/src/services/trip.service.test.ts
+++ b/server/src/services/trip.service.test.ts
@@ -2211,6 +2211,61 @@ describe('TripService — scoring', () => {
 
 // ── Validation ──────────────────────────────────────────────────────────────
 
+describe('TripService — walk route deduplication', () => {
+  /** Two itineraries on different lines that share the same access/egress walks. */
+  function makeSharedWalkItineraries() {
+    const a = makeTransitItinerary()
+    const b = makeTransitItinerary()
+    b.legs[1] = { ...b.legs[1], routeId: 'route-7y', routeShortName: '7Y' }
+    return [a, b]
+  }
+
+  test('routes each distinct walk once across itineraries', async () => {
+    mockGetIntermodalRoute.mockImplementation(async () => ({
+      itineraries: makeSharedWalkItineraries(),
+      metadata: { searchWindow: 3600 },
+    }))
+    mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(250, 200))
+
+    await tripService.planTrip({
+      waypoints: [CHARLOTTE_ORIGIN, CHARLOTTE_DEST],
+      selectedMode: 'transit',
+      preferredDepartureTime: '2026-01-15T08:00:00Z',
+    })
+
+    // Four walk legs (access + egress on each itinerary), two distinct routes.
+    const walkCalls = mockGetRoute.mock.calls.filter(
+      ([, profile]: any[]) => profile === 'pedestrian',
+    )
+    const distinct = new Set(walkCalls.map(([pts]: any[]) => JSON.stringify(pts)))
+    expect(distinct.size).toBe(2)
+    expect(walkCalls.length).toBe(distinct.size)
+  })
+
+  test('a failed walk route is not cached', async () => {
+    mockGetIntermodalRoute.mockImplementation(async () => ({
+      itineraries: [makeTransitItinerary()],
+      metadata: { searchWindow: 3600 },
+    }))
+    let attempt = 0
+    mockGetRoute.mockImplementation(async () => {
+      if (++attempt === 1) throw new Error('routing unavailable')
+      return makeBasicWalkRoute(250, 200)
+    })
+
+    const req = {
+      waypoints: [CHARLOTTE_ORIGIN, CHARLOTTE_DEST],
+      selectedMode: 'transit' as const,
+      preferredDepartureTime: '2026-01-15T08:00:00Z',
+    }
+    await tripService.planTrip(req)
+    const afterFirst = mockGetRoute.mock.calls.length
+
+    await tripService.planTrip({ ...req, requestId: 'second' })
+    expect(mockGetRoute.mock.calls.length).toBeGreaterThan(afterFirst)
+  })
+})
+
 describe('TripService — validateRequest', () => {
   test('throws on fewer than 2 waypoints', () => {
     expect(() =>

--- a/server/src/services/trip.service.ts
+++ b/server/src/services/trip.service.ts
@@ -3224,6 +3224,54 @@ export class TripService {
   >()
   private static readonly ENTRANCE_CACHE_MAX = 500
 
+  /**
+   * Cached pedestrian re-routes, keyed by endpoints and preferences.
+   *
+   * One plan enriches every walk leg of every itinerary across ~5 MOTIS
+   * queries, and those itineraries overlap heavily — the access walk to a
+   * given station is identical in each itinerary boarding there. Without
+   * this, the same route is fetched once per itinerary.
+   */
+  private walkRouteCache = new Map<
+    string,
+    Promise<Awaited<ReturnType<typeof routingService.getRoute>>>
+  >()
+  private static readonly WALK_ROUTE_CACHE_MAX = 500
+
+  private cachedWalkRoute(
+    start: Coordinate,
+    end: Coordinate,
+    preferences?: any,
+  ): Promise<Awaited<ReturnType<typeof routingService.getRoute>>> {
+    // Preferences ride in the key: they change the route and the language of
+    // its instructions, so two requests may share endpoints but not a result.
+    const key = [
+      start.lat.toFixed(5), start.lng.toFixed(5),
+      end.lat.toFixed(5), end.lng.toFixed(5),
+      JSON.stringify(preferences ?? null),
+    ].join(',')
+
+    let hit = this.walkRouteCache.get(key)
+    if (!hit) {
+      hit = routingService.getRoute(
+        [
+          { type: 'coordinates', value: [start.lat, start.lng] },
+          { type: 'coordinates', value: [end.lat, end.lng] },
+        ],
+        'pedestrian',
+        preferences,
+      )
+      this.walkRouteCache.set(key, hit)
+      // A rejected route must not be cached — the next plan should retry.
+      hit.catch(() => this.walkRouteCache.delete(key))
+      if (this.walkRouteCache.size > TripService.WALK_ROUTE_CACHE_MAX) {
+        const oldest = this.walkRouteCache.keys().next().value
+        if (oldest) this.walkRouteCache.delete(oldest)
+      }
+    }
+    return hit
+  }
+
   private cachedNearestEntrance(
     lat: number,
     lng: number,
@@ -3365,15 +3413,13 @@ export class TripService {
 
         // 3. GraphHopper re-route between the (possibly moved) endpoints
         try {
-          const route = await routingService.getRoute(
-            [
-              { type: 'coordinates', value: [seg.start.location.lat, seg.start.location.lng] },
-              { type: 'coordinates', value: [seg.end.location.lat, seg.end.location.lng] },
-            ],
-            'pedestrian',
+          const route = await this.cachedWalkRoute(
+            seg.start.location,
+            seg.end.location,
             preferences,
           )
           if (!route.routes.length) return
+          // Shared with every other segment on this route — read, never mutate.
           const leg = route.routes[0].legs[0]
 
           seg.geometry = leg.geometry


### PR DESCRIPTION
One trip plan enriches every walk leg of every itinerary across ~5 MOTIS queries, and those itineraries overlap heavily — the access walk to a given station is identical in every itinerary that boards there. Each copy was routed separately.

`cachedWalkRoute` memoises the pedestrian re-route on endpoints plus preferences, mirroring the existing `cachedNearestEntrance` pattern (same FIFO trim, same promise-caching so concurrent callers share one in-flight request). Preferences are part of the key because they change both the route and the language of its instructions. Rejected routes are evicted so a transient failure isn't cached.

## What this is and isn't

**It is** a reduction in redundant load on Barrelman, which is production. Measured on a Brooklyn → Manhattan transit plan: 9 routed walk legs collapse to 5 distinct routes, a 44% cut. The real saving is larger, since enrichment runs over every itinerary, not just the ones that survive filtering.

**It is not** a latency win. Interleaved runs against `dev`: dev 1.69–1.94s, this branch 1.70–2.22s — no meaningful difference. Those calls were already concurrent and bounded by the 48-slot semaphore in `barrelman-integration.ts`, and wall-clock is dominated by the MOTIS queries. Ship this for the load reduction or not at all; it will not make trips feel faster.

## Correctness

The cached route object is now shared across segments, so the leg is read-only at the assignment site (noted in a comment there). I checked for post-enrichment mutation of `geometry` / `instructions` / `edgeSegments`: there is none, and `collapseWalkableTransitLegs` runs before enrichment and shallow-copies.

Output is unchanged. An early comparison appeared to show a dropped bike-share leg, but that was live GBFS availability drifting between two time-separated runs — interleaving the two servers gives byte-identical trip shapes.

## Tests

Two added. `routes each distinct walk once across itineraries` fails on `dev` (4 calls, expected 2) and passes here. The second is a regression guard that a failed route isn't cached; it passes both ways by construction.

Full trip suite 144 pass / 0 fail. `tsc` error count unchanged from `dev` at 320.