### PR TITLE
Scroll the trip timeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,8 @@
 ### Fixed
 
 * The trip suggestions timeline scrolls sideways, so a trip that runs past the
-  visible range can be followed to its end. Each suggestion's duration, arrival
-  and summary stay pinned in place while the bars pan.
+  visible range can be followed to its end. Each suggestion's type and route
+  description stay pinned at the edge so you can tell the rows apart.
 
 ## [0.11.5] - 2026-09-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 ### Fixed
 
+* The trip suggestions timeline scrolls sideways, so a trip that runs past the
+  visible range can be followed to its end. Each suggestion's duration, arrival
+  and summary stay pinned in place while the bars pan.
+
 ## [0.11.5] - 2026-09-09
 
 ### Added

--- a/web/src/components/directions/TripItem.test.ts
+++ b/web/src/components/directions/TripItem.test.ts
@@ -50,6 +50,7 @@ function mountTrip(segments: Record<string, unknown>[]) {
       timelineStart: new Date('2026-06-12T13:55:00Z'),
       pxPerMinute: 8,
       sidebarWidth: 80,
+      barAreaWidth: 280,
     },
   })
 }

--- a/web/src/components/directions/TripItem.vue
+++ b/web/src/components/directions/TripItem.vue
@@ -19,6 +19,8 @@ interface Props {
   timelineStart: Date
   pxPerMinute: number
   sidebarWidth: number
+  /** Visible width of the bar column; bounds the pinned summary. */
+  barAreaWidth: number
   isClickable?: boolean
 }
 
@@ -282,29 +284,34 @@ function handleMouseEnter() {
 
 <template>
   <div
-    class="grid gap-3.5 py-3 transition-colors"
+    class="group grid transition-colors"
     :class="{ 'cursor-pointer hover:bg-accent/50': isClickable }"
     :style="{ gridTemplateColumns: sidebarWidth ? `${sidebarWidth}px 1fr` : 'auto 1fr' }"
     @click="handleClick"
     @mouseenter="handleMouseEnter"
   >
-    <!-- Duration sidebar -->
-    <div data-sidebar class="text-right tabular-nums pt-0.5 pl-3 pr-2 whitespace-nowrap">
-      <div class="text-base font-semibold leading-tight">
-        <template v-for="(part, i) in formatDurationParts(trip.summary.totalDuration).parts" :key="i">
-          <span v-if="i > 0" class="inline-block w-1" />{{ part.value }}<span class="text-[11px] font-medium ml-px">{{ part.unit }}</span>
-        </template>
-      </div>
-      <div class="text-[10px] text-muted-foreground font-medium mt-0.5">
-        {{ getArrivalTime() }}
-      </div>
-      <div class="text-[10px] text-muted-foreground font-medium">
-        {{ formatDistance(trip.summary.totalDistance) }}
+    <!-- Duration sidebar — pinned so it stays readable while the bar pans -->
+    <div data-sidebar class="sticky left-0 z-[21] grid bg-background transition-shadow">
+      <div
+        class="text-right tabular-nums pt-3.5 pb-3 pl-3 pr-5 whitespace-nowrap transition-colors"
+        :class="{ 'group-hover:bg-accent/50': isClickable }"
+      >
+        <div class="text-base font-semibold leading-tight">
+          <template v-for="(part, i) in formatDurationParts(trip.summary.totalDuration).parts" :key="i">
+            <span v-if="i > 0" class="inline-block w-1" />{{ part.value }}<span class="text-[11px] font-medium ml-px">{{ part.unit }}</span>
+          </template>
+        </div>
+        <div class="text-[10px] text-muted-foreground font-medium mt-0.5">
+          {{ getArrivalTime() }}
+        </div>
+        <div class="text-[10px] text-muted-foreground font-medium">
+          {{ formatDistance(trip.summary.totalDistance) }}
+        </div>
       </div>
     </div>
 
     <!-- Bar + meta -->
-    <div>
+    <div class="py-3">
       <!-- Trip bar -->
       <div class="relative h-7 flex items-center">
         <!-- Faint baseline for the empty axis (before departure / after arrival) -->
@@ -375,34 +382,40 @@ function handleMouseEnter() {
         />
       </div>
 
-      <!-- Trip meta -->
-      <div class="flex items-center gap-1.5 flex-wrap mt-1.5 pr-4 text-[11px] text-muted-foreground">
-        <span class="inline-flex items-center gap-1">
-          <component
-            :is="tripIcon"
-            class="size-3"
-            :style="{ color: getTravelModeColor(tripType.iconMode) }"
-          />
-          <span class="font-semibold text-foreground/80">{{ t(`directions.tripTypes.${tripType.key}`) }}</span>
-        </span>
-
-        <template v-if="trip.cost?.total">
-          <span class="size-0.5 rounded-full bg-muted-foreground/50" />
-          <span class="tabular-nums">${{ trip.cost.total.amount.toFixed(2) }}</span>
-        </template>
-
-        <template v-if="trip.co2Emissions != null && trip.co2Emissions > 0">
-          <span class="size-0.5 rounded-full bg-muted-foreground/50" />
-          <span class="tabular-nums">{{ formatCo2(trip.co2Emissions) }} CO₂</span>
-        </template>
-      </div>
-
-      <!-- First transit leg headsign — one quiet line instead of a card row -->
+      <!-- Trip summary — pinned beside the sidebar so it stays on screen -->
       <div
-        v-if="firstTransitHeadsign"
-        class="mt-1 text-[11px] text-muted-foreground truncate pr-4"
+        class="sticky w-fit"
+        :style="{ left: `${sidebarWidth}px`, maxWidth: `${barAreaWidth}px` }"
       >
-        {{ firstTransitHeadsign }}
+        <!-- Trip meta -->
+        <div class="flex items-center gap-1.5 flex-wrap mt-1.5 pr-4 text-[11px] text-muted-foreground">
+          <span class="inline-flex items-center gap-1">
+            <component
+              :is="tripIcon"
+              class="size-3"
+              :style="{ color: getTravelModeColor(tripType.iconMode) }"
+            />
+            <span class="font-semibold text-foreground/80">{{ t(`directions.tripTypes.${tripType.key}`) }}</span>
+          </span>
+
+          <template v-if="trip.cost?.total">
+            <span class="size-0.5 rounded-full bg-muted-foreground/50" />
+            <span class="tabular-nums">${{ trip.cost.total.amount.toFixed(2) }}</span>
+          </template>
+
+          <template v-if="trip.co2Emissions != null && trip.co2Emissions > 0">
+            <span class="size-0.5 rounded-full bg-muted-foreground/50" />
+            <span class="tabular-nums">{{ formatCo2(trip.co2Emissions) }} CO₂</span>
+          </template>
+        </div>
+
+        <!-- First transit leg headsign — one quiet line instead of a card row -->
+        <div
+          v-if="firstTransitHeadsign"
+          class="mt-1 text-[11px] text-muted-foreground truncate pr-4"
+        >
+          {{ firstTransitHeadsign }}
+        </div>
       </div>
     </div>
   </div>

--- a/web/src/components/directions/TripItem.vue
+++ b/web/src/components/directions/TripItem.vue
@@ -284,34 +284,29 @@ function handleMouseEnter() {
 
 <template>
   <div
-    class="group grid transition-colors"
+    class="grid py-3 transition-colors"
     :class="{ 'cursor-pointer hover:bg-accent/50': isClickable }"
     :style="{ gridTemplateColumns: sidebarWidth ? `${sidebarWidth}px 1fr` : 'auto 1fr' }"
     @click="handleClick"
     @mouseenter="handleMouseEnter"
   >
-    <!-- Duration sidebar — pinned so it stays readable while the bar pans -->
-    <div data-sidebar class="sticky left-0 z-[21] grid bg-background transition-shadow">
-      <div
-        class="text-right tabular-nums pt-3.5 pb-3 pl-3 pr-5 whitespace-nowrap transition-colors"
-        :class="{ 'group-hover:bg-accent/50': isClickable }"
-      >
-        <div class="text-base font-semibold leading-tight">
-          <template v-for="(part, i) in formatDurationParts(trip.summary.totalDuration).parts" :key="i">
-            <span v-if="i > 0" class="inline-block w-1" />{{ part.value }}<span class="text-[11px] font-medium ml-px">{{ part.unit }}</span>
-          </template>
-        </div>
-        <div class="text-[10px] text-muted-foreground font-medium mt-0.5">
-          {{ getArrivalTime() }}
-        </div>
-        <div class="text-[10px] text-muted-foreground font-medium">
-          {{ formatDistance(trip.summary.totalDistance) }}
-        </div>
+    <!-- Duration sidebar -->
+    <div data-sidebar class="text-right tabular-nums pt-0.5 pl-3 pr-5 whitespace-nowrap">
+      <div class="text-base font-semibold leading-tight">
+        <template v-for="(part, i) in formatDurationParts(trip.summary.totalDuration).parts" :key="i">
+          <span v-if="i > 0" class="inline-block w-1" />{{ part.value }}<span class="text-[11px] font-medium ml-px">{{ part.unit }}</span>
+        </template>
+      </div>
+      <div class="text-[10px] text-muted-foreground font-medium mt-0.5">
+        {{ getArrivalTime() }}
+      </div>
+      <div class="text-[10px] text-muted-foreground font-medium">
+        {{ formatDistance(trip.summary.totalDistance) }}
       </div>
     </div>
 
     <!-- Bar + meta -->
-    <div class="py-3">
+    <div>
       <!-- Trip bar -->
       <div class="relative h-7 flex items-center">
         <!-- Faint baseline for the empty axis (before departure / after arrival) -->
@@ -382,11 +377,8 @@ function handleMouseEnter() {
         />
       </div>
 
-      <!-- Trip summary — pinned beside the sidebar so it stays on screen -->
-      <div
-        class="sticky w-fit"
-        :style="{ left: `${sidebarWidth}px`, maxWidth: `${barAreaWidth}px` }"
-      >
+      <!-- Trip summary — travels with the bar, then pins at the panel edge -->
+      <div class="sticky left-3 w-fit" :style="{ maxWidth: `${barAreaWidth}px` }">
         <!-- Trip meta -->
         <div class="flex items-center gap-1.5 flex-wrap mt-1.5 pr-4 text-[11px] text-muted-foreground">
           <span class="inline-flex items-center gap-1">

--- a/web/src/components/directions/TripsList.vue
+++ b/web/src/components/directions/TripsList.vue
@@ -30,6 +30,13 @@ const sidebarWidth = ref(0)
 
 let observer: ResizeObserver | null = null
 
+const scrollRef = ref<HTMLElement | null>(null)
+const scrollLeft = ref(0)
+
+function onScroll() {
+  scrollLeft.value = scrollRef.value?.scrollLeft ?? 0
+}
+
 function updateWidth() {
   if (containerRef.value) {
     containerWidth.value = containerRef.value.clientWidth
@@ -50,6 +57,8 @@ onMounted(() => {
 
 watch(() => props.trips, () => {
   sidebarWidth.value = 0
+  if (scrollRef.value) scrollRef.value.scrollLeft = 0
+  scrollLeft.value = 0
   nextTick(() => updateWidth())
 })
 
@@ -210,25 +219,24 @@ function navigateToTripDetail(trip: TripOption) {
 </script>
 
 <template>
-  <!-- overflow-x-clip contains an over-long outlier bar without becoming a
-       scroll container (which would capture the sticky axis and fight the
-       sheet's single scroll surface). overflow-y stays visible so rows scroll
-       in the host scroller. -->
-  <div ref="containerRef" class="min-w-0 overflow-x-clip">
-    <div :style="{ minWidth: `${timelineWidth + sidebarWidth}px` }">
-      <!-- Time axis — opaque so suggestions are fully hidden as they scroll
-           under it, docked just below the pinned controls. -->
-      <!-- z above the trip caps (z-20) so rows are fully hidden under it, but
-           below the pinned controls (z-30). -->
-      <div
-        class="sticky z-[25] pt-2 pb-1 border-b border-border/40 bg-background grid"
-        :style="{
-          gridTemplateColumns: 'auto 1fr',
-          top: `calc(var(--sheet-sticky-top, 0px) + ${stickyTop}px)`,
-        }"
-      >
-        <span :style="{ width: `${sidebarWidth}px` }" />
-        <div class="relative h-7">
+  <div ref="containerRef" class="min-w-0">
+    <!-- Time axis — opaque so suggestions are fully hidden as they scroll
+         under it, docked just below the pinned controls. It sits outside the
+         horizontal scroller (which would capture its vertical stickiness) and
+         mirrors that scroller's offset instead.
+
+         z above the trip caps (z-20) so rows are fully hidden under it, but
+         below the pinned controls (z-30). -->
+    <div
+      class="sticky z-[25] pt-2 pb-1 border-b border-border/40 bg-background grid"
+      :style="{
+        gridTemplateColumns: 'auto 1fr',
+        top: `calc(var(--sheet-sticky-top, 0px) + ${stickyTop}px)`,
+      }"
+    >
+      <span :style="{ width: `${sidebarWidth}px` }" />
+      <div class="relative h-7 overflow-hidden">
+        <div class="absolute inset-0" :style="{ transform: `translateX(${-scrollLeft}px)` }">
           <template v-for="tick in timeTicks" :key="tick.time">
             <div
               class="absolute bottom-0"
@@ -245,9 +253,25 @@ function navigateToTripDetail(trip: TripOption) {
           </template>
         </div>
       </div>
+    </div>
 
+    <!-- The timeline outruns the panel whenever a trip is longer than the
+         fitted range, so the rows pan horizontally. Bottom padding gives the
+         entrance transform room before overflow clips it. -->
+    <div
+      ref="scrollRef"
+      class="trip-scroll overflow-x-auto overflow-y-hidden overscroll-x-contain pb-3 -mb-3"
+      :data-scrolled="scrollLeft > 0"
+      @scroll.passive="onScroll"
+    >
       <!-- Trip rows — staggered entrance as a fresh set of suggestions loads -->
-      <TransitionGroup name="trip" tag="div" class="flex flex-col" appear>
+      <TransitionGroup
+        name="trip"
+        tag="div"
+        class="flex flex-col"
+        :style="{ minWidth: `${timelineWidth + sidebarWidth}px` }"
+        appear
+      >
         <div
           v-for="(trip, tripIndex) in sortedTrips"
           :key="trip.id || tripIndex"
@@ -259,23 +283,35 @@ function navigateToTripDetail(trip: TripOption) {
             :timeline-start="timelineStart.toDate()"
             :px-per-minute="pxPerMinute"
             :sidebar-width="sidebarWidth"
+            :bar-area-width="barAreaWidth"
             @click="navigateToTripDetail"
           />
           <div v-if="tripIndex < sortedTrips.length - 1" class="border-b border-border/50 mx-4" />
         </div>
       </TransitionGroup>
+    </div>
 
-      <div
-        v-if="sortedTrips.length === 0"
-        class="text-center py-8 text-muted-foreground"
-      >
-        <p class="text-sm">No trips available</p>
-      </div>
+    <div
+      v-if="sortedTrips.length === 0"
+      class="text-center py-8 text-muted-foreground"
+    >
+      <p class="text-sm">No trips available</p>
     </div>
   </div>
 </template>
 
 <style scoped>
+.trip-scroll {
+  scrollbar-width: none;
+}
+.trip-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.trip-scroll[data-scrolled='true'] :deep([data-sidebar]) {
+  box-shadow: 6px 0 8px -6px hsl(var(--foreground) / 0.15);
+}
+
 /* Staggered entrance: each row fades and lifts in, offset by its index via
    the inline --trip-delay. `appear` replays it whenever a new result set
    mounts (new trip ids). */

--- a/web/src/components/directions/TripsList.vue
+++ b/web/src/components/directions/TripsList.vue
@@ -261,7 +261,6 @@ function navigateToTripDetail(trip: TripOption) {
     <div
       ref="scrollRef"
       class="trip-scroll overflow-x-auto overflow-y-hidden overscroll-x-contain pb-3 -mb-3"
-      :data-scrolled="scrollLeft > 0"
       @scroll.passive="onScroll"
     >
       <!-- Trip rows — staggered entrance as a fresh set of suggestions loads -->
@@ -306,10 +305,6 @@ function navigateToTripDetail(trip: TripOption) {
 }
 .trip-scroll::-webkit-scrollbar {
   display: none;
-}
-
-.trip-scroll[data-scrolled='true'] :deep([data-sidebar]) {
-  box-shadow: 6px 0 8px -6px hsl(var(--foreground) / 0.15);
 }
 
 /* Staggered entrance: each row fades and lifts in, offset by its index via

--- a/web/src/components/directions/TripsList.vue
+++ b/web/src/components/directions/TripsList.vue
@@ -228,15 +228,17 @@ function navigateToTripDetail(trip: TripOption) {
          z above the trip caps (z-20) so rows are fully hidden under it, but
          below the pinned controls (z-30). -->
     <div
-      class="sticky z-[25] pt-2 pb-1 border-b border-border/40 bg-background grid"
-      :style="{
-        gridTemplateColumns: 'auto 1fr',
-        top: `calc(var(--sheet-sticky-top, 0px) + ${stickyTop}px)`,
-      }"
+      class="sticky z-[25] pt-2 pb-1 border-b border-border/40 bg-background"
+      :style="{ top: `calc(var(--sheet-sticky-top, 0px) + ${stickyTop}px)` }"
     >
-      <span :style="{ width: `${sidebarWidth}px` }" />
+      <!-- Ticks are positioned from the bar column's origin, so the track is
+           offset by the sidebar and then panned with the rows. It spans the
+           full width: once scrolled, bars reach the panel's left edge too. -->
       <div class="relative h-7 overflow-hidden">
-        <div class="absolute inset-0" :style="{ transform: `translateX(${-scrollLeft}px)` }">
+        <div
+          class="absolute inset-0"
+          :style="{ transform: `translateX(${sidebarWidth - scrollLeft}px)` }"
+        >
           <template v-for="tick in timeTicks" :key="tick.time">
             <div
               class="absolute bottom-0"


### PR DESCRIPTION
The trip suggestions timeline was clipped: a trip longer than the fitted range (an 11-hour Park & Ride among 40-minute transit trips) ran off the right edge with no way to see the rest of it. `overflow-x-clip` was deliberate — making the list a scroll container would have captured the time axis's vertical stickiness.

## What changed

* The trip rows now live in their own horizontal scroller. The time axis stays outside it — keeping its `sticky top` docking under the pinned controls — and mirrors the scroller's offset with a `translateX`, so ticks and bars stay locked together.
* Everything pans together: bars, and the duration/arrival/distance column. The only thing that pins is each row's summary line (`Transit & Walking · 529 g CO₂` / `4 or 5 · toward Woodlawn`) — it travels with the bar until it reaches the panel's left gutter, then holds there, so the rows stay identifiable however far you scroll.
* Removed the row's `gap-3.5`: the axis grid had no gap, so ticks sat 14px left of the bars they labelled. The gutter now comes from the sidebar's padding, and the axis lines up with the timeline.

Verified in the preview — summary position by scroll offset: `0 → 95px`, `40 → 55px`, `95 → 12px`, `900 → 12px`, while the duration column tracks the content the whole way.