### PR TITLE
Map markers for trip stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Added
 
+* Stops a trip makes for you — the bike rack it parks at, the lot it leaves the
+  car in — now show on the map as their own labelled POI marker, matching the
+  timeline
+
 ### Changed
 
 ### Fixed

--- a/web/src/components/map/markers/WaypointMarker.vue
+++ b/web/src/components/map/markers/WaypointMarker.vue
@@ -23,12 +23,16 @@ import type { Place } from '@/types/place.types'
  * at 13px, 1.1em below the icon's centre. A stop is a POI, so it should not be
  * possible to tell which of the two labels the style drew.
  */
-const props = defineProps<{
-  index: number
-  totalWaypoints: number
-  type?: 'origin' | 'destination' | 'waypoint'
-  place?: Partial<Place> | null
-}>()
+const props = withDefaults(
+  defineProps<{
+    type?: 'origin' | 'destination' | 'waypoint'
+    place?: Partial<Place> | null
+    /** Overrides the name derived from `place`, for a stop the plan named. */
+    label?: string
+    draggable?: boolean
+  }>(),
+  { type: 'waypoint', place: null, label: '', draggable: false },
+)
 
 const themeStore = useThemeStore()
 const { t } = useI18n()
@@ -44,7 +48,7 @@ const mark = computed(() =>
 
 /** The origin is the one stop that isn't a place; the rest all draw a plate. */
 const drawsPlate = computed(
-  () => mark.value.ownIcon || (props.index > 0 && props.type !== 'origin'),
+  () => mark.value.ownIcon || props.type !== 'origin',
 )
 
 const iconName = computed(() => mark.value.display.icon)
@@ -56,6 +60,7 @@ const iconPack = computed(() => mark.value.display.iconPack)
  * itself already says "a stop is here", so that gets no label.
  */
 const label = computed(() => {
+  if (props.label) return props.label
   const place = props.place
   if (!place?.name?.value && !place?.bookmark) return ''
   return mark.value.display.title
@@ -101,7 +106,10 @@ const lucideIcon = computed(() => {
 </script>
 
 <template>
-  <div class="relative size-8 shrink-0 cursor-move flex items-center justify-center">
+  <div
+    class="relative size-8 shrink-0 flex items-center justify-center"
+    :class="draggable ? 'cursor-move' : 'cursor-default'"
+  >
     <!-- The place's own marker -->
     <div v-if="css" class="shadow-md select-none" :style="css.plate">
       <MakiIcon

--- a/web/src/lib/directions/trip-stops.test.ts
+++ b/web/src/lib/directions/trip-stops.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { tripPlaceStops, type TripStopSegment } from './trip-stops'
+import type { Place } from '@/types/place.types'
+
+const rack = {
+  id: 'osm/node/1',
+  name: { value: 'Rack' },
+} as unknown as Place
+
+const segment = (
+  end: TripStopSegment['end'],
+  endTime = '2026-09-09T15:44:00Z',
+): TripStopSegment => ({ end, endTime })
+
+describe('tripPlaceStops', () => {
+  it('returns the place-bearing boundaries between segments', () => {
+    const stops = tripPlaceStops([
+      segment({ location: { lat: 1, lng: 2 }, label: 'Bike parking', place: rack }),
+      segment({ location: { lat: 3, lng: 4 }, place: undefined }),
+    ])
+
+    expect(stops).toEqual([
+      {
+        id: '0-osm/node/1',
+        segmentIndex: 0,
+        place: rack,
+        label: 'Bike parking',
+        lngLat: { lat: 1, lng: 2 },
+        time: '2026-09-09T15:44:00Z',
+      },
+    ])
+  })
+
+  it('ignores the last segment, whose end is the destination', () => {
+    expect(
+      tripPlaceStops([
+        segment({ location: { lat: 3, lng: 4 }, place: rack }),
+      ]),
+    ).toEqual([])
+  })
+
+  it('skips boundaries with no place or no location', () => {
+    expect(
+      tripPlaceStops([
+        segment({ location: { lat: 1, lng: 2 }, label: 'Your bike' }),
+        segment({ place: rack }),
+        segment({ location: { lat: 5, lng: 6 }, place: rack }),
+      ]),
+    ).toEqual([])
+  })
+
+  it('falls back to the place name when the plan gave no label', () => {
+    const stops = tripPlaceStops([
+      segment({ location: { lat: 1, lng: 2 }, place: rack }),
+      segment({ location: { lat: 3, lng: 4 } }),
+    ])
+    expect(stops[0].label).toBe('Rack')
+  })
+
+  it('handles a missing segment list', () => {
+    expect(tripPlaceStops(undefined)).toEqual([])
+  })
+})

--- a/web/src/lib/directions/trip-stops.ts
+++ b/web/src/lib/directions/trip-stops.ts
@@ -1,0 +1,55 @@
+import type { Place } from '@/types/place.types'
+import type { LngLat } from '@/types/map.types'
+
+/**
+ * A stop the plan makes on the traveller's behalf — the rack it parks the bike
+ * at, the lot it leaves the car in. The planner hangs a full Place on the
+ * waypoint the segment ends at, so the timeline and the map both read the
+ * stops from here rather than each walking the segments themselves.
+ */
+export interface TripPlaceStop {
+  id: string
+  /** Index of the segment this stop ends. */
+  segmentIndex: number
+  place: Place
+  label: string
+  lngLat: LngLat
+  /** When the trip reaches the stop. */
+  time: string | null
+}
+
+export interface TripStopSegment {
+  end?: {
+    location?: { lat: number; lng: number }
+    label?: string
+    place?: Place
+  }
+  endTime?: string
+}
+
+/**
+ * The final segment's end is the destination, which is a waypoint of its own —
+ * only the boundaries between segments are stops the plan invented.
+ */
+export function tripPlaceStops(
+  segments: TripStopSegment[] | undefined | null,
+): TripPlaceStop[] {
+  if (!segments) return []
+
+  return segments.slice(0, -1).flatMap((segment, index) => {
+    const end = segment.end
+    const place = end?.place
+    if (!place || !end?.location) return []
+
+    return [
+      {
+        id: place.id ? `${index}-${place.id}` : String(index),
+        segmentIndex: index,
+        place,
+        label: end.label || place.name?.value || 'Stop',
+        lngLat: { lat: end.location.lat, lng: end.location.lng },
+        time: segment.endTime ?? null,
+      },
+    ]
+  })
+}

--- a/web/src/services/layers/markers/marker-layers.service.ts
+++ b/web/src/services/layers/markers/marker-layers.service.ts
@@ -11,6 +11,7 @@ import { WaypointsLayer } from '@/services/layers/markers/waypoints-layer'
 import type { MarkerDragOptions } from '@/services/layers/markers/base-marker-layer'
 import { FriendLocationsLayer } from '@/services/layers/markers/friend-locations-layer'
 import { TripInstructionsLayer } from '@/services/layers/markers/trip-instructions-layer'
+import { TripStopsLayer } from '@/services/layers/markers/trip-stops-layer'
 import { UserLocationLayer } from '@/services/layers/markers/user-location-layer'
 import { TrackerLocationsLayer } from '@/services/layers/markers/tracker-locations-layer'
 import { TransitVehiclesLayer } from '@/services/layers/features/transit-vehicles-layer'
@@ -32,6 +33,7 @@ export function useMarkerLayersService() {
   let waypointsLayer: WaypointsLayer | null = null
   let friendLocationsLayer: FriendLocationsLayer | null = null
   let tripInstructionsLayer: TripInstructionsLayer | null = null
+  let tripStopsLayer: TripStopsLayer | null = null
   let userLocationLayer: UserLocationLayer | null = null
   let trackerLocationsLayer: TrackerLocationsLayer | null = null
   let transitVehiclesLayer: TransitVehiclesLayer | null = null
@@ -60,6 +62,7 @@ export function useMarkerLayersService() {
     waypointsLayer = new WaypointsLayer()
     friendLocationsLayer = new FriendLocationsLayer()
     tripInstructionsLayer = new TripInstructionsLayer()
+    tripStopsLayer = new TripStopsLayer()
     userLocationLayer = new UserLocationLayer()
     trackerLocationsLayer = new TrackerLocationsLayer()
     transitVehiclesLayer = new TransitVehiclesLayer()
@@ -96,6 +99,7 @@ export function useMarkerLayersService() {
     waypointsLayer.initialize(markerAPI)
     friendLocationsLayer.initialize(markerAPI)
     tripInstructionsLayer.initialize(markerAPI)
+    tripStopsLayer.initialize(markerAPI)
     userLocationLayer.initialize(markerAPI)
     trackerLocationsLayer.initialize(markerAPI)
     transitVehiclesLayer.initialize(markerAPI)
@@ -128,24 +132,25 @@ export function useMarkerLayersService() {
    * Set up watchers to sync marker layers with store state
    */
   function setupMarkerLayerWatchers() {
+    // Instruction points and the plan's own stops both belong to whichever
+    // single trip is on the map, so they follow the same trip.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const showTrip = (trip: any | null) => {
+      tripInstructionsLayer?.setTrip(trip)
+      tripStopsLayer?.setTrip(trip)
+    }
+
     watchStops.push(watch(
       () => directionsStore.trips,
       trips => {
-        if (trips) {
-          // Show the first trip by default (recommended or first in list)
-          const firstTrip =
-            trips.trips.find(trip => trip.isRecommended) || trips.trips[0]
-
-          // Update instruction markers if showing single trip
-          if (firstTrip) {
-            tripInstructionsLayer?.setTrip(firstTrip)
-          } else {
-            tripInstructionsLayer?.setTrip(null)
-          }
-        } else {
-          // Clear instruction markers when trips are cleared
-          tripInstructionsLayer?.setTrip(null)
+        if (!trips) {
+          showTrip(null)
+          return
         }
+        // Show the first trip by default (recommended or first in list)
+        showTrip(
+          trips.trips.find(trip => trip.isRecommended) || trips.trips[0] || null,
+        )
       },
     ))
 
@@ -154,12 +159,11 @@ export function useMarkerLayersService() {
       selectedTripId => {
         const trips = directionsStore.trips
         if (!trips || !selectedTripId) {
-          tripInstructionsLayer?.setTrip(null)
+          showTrip(null)
           return
         }
 
-        const trip = trips.trips.find(t => t.id === selectedTripId)
-        tripInstructionsLayer?.setTrip(trip || null)
+        showTrip(trips.trips.find(t => t.id === selectedTripId) || null)
       },
     ))
   }
@@ -182,6 +186,7 @@ export function useMarkerLayersService() {
     waypointsLayer?.destroy()
     friendLocationsLayer?.destroy()
     tripInstructionsLayer?.destroy()
+    tripStopsLayer?.destroy()
     userLocationLayer?.destroy()
     trackerLocationsLayer?.destroy()
     transitVehiclesLayer?.destroy()
@@ -192,6 +197,7 @@ export function useMarkerLayersService() {
     waypointsLayer = null
     friendLocationsLayer = null
     tripInstructionsLayer = null
+    tripStopsLayer = null
     userLocationLayer = null
     trackerLocationsLayer = null
     transitVehiclesLayer = null

--- a/web/src/services/layers/markers/trip-stops-layer.ts
+++ b/web/src/services/layers/markers/trip-stops-layer.ts
@@ -1,0 +1,45 @@
+/**
+ * Trip Stops Marker Layer
+ *
+ * Draws the stops a plan makes on the traveller's behalf — the bike rack it
+ * parks at, the lot it leaves the car in — as the same marker the origin and
+ * destination wear, so a stop on the timeline is a stop on the map.
+ */
+
+import { ref, type Ref } from 'vue'
+import { BaseMarkerLayer, type MarkerData } from './base-marker-layer'
+import WaypointMarker from '@/components/map/markers/WaypointMarker.vue'
+import { tripPlaceStops, type TripStopSegment } from '@/lib/directions/trip-stops'
+
+interface TripWithStops {
+  segments: TripStopSegment[]
+}
+
+export class TripStopsLayer extends BaseMarkerLayer {
+  private currentTrip: Ref<TripWithStops | null> = ref(null)
+
+  constructor() {
+    super({
+      idPrefix: 'trip-stop-',
+      component: WaypointMarker,
+      // Below the waypoints the user asked for, above the instruction points.
+      zIndex: 2,
+    })
+  }
+
+  protected getData(): MarkerData[] {
+    return tripPlaceStops(this.currentTrip.value?.segments).map(stop => ({
+      id: stop.id,
+      lngLat: stop.lngLat,
+      props: {
+        type: 'waypoint',
+        place: stop.place,
+        label: stop.label,
+      },
+    }))
+  }
+
+  setTrip(trip: TripWithStops | null) {
+    this.currentTrip.value = trip
+  }
+}

--- a/web/src/services/layers/markers/waypoints-layer.ts
+++ b/web/src/services/layers/markers/waypoints-layer.ts
@@ -33,8 +33,6 @@ export class WaypointsLayer extends BaseMarkerLayer {
           id: String(index),
           lngLat: waypoint.lngLat,
           props: {
-            index,
-            totalWaypoints: waypoints.length,
             type: index === 0
               ? 'origin'
               : index === waypoints.length - 1
@@ -43,6 +41,7 @@ export class WaypointsLayer extends BaseMarkerLayer {
             // The marker draws the place's own icon when it has one, so the
             // record has to reach it.
             place: waypoint.place ?? null,
+            draggable: true,
           },
           dragOptions: {
             onDragEnd: (lngLat) => {
@@ -68,8 +67,6 @@ export class WaypointsLayer extends BaseMarkerLayer {
       // be rebuilt when it is, or it keeps the numbered dot it was born with.
       const place = markerData.props.place
       const snapshot = [
-        markerData.props.index,
-        markerData.props.totalWaypoints,
         markerData.props.type,
         place?.id ?? '',
         place?.icon?.icon ?? '',

--- a/web/src/services/map/providers/layer-group.ts
+++ b/web/src/services/map/providers/layer-group.ts
@@ -9,7 +9,6 @@ import { Layer, LayerType, MapEngine } from '@/types/map.types'
 import { palette } from '@/lib/palette'
 import { FeatureCollection } from 'geojson'
 import { toRaw } from 'vue'
-import WaypointMarker from '@/components/map/markers/WaypointMarker.vue'
 import {
   getTravelModeColor,
   getTravelModeCaseColor,

--- a/web/src/services/map/providers/mapbox.strategy.ts
+++ b/web/src/services/map/providers/mapbox.strategy.ts
@@ -447,8 +447,6 @@ export class MapboxStrategy extends MapStrategy {
         { lat: location.lat, lng: location.lon },
         WaypointMarker,
         {
-          index,
-          totalWaypoints: directions.locations.length,
           type:
             index === 0
               ? 'origin'

--- a/web/src/services/map/providers/maplibre.strategy.ts
+++ b/web/src/services/map/providers/maplibre.strategy.ts
@@ -561,8 +561,6 @@ export class MaplibreStrategy extends MapStrategy {
         { lat: location.lat, lng: location.lon },
         WaypointMarker,
         {
-          index,
-          totalWaypoints: directions.locations.length,
           type:
             index === 0
               ? 'origin'

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -54,6 +54,7 @@ import type { Place } from '@/types/place.types'
 import type { RouteProfileType } from '@/lib/directions/route-profile-colors'
 import type { SharedMobilityDetails } from '@/types/multimodal.types'
 import { getSegmentIcon } from '@/lib/directions/travel-mode-icons'
+import { tripPlaceStops, type TripPlaceStop } from '@/lib/directions/trip-stops'
 import { getPlaceRoute } from '@/lib/place/place-route'
 import {
   getSearchResultIconName,
@@ -856,7 +857,7 @@ const formatDistanceDisplay = (meters: number | undefined): string => {
   return formatDistance(meters)
 }
 
-const formatTime = (date: Date): string => {
+const formatTime = (date: Date | string): string => {
   return new Date(date).toLocaleTimeString([], {
     hour: 'numeric',
     minute: '2-digit',
@@ -950,6 +951,15 @@ const routeWaypoints = computed<RouteWaypointDisplay[]>(() => {
   })
 })
 
+/** Stops the plan makes on its own — a bike rack, a parking lot. */
+const placeStopsBySegment = computed(
+  () =>
+    new Map(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      tripPlaceStops((trip.value as any)?.segments).map(s => [s.segmentIndex, s]),
+    ),
+)
+
 // ── Unified timeline ───────────────────────────────────────────────
 
 interface TimelineWaypointEntry {
@@ -965,11 +975,8 @@ interface TimelineSegmentEntry {
   segmentIndex: number
 }
 
-interface TimelinePlaceStopEntry {
+interface TimelinePlaceStopEntry extends TripPlaceStop {
   kind: 'place-stop'
-  place: Place
-  label: string
-  time: Date | null
 }
 
 type TimelineEntry = TimelineWaypointEntry | TimelineSegmentEntry | TimelinePlaceStopEntry
@@ -998,19 +1005,8 @@ const timelineEntries = computed<TimelineEntry[]>(() => {
   for (let i = 0; i < segs.length; i++) {
     entries.push({ kind: 'segment', segment: segs[i], segmentIndex: i })
 
-    // Check for a place-bearing intermediate waypoint (e.g. parking) between
-    // consecutive segments. The backend attaches a full Place object to the
-    // segment end waypoint when it represents an OSM POI like a bike rack.
-    const seg = segs[i]
-    const nextSeg = segs[i + 1]
-    if (nextSeg && seg.end?.place) {
-      entries.push({
-        kind: 'place-stop',
-        place: seg.end.place as Place,
-        label: seg.end.label || seg.end.place.name?.value || 'Stop',
-        time: seg.endTime ?? null,
-      })
-    }
+    const stop = placeStopsBySegment.value.get(i)
+    if (stop) entries.push({ kind: 'place-stop', ...stop })
 
     const viaIndex = i + 1
     if (viaIndex < wps.length - 1) {
@@ -1183,7 +1179,7 @@ function showSegmentChart(segment: any): boolean {
       <div class="mt-4">
         <div
           v-for="(entry, i) in timelineEntries"
-          :key="entry.kind === 'waypoint' ? entry.wp.id : entry.kind === 'place-stop' ? `place-${entry.place.id}` : `seg-${entry.segmentIndex}`"
+          :key="entry.kind === 'waypoint' ? entry.wp.id : entry.kind === 'place-stop' ? `place-${entry.id}` : `seg-${entry.segmentIndex}`"
           class="flex"
           :class="!isTransitCard(entry) && 'pl-2'"
         >


### PR DESCRIPTION
A trip that parks the bike at a rack showed that stop on the timeline but not on the map — the rack was an invisible corner in the line. Now every stop the plan makes on your behalf wears the same marker the origin and destination do.

## What changed

- `lib/directions/trip-stops.ts` — one pure reading of "which segment boundaries are places the plan stopped at". The timeline and the map both use it; the timeline used to walk the segments itself.
- `TripStopsLayer` — a marker layer for those stops, following the same trip as the instruction points (z-index 2: under the waypoints you asked for, over the instruction dots).
- `WaypointMarker` lost `totalWaypoints` (never read) and `index` (only ever meant "not the origin", which `type` already says), and gained `label` (a stop the plan named, like "Bike parking", has no name on its `Place`) and `draggable` — the route-stop markers the map strategies draw were never draggable but wore `cursor-move` anyway.

Transit boarding and alighting stops are not covered: they arrive as `TransitStop` (id, name, location), not a `Place`, so there is no POI glyph to draw. Every timeline entry that carries a `Place` now has a marker.

## Testing

`trip-stops.test.ts` covers the boundary rules — last segment excluded, place-less and location-less boundaries skipped, label fallback. `vue-tsc` clean; 255 tests in the touched areas pass.