### PR TITLE
Trip list view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Stops a trip makes for you — the bike rack it parks at, the lot it leaves the
   car in — now show on the map as their own labelled POI marker, matching the
   timeline
+* Trip suggestions can be shown as a plain list instead of the timeline, with
+  each option's legs as a row of route badges. The toggle sits next to the
+  sort control and is remembered
 
 ### Changed
 

--- a/web/src/components/directions/TripItem.vue
+++ b/web/src/components/directions/TripItem.vue
@@ -4,8 +4,9 @@ import dayjs from 'dayjs'
 import { useI18n } from 'vue-i18n'
 import { useMapService } from '@/services/map/map.service'
 import { useUnits } from '@/composables/useUnits'
-import { getTravelModeCssClass, getTravelModeColor } from '@/lib/directions/travel-mode-colors'
-import { getSegmentIcon, getModeIcon } from '@/lib/directions/travel-mode-icons'
+import { getTravelModeCssClass } from '@/lib/directions/travel-mode-colors'
+import { getSegmentIcon } from '@/lib/directions/travel-mode-icons'
+import TripMeta from './TripMeta.vue'
 import type {
   TripOption,
   TripsResponse,
@@ -35,73 +36,6 @@ const emit = defineEmits<{
 const mapService = useMapService()
 const { t } = useI18n()
 const { formatDistance } = useUnits()
-
-function formatCo2(kg: number): string {
-  if (kg >= 1) return `${kg.toFixed(1)} kg`
-  return `${Math.round(kg * 1000)} g`
-}
-
-/**
- * Trip type — the combination pattern, not the longest mode. A subway trip
- * with two long walks is still a transit trip ("Transit & Walking"), a
- * drive to the station is "Park & Ride". Mirrors the trip-combination
- * taxonomy the planner generates from.
- */
-const tripType = computed<{ key: string; iconMode: string }>(() => {
-  const segs = props.trip.segments as any[]
-  const has = (m: string) => segs.some(s => s.mode === m)
-
-  if (!has('transit')) {
-    const shared = segs.find(s => s.sharedMobilityDetails)
-    if (shared) {
-      const kind = shared.sharedMobilityDetails?.vehicleType === 'scooter'
-        ? 'scootershare' : 'bikeshare'
-      return { key: kind, iconMode: 'cycling' }
-    }
-    if (has('rideshare')) return { key: 'rideshare', iconMode: 'rideshare' }
-    if (has('driving')) return { key: 'driving', iconMode: 'driving' }
-    if (has('cycling')) return { key: 'cycling', iconMode: 'cycling' }
-    return { key: 'walking', iconMode: 'walking' }
-  }
-
-  if (has('driving')) return { key: 'parkAndRide', iconMode: 'transit' }
-  if (has('rideshare')) return { key: 'transitRideshare', iconMode: 'transit' }
-  const shared = segs.find(s => s.sharedMobilityDetails)
-  if (shared) {
-    const kind = shared.sharedMobilityDetails?.vehicleType === 'scooter'
-      ? 'transitScooter' : 'transitBikeShare'
-    return { key: kind, iconMode: 'transit' }
-  }
-  if (has('cycling')) return { key: 'transitBike', iconMode: 'transit' }
-
-  // "Transit & Walking" only when walking is a significant journey of its
-  // own (15+ min in motion) — ordinary access and transfer walks are just
-  // part of riding transit.
-  const walkSec = segs.reduce(
-    (sum, s) => sum + (s.mode === 'walking' ? (s.duration || 0) - (s.waitSeconds ?? 0) : 0),
-    0,
-  )
-  if (walkSec >= 900) {
-    return { key: 'transitWalking', iconMode: 'transit' }
-  }
-  return { key: 'transit', iconMode: 'transit' }
-})
-
-/** Icon for the trip type — transit types use the longest transit segment's route type */
-const tripIcon = computed(() => {
-  if (tripType.value.iconMode !== 'transit') {
-    return getModeIcon(tripType.value.iconMode)
-  }
-  let longestSeg: any = null
-  let longestDur = 0
-  for (const seg of props.trip.segments) {
-    if (seg.mode === 'transit' && seg.duration > longestDur) {
-      longestDur = seg.duration
-      longestSeg = seg
-    }
-  }
-  return getSegmentIcon('transit', longestSeg?.routeType)
-})
 
 function segLeft(segment: { startTime: Date }) {
   return dayjs(segment.startTime).diff(props.timelineStart, 'minute', true) * props.pxPerMinute
@@ -196,18 +130,6 @@ function getSegmentTooltip(segment: any): string {
   const mode = getTripModeLabel(segment.mode)
   return `${mode}: ${duration}${distance ? ', ' + distance : ''}`
 }
-
-/** "Q · toward Coney Island" — single quiet context line under the bar.
- *  Merged interchangeable legs read "4 or 5 · toward …". */
-const firstTransitHeadsign = computed(() => {
-  const seg = props.trip.segments.find(s => s.mode === 'transit' && (s as any).headsign) as any
-  if (!seg) return null
-  const opts: { shortName?: string }[] = seg.routeOptions ?? []
-  const line = opts.length > 1
-    ? opts.map(o => o.shortName).filter(Boolean).join(` ${t('directions.or')} `)
-    : seg.lineName
-  return `${line ? line + ' · ' : ''}${t('directions.toward', { headsign: seg.headsign })}`
-})
 
 const legs = computed(() => {
   const groups: { legIndex: number; segments: typeof props.trip.segments }[] = []
@@ -379,35 +301,7 @@ function handleMouseEnter() {
 
       <!-- Trip summary — travels with the bar, then pins at the panel edge -->
       <div class="sticky left-3 w-fit" :style="{ maxWidth: `${barAreaWidth}px` }">
-        <!-- Trip meta -->
-        <div class="flex items-center gap-1.5 flex-wrap mt-1.5 pr-4 text-[11px] text-muted-foreground">
-          <span class="inline-flex items-center gap-1">
-            <component
-              :is="tripIcon"
-              class="size-3"
-              :style="{ color: getTravelModeColor(tripType.iconMode) }"
-            />
-            <span class="font-semibold text-foreground/80">{{ t(`directions.tripTypes.${tripType.key}`) }}</span>
-          </span>
-
-          <template v-if="trip.cost?.total">
-            <span class="size-0.5 rounded-full bg-muted-foreground/50" />
-            <span class="tabular-nums">${{ trip.cost.total.amount.toFixed(2) }}</span>
-          </template>
-
-          <template v-if="trip.co2Emissions != null && trip.co2Emissions > 0">
-            <span class="size-0.5 rounded-full bg-muted-foreground/50" />
-            <span class="tabular-nums">{{ formatCo2(trip.co2Emissions) }} CO₂</span>
-          </template>
-        </div>
-
-        <!-- First transit leg headsign — one quiet line instead of a card row -->
-        <div
-          v-if="firstTransitHeadsign"
-          class="mt-1 text-[11px] text-muted-foreground truncate pr-4"
-        >
-          {{ firstTransitHeadsign }}
-        </div>
+        <TripMeta :trip="trip" class="mt-1.5 pr-4" />
       </div>
     </div>
   </div>

--- a/web/src/components/directions/TripLegChips.vue
+++ b/web/src/components/directions/TripLegChips.vue
@@ -1,0 +1,60 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { ChevronRightIcon } from 'lucide-vue-next'
+import {
+  getTravelModeColor,
+  getTravelModeCssClass,
+} from '@/lib/directions/travel-mode-colors'
+import { getModeIcon, getSegmentIcon } from '@/lib/directions/travel-mode-icons'
+import { tripChips, type TripChip } from '@/lib/directions/trip-chips'
+import type { TripOption } from '@/types/directions.types'
+
+const props = defineProps<{ segments: TripOption['segments'] }>()
+
+const chips = computed(() => tripChips(props.segments))
+
+function badgeStyle(chip: Extract<TripChip, { kind: 'transit' }>) {
+  if (!chip.color) return {}
+  return { background: `#${chip.color}`, color: `#${chip.textColor ?? 'fff'}` }
+}
+</script>
+
+<template>
+  <div class="flex items-center gap-1 flex-wrap">
+    <template v-for="(chip, i) in chips" :key="i">
+      <ChevronRightIcon
+        v-if="i > 0"
+        class="size-3 shrink-0 text-muted-foreground/40"
+      />
+
+      <span v-if="chip.kind === 'transit'" class="inline-flex items-center gap-1">
+        <component
+          :is="getSegmentIcon('transit', chip.routeType)"
+          class="size-3.5 text-muted-foreground"
+        />
+        <span
+          v-if="chip.label"
+          class="rounded px-1.5 py-px text-[11px] font-bold leading-[1.35] text-white"
+          :class="!chip.color && getTravelModeCssClass('transit')"
+          :style="badgeStyle(chip)"
+        >
+          {{ chip.label }}
+        </span>
+      </span>
+
+      <span
+        v-else
+        class="inline-flex items-center gap-1 text-[11px] font-medium tabular-nums text-muted-foreground"
+      >
+        <component
+          :is="getModeIcon(chip.kind === 'walk' ? 'walking' : chip.mode)"
+          class="size-3.5"
+          :style="{
+            color: getTravelModeColor(chip.kind === 'walk' ? 'walking' : chip.mode),
+          }"
+        />
+        {{ chip.minutes }}<span class="text-[10px] font-normal">min</span>
+      </span>
+    </template>
+  </div>
+</template>

--- a/web/src/components/directions/TripList.vue
+++ b/web/src/components/directions/TripList.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import { useTripNavigation } from '@/composables/directions/useTripNavigation'
+import type { TripsResponse } from '@/types/directions.types'
+import TripListItem from './TripListItem.vue'
+import TripRows from './TripRows.vue'
+
+const props = defineProps<{ trips: TripsResponse }>()
+
+const { openTrip } = useTripNavigation(() => props.trips.request)
+</script>
+
+<template>
+  <TripRows :trips="trips.trips" v-slot="{ trip }">
+    <TripListItem :trip="trip" @click="openTrip" />
+  </TripRows>
+</template>

--- a/web/src/components/directions/TripListItem.vue
+++ b/web/src/components/directions/TripListItem.vue
@@ -1,0 +1,63 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useMapService } from '@/services/map/map.service'
+import { formatTimeRange } from '@/lib/directions/trip-display'
+import { formatDurationParts } from '@/lib/time-format'
+import type { TripOption } from '@/types/directions.types'
+import TripLegChips from './TripLegChips.vue'
+import TripMeta from './TripMeta.vue'
+
+interface Props {
+  trip: TripOption
+  isClickable?: boolean
+}
+
+const props = withDefaults(defineProps<Props>(), { isClickable: true })
+
+const emit = defineEmits<{ click: [trip: TripOption] }>()
+
+const mapService = useMapService()
+
+const duration = computed(
+  () => formatDurationParts(props.trip.summary.totalDuration).parts,
+)
+
+const timeRange = computed(() => {
+  const segments = props.trip.segments
+  if (!segments.length) return ''
+  return formatTimeRange(
+    new Date(segments[0].startTime),
+    new Date(segments[segments.length - 1].endTime),
+  )
+})
+
+function handleClick() {
+  if (props.isClickable) emit('click', props.trip)
+}
+</script>
+
+<template>
+  <div
+    class="px-4 py-3 space-y-2 transition-colors"
+    :class="{ 'cursor-pointer hover:bg-accent/50': isClickable }"
+    @click="handleClick"
+    @mouseenter="mapService.showTripOnHover(trip.id)"
+  >
+    <div class="flex items-baseline gap-2">
+      <span class="text-lg font-semibold leading-none tabular-nums">
+        <template v-for="(part, i) in duration" :key="i">
+          <span v-if="i > 0" class="inline-block w-1" />{{ part.value
+          }}<span class="text-xs font-medium ml-px">{{ part.unit }}</span>
+        </template>
+      </span>
+      <span class="flex-1" />
+      <span class="text-xs text-muted-foreground tabular-nums whitespace-nowrap">
+        {{ timeRange }}
+      </span>
+    </div>
+
+    <TripLegChips :segments="trip.segments" />
+
+    <TripMeta :trip="trip" show-distance />
+  </div>
+</template>

--- a/web/src/components/directions/TripMeta.vue
+++ b/web/src/components/directions/TripMeta.vue
@@ -1,0 +1,79 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useUnits } from '@/composables/useUnits'
+import { getTravelModeColor } from '@/lib/directions/travel-mode-colors'
+import { getModeIcon, getSegmentIcon } from '@/lib/directions/travel-mode-icons'
+import { formatCo2 } from '@/lib/directions/trip-display'
+import { longestTransitSegment, tripType } from '@/lib/directions/trip-type'
+import type { TripOption } from '@/types/directions.types'
+
+interface Props {
+  trip: TripOption
+  /** List view has no duration sidebar, so distance rides along here. */
+  showDistance?: boolean
+}
+
+const props = defineProps<Props>()
+
+const { t } = useI18n()
+const { formatDistance } = useUnits()
+
+const type = computed(() => tripType(props.trip.segments))
+
+const icon = computed(() => {
+  if (type.value.iconMode !== 'transit') return getModeIcon(type.value.iconMode)
+  const seg = longestTransitSegment(props.trip.segments)
+  return getSegmentIcon('transit', seg?.routeType)
+})
+
+/** "Q · toward Coney Island" — merged interchangeable legs read "4 or 5 · toward …". */
+const headsign = computed(() => {
+  const seg = props.trip.segments.find(
+    s => s.mode === 'transit' && (s as { headsign?: string }).headsign,
+  ) as { headsign?: string; lineName?: string; routeOptions?: { shortName?: string }[] } | undefined
+  if (!seg) return null
+  const options = seg.routeOptions ?? []
+  const line =
+    options.length > 1
+      ? options.map(o => o.shortName).filter(Boolean).join(` ${t('directions.or')} `)
+      : seg.lineName
+  return `${line ? line + ' · ' : ''}${t('directions.toward', { headsign: seg.headsign })}`
+})
+</script>
+
+<template>
+  <div>
+    <div class="flex items-center gap-1.5 flex-wrap text-[11px] text-muted-foreground">
+      <span class="inline-flex items-center gap-1">
+        <component
+          :is="icon"
+          class="size-3"
+          :style="{ color: getTravelModeColor(type.iconMode) }"
+        />
+        <span class="font-semibold text-foreground/80">
+          {{ t(`directions.tripTypes.${type.key}`) }}
+        </span>
+      </span>
+
+      <template v-if="showDistance">
+        <span class="size-0.5 rounded-full bg-muted-foreground/50" />
+        <span class="tabular-nums">{{ formatDistance(trip.summary.totalDistance) }}</span>
+      </template>
+
+      <template v-if="trip.cost?.total">
+        <span class="size-0.5 rounded-full bg-muted-foreground/50" />
+        <span class="tabular-nums">${{ trip.cost.total.amount.toFixed(2) }}</span>
+      </template>
+
+      <template v-if="trip.co2Emissions != null && trip.co2Emissions > 0">
+        <span class="size-0.5 rounded-full bg-muted-foreground/50" />
+        <span class="tabular-nums">{{ formatCo2(trip.co2Emissions) }} CO₂</span>
+      </template>
+    </div>
+
+    <div v-if="headsign" class="mt-1 text-[11px] text-muted-foreground truncate">
+      {{ headsign }}
+    </div>
+  </div>
+</template>

--- a/web/src/components/directions/TripRows.vue
+++ b/web/src/components/directions/TripRows.vue
@@ -1,0 +1,56 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import { byRank } from '@/lib/directions/trip-display'
+import type { TripOption } from '@/types/directions.types'
+
+const props = defineProps<{ trips: TripOption[] }>()
+
+const ranked = computed(() => byRank(props.trips))
+</script>
+
+<template>
+  <!-- Staggered entrance as a fresh set of suggestions loads -->
+  <TransitionGroup name="trip" tag="div" class="flex flex-col" appear>
+    <div
+      v-for="(trip, index) in ranked"
+      :key="trip.id || index"
+      :style="{ '--trip-delay': `${Math.min(index, 8) * 45}ms` }"
+    >
+      <slot :trip="trip" :index="index" />
+      <div
+        v-if="index < ranked.length - 1"
+        class="border-b border-border/50 mx-4"
+      />
+    </div>
+  </TransitionGroup>
+
+  <div v-if="!ranked.length" class="text-center py-8 text-muted-foreground">
+    <p class="text-sm">No trips available</p>
+  </div>
+</template>
+
+<style scoped>
+/* Each row fades and lifts in, offset by its index via the inline
+   --trip-delay. `appear` replays it whenever a new result set mounts. */
+.trip-enter-active {
+  transition:
+    opacity 0.4s ease,
+    transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
+  transition-delay: var(--trip-delay, 0ms);
+}
+
+.trip-enter-from {
+  opacity: 0;
+  transform: translateY(10px);
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .trip-enter-active {
+    transition: opacity 0.2s ease;
+    transition-delay: 0ms;
+  }
+  .trip-enter-from {
+    transform: none;
+  }
+}
+</style>

--- a/web/src/components/directions/TripsList.vue
+++ b/web/src/components/directions/TripsList.vue
@@ -1,13 +1,11 @@
 <script setup lang="ts">
 import { computed, ref, onMounted, onUnmounted, nextTick, watch } from 'vue'
 import dayjs from 'dayjs'
-import { useRouter } from 'vue-router'
-import type { TripsResponse, TripOption } from '@/types/directions.types'
+import type { TripsResponse } from '@/types/directions.types'
 import TripItem from './TripItem.vue'
-import { useDirectionsStore } from '@/stores/directions.store'
-import { serializeDirectionsQuery, shareableWaypointId } from '@/lib/directions/directions-url'
-import { tripSignature } from '@/lib/directions/trip-signature'
-import { api } from '@/lib/api'
+import TripRows from './TripRows.vue'
+import { useTripNavigation } from '@/composables/directions/useTripNavigation'
+import { byRank } from '@/lib/directions/trip-display'
 
 interface Props {
   trips: TripsResponse
@@ -18,8 +16,6 @@ interface Props {
 const props = withDefaults(defineProps<Props>(), {
   stickyTop: 0,
 })
-const router = useRouter()
-const directionsStore = useDirectionsStore()
 
 const MIN_PX_PER_MIN = 1.5
 const MAX_PX_PER_MIN = 50
@@ -66,9 +62,7 @@ onUnmounted(() => {
   observer?.disconnect()
 })
 
-const sortedTrips = computed(() => {
-  return [...props.trips.trips].sort((a, b) => a.rank - b.rank)
-})
+const sortedTrips = computed(() => byRank(props.trips.trips))
 
 const actualStart = computed(() => {
   const starts = props.trips.trips.flatMap(t => t.segments.map(s => new Date(s.startTime).getTime()))
@@ -178,44 +172,7 @@ const timeTicks = computed(() => {
   return result
 })
 
-function navigateToTripDetail(trip: TripOption) {
-  // The trip URL carries the full planning inputs (same wp/mode/sort/depart
-  // format as the directions URL) plus the trip's stable signature, so a
-  // refresh or a shared link can re-plan and find this same trip again.
-  const query = {
-    ...serializeDirectionsQuery({
-      waypoints: props.trips.request.waypoints.map((wp) => ({
-        lat: wp.coordinate.lat,
-        lng: wp.coordinate.lng,
-        label: wp.name || undefined,
-        id: shareableWaypointId(wp.place),
-      })),
-      mode: directionsStore.selectedMode,
-      sort: directionsStore.sortPreference || undefined,
-      depart: directionsStore.departureTime || undefined,
-    }),
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    sig: tripSignature((trip as any).segments),
-  }
-  router.push({ name: 'trip', params: { id: trip.id }, query })
-
-  // Persist a server-side snapshot in the background and slip its token
-  // into the URL — the snapshot makes refresh and cross-device shares
-  // exact, independent of schedule drift. Best-effort: the sig/re-plan
-  // path still recovers the trip if this fails.
-  api
-    .post('/directions/trips', { request: query, trip })
-    .then(({ data }) => {
-      router
-        .replace({
-          name: 'trip',
-          params: { id: trip.id },
-          query: { ...query, pt: data.id },
-        })
-        .catch(() => {})
-    })
-    .catch(() => {})
-}
+const { openTrip } = useTripNavigation(() => props.trips.request)
 </script>
 
 <template>
@@ -265,19 +222,14 @@ function navigateToTripDetail(trip: TripOption) {
       class="trip-scroll overflow-x-auto overflow-y-hidden overscroll-x-contain pb-3 -mb-3"
       @scroll.passive="onScroll"
     >
-      <!-- Trip rows — staggered entrance as a fresh set of suggestions loads -->
-      <TransitionGroup
-        name="trip"
-        tag="div"
-        class="flex flex-col"
-        :style="{ minWidth: `${timelineWidth + sidebarWidth}px` }"
-        appear
+      <div
+        :style="{
+          minWidth: sortedTrips.length
+            ? `${timelineWidth + sidebarWidth}px`
+            : undefined,
+        }"
       >
-        <div
-          v-for="(trip, tripIndex) in sortedTrips"
-          :key="trip.id || tripIndex"
-          :style="{ '--trip-delay': `${Math.min(tripIndex, 8) * 45}ms` }"
-        >
+        <TripRows :trips="trips.trips" v-slot="{ trip }">
           <TripItem
             :trip="trip"
             :trip-request="trips.request"
@@ -285,18 +237,10 @@ function navigateToTripDetail(trip: TripOption) {
             :px-per-minute="pxPerMinute"
             :sidebar-width="sidebarWidth"
             :bar-area-width="barAreaWidth"
-            @click="navigateToTripDetail"
+            @click="openTrip"
           />
-          <div v-if="tripIndex < sortedTrips.length - 1" class="border-b border-border/50 mx-4" />
-        </div>
-      </TransitionGroup>
-    </div>
-
-    <div
-      v-if="sortedTrips.length === 0"
-      class="text-center py-8 text-muted-foreground"
-    >
-      <p class="text-sm">No trips available</p>
+        </TripRows>
+      </div>
     </div>
   </div>
 </template>
@@ -307,30 +251,5 @@ function navigateToTripDetail(trip: TripOption) {
 }
 .trip-scroll::-webkit-scrollbar {
   display: none;
-}
-
-/* Staggered entrance: each row fades and lifts in, offset by its index via
-   the inline --trip-delay. `appear` replays it whenever a new result set
-   mounts (new trip ids). */
-.trip-enter-active {
-  transition:
-    opacity 0.4s ease,
-    transform 0.4s cubic-bezier(0.22, 1, 0.36, 1);
-  transition-delay: var(--trip-delay, 0ms);
-}
-
-.trip-enter-from {
-  opacity: 0;
-  transform: translateY(10px);
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .trip-enter-active {
-    transition: opacity 0.2s ease;
-    transition-delay: 0ms;
-  }
-  .trip-enter-from {
-    transform: none;
-  }
 }
 </style>

--- a/web/src/composables/directions/useTripNavigation.ts
+++ b/web/src/composables/directions/useTripNavigation.ts
@@ -1,0 +1,59 @@
+import { useRouter } from 'vue-router'
+import { api } from '@/lib/api'
+import {
+  serializeDirectionsQuery,
+  shareableWaypointId,
+} from '@/lib/directions/directions-url'
+import { tripSignature } from '@/lib/directions/trip-signature'
+import { useDirectionsStore } from '@/stores/directions.store'
+import type { TripOption, TripsResponse } from '@/types/directions.types'
+
+/**
+ * Opening a suggestion from any of the result views.
+ *
+ * `request` is a getter so the caller can pass a prop without it going stale.
+ */
+export function useTripNavigation(request: () => TripsResponse['request']) {
+  const router = useRouter()
+  const directionsStore = useDirectionsStore()
+
+  function openTrip(trip: TripOption) {
+    // The trip URL carries the full planning inputs (same wp/mode/sort/depart
+    // format as the directions URL) plus the trip's stable signature, so a
+    // refresh or a shared link can re-plan and find this same trip again.
+    const query = {
+      ...serializeDirectionsQuery({
+        waypoints: request().waypoints.map(wp => ({
+          lat: wp.coordinate.lat,
+          lng: wp.coordinate.lng,
+          label: wp.name || undefined,
+          id: shareableWaypointId(wp.place),
+        })),
+        mode: directionsStore.selectedMode,
+        sort: directionsStore.sortPreference || undefined,
+        depart: directionsStore.departureTime || undefined,
+      }),
+      sig: tripSignature(trip.segments),
+    }
+    router.push({ name: 'trip', params: { id: trip.id }, query })
+
+    // Persist a server-side snapshot in the background and slip its token
+    // into the URL — the snapshot makes refresh and cross-device shares
+    // exact, independent of schedule drift. Best-effort: the sig/re-plan
+    // path still recovers the trip if this fails.
+    api
+      .post('/directions/trips', { request: query, trip })
+      .then(({ data }) => {
+        router
+          .replace({
+            name: 'trip',
+            params: { id: trip.id },
+            query: { ...query, pt: data.id },
+          })
+          .catch(() => {})
+      })
+      .catch(() => {})
+  }
+
+  return { openTrip }
+}

--- a/web/src/lib/directions/trip-chips.test.ts
+++ b/web/src/lib/directions/trip-chips.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { tripChips } from './trip-chips'
+
+describe('tripChips', () => {
+  it('renders one chip per leg, in order', () => {
+    const chips = tripChips([
+      { mode: 'walking', duration: 300 },
+      { mode: 'transit', lineName: 'B45', routeType: 'bus', lineColor: '0039A6' },
+      { mode: 'walking', duration: 120 },
+    ])
+    expect(chips).toEqual([
+      { kind: 'walk', minutes: 5 },
+      {
+        kind: 'transit',
+        label: 'B45',
+        routeType: 'bus',
+        color: '0039A6',
+        textColor: undefined,
+      },
+      { kind: 'walk', minutes: 2 },
+    ])
+  })
+
+  it('counts only the moving part of a walk that absorbed a wait', () => {
+    const chips = tripChips([
+      { mode: 'walking', duration: 420, waitSeconds: 165 },
+    ])
+    expect(chips).toEqual([{ kind: 'walk', minutes: 4 }])
+  })
+
+  it('drops a walk too short to round to a minute', () => {
+    const chips = tripChips([
+      { mode: 'walking', duration: 20 },
+      { mode: 'transit', lineName: 'Q', routeType: 'subway' },
+    ])
+    expect(chips).toHaveLength(1)
+    expect(chips[0].kind).toBe('transit')
+  })
+
+  it('merges adjacent walks into one chip', () => {
+    const chips = tripChips([
+      { mode: 'walking', duration: 300 },
+      { mode: 'walking', duration: 180 },
+    ])
+    expect(chips).toEqual([{ kind: 'walk', minutes: 8 }])
+  })
+
+  it('gives a transit leg with no line name an unlabelled chip', () => {
+    const chips = tripChips([{ mode: 'transit', routeType: 'ferry' }])
+    expect(chips[0]).toMatchObject({ kind: 'transit', label: null })
+  })
+
+  it('carries minutes on vehicle legs', () => {
+    const chips = tripChips([
+      { mode: 'cycling', duration: 900 },
+      { mode: 'driving', duration: 600 },
+    ])
+    expect(chips).toEqual([
+      { kind: 'vehicle', mode: 'cycling', minutes: 15 },
+      { kind: 'vehicle', mode: 'driving', minutes: 10 },
+    ])
+  })
+})

--- a/web/src/lib/directions/trip-chips.ts
+++ b/web/src/lib/directions/trip-chips.ts
@@ -1,0 +1,63 @@
+/**
+ * The leg strip under a trip in list view — "walk 5 › B45 › walk 2".
+ *
+ * One chip per travelled leg, in order. Walking chips carry minutes and
+ * absorb the wait folded into them; vehicle legs carry their line badge.
+ */
+import { movingDuration } from './trip-display'
+
+export interface ChipSegment {
+  mode: string
+  duration?: number
+  waitSeconds?: number
+  routeType?: string
+  lineName?: string | null
+  lineColor?: string | null
+  lineTextColor?: string | null
+}
+
+export type TripChip =
+  | { kind: 'walk'; minutes: number }
+  | {
+      kind: 'transit'
+      label: string | null
+      routeType?: string
+      color?: string
+      textColor?: string
+    }
+  | { kind: 'vehicle'; mode: string; minutes: number }
+
+export function tripChips(segments: ChipSegment[]): TripChip[] {
+  const chips: TripChip[] = []
+
+  for (const seg of segments) {
+    if (seg.mode === 'walking') {
+      const minutes = Math.round(movingDuration(seg) / 60)
+      // A walk that rounds to nothing is a doorway, not a leg.
+      if (minutes < 1) continue
+      const last = chips[chips.length - 1]
+      if (last?.kind === 'walk') last.minutes += minutes
+      else chips.push({ kind: 'walk', minutes })
+      continue
+    }
+
+    if (seg.mode === 'transit') {
+      chips.push({
+        kind: 'transit',
+        label: seg.lineName || null,
+        routeType: seg.routeType,
+        color: seg.lineColor || undefined,
+        textColor: seg.lineTextColor || undefined,
+      })
+      continue
+    }
+
+    chips.push({
+      kind: 'vehicle',
+      mode: seg.mode,
+      minutes: Math.round(movingDuration(seg) / 60),
+    })
+  }
+
+  return chips
+}

--- a/web/src/lib/directions/trip-display.test.ts
+++ b/web/src/lib/directions/trip-display.test.ts
@@ -3,6 +3,7 @@ import {
   depCountdown,
   entrancePhrase,
   formatCo2,
+  formatTimeRange,
   joinStatus,
   modeColor,
   movingDuration,
@@ -128,5 +129,23 @@ describe('rail paint', () => {
 
   test('falls back for an unknown mode', () => {
     expect(modeColor('teleport')).toBe('bg-parchment-500')
+  })
+})
+
+describe('formatTimeRange', () => {
+  test('drops the shared am/pm marker from the start', () => {
+    const range = formatTimeRange(
+      new Date('2026-06-12T15:30:00'),
+      new Date('2026-06-12T15:48:00'),
+    )
+    expect(range).toBe('3:30 – 3:48 PM')
+  })
+
+  test('keeps both markers across noon', () => {
+    const range = formatTimeRange(
+      new Date('2026-06-12T11:50:00'),
+      new Date('2026-06-12T12:10:00'),
+    )
+    expect(range).toBe('11:50 AM – 12:10 PM')
   })
 })

--- a/web/src/lib/directions/trip-display.ts
+++ b/web/src/lib/directions/trip-display.ts
@@ -31,6 +31,21 @@ export function formatClockCompact(date: Date): string {
     .trim()
 }
 
+/** Clock time with its am/pm marker — "3:48 PM". */
+export function formatClock(date: Date): string {
+  return date.toLocaleTimeString(undefined, { hour: 'numeric', minute: '2-digit' })
+}
+
+/**
+ * "3:30 – 3:48 PM" for a trip's departure and arrival. The am/pm marker is
+ * dropped from the start only when both ends share it, so a trip over noon
+ * or midnight still reads unambiguously.
+ */
+export function formatTimeRange(start: Date, end: Date): string {
+  const samePeriod = start.getHours() < 12 === end.getHours() < 12
+  return `${samePeriod ? formatClockCompact(start) : formatClock(start)} – ${formatClock(end)}`
+}
+
 /**
  * Lead line and clock sub-line for a departure chip. Departure is detected by
  * the sign of the delta, not the rounded minute, so the last thirty seconds
@@ -143,4 +158,9 @@ export function railStyleAt(
     return lineColor ? { background: `#${lineColor}` } : {}
   }
   return {}
+}
+
+/** Suggestions are shown in the planner's ranking, best first. */
+export function byRank<T extends { rank: number }>(trips: readonly T[]): T[] {
+  return [...trips].sort((a, b) => a.rank - b.rank)
 }

--- a/web/src/lib/directions/trip-type.test.ts
+++ b/web/src/lib/directions/trip-type.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect } from 'vitest'
+import { longestTransitSegment, tripType } from './trip-type'
+
+describe('tripType', () => {
+  it('labels by combination, not by the longest mode', () => {
+    expect(
+      tripType([
+        { mode: 'walking', duration: 600 },
+        { mode: 'transit', duration: 400 },
+        { mode: 'walking', duration: 500 },
+      ]).key,
+    ).toBe('transitWalking')
+  })
+
+  it('treats short access walks as part of riding transit', () => {
+    expect(
+      tripType([
+        { mode: 'walking', duration: 120 },
+        { mode: 'transit', duration: 1500 },
+        { mode: 'walking', duration: 100 },
+      ]).key,
+    ).toBe('transit')
+  })
+
+  it('excludes an absorbed wait from the walking total', () => {
+    // 960s of walk segments, but 300s of it is waiting — under the threshold.
+    expect(
+      tripType([
+        { mode: 'walking', duration: 960, waitSeconds: 300 },
+        { mode: 'transit', duration: 1500 },
+      ]).key,
+    ).toBe('transit')
+  })
+
+  it('names driving to transit Park & Ride', () => {
+    expect(
+      tripType([
+        { mode: 'driving', duration: 600 },
+        { mode: 'transit', duration: 900 },
+      ]).key,
+    ).toBe('parkAndRide')
+  })
+
+  it('distinguishes shared mobility from owned vehicles', () => {
+    expect(
+      tripType([
+        { mode: 'cycling', duration: 900, sharedMobilityDetails: { vehicleType: 'bike' } },
+      ]).key,
+    ).toBe('bikeshare')
+    expect(
+      tripType([
+        { mode: 'cycling', duration: 900, sharedMobilityDetails: { vehicleType: 'scooter' } },
+      ]).key,
+    ).toBe('scootershare')
+    expect(tripType([{ mode: 'cycling', duration: 900 }]).key).toBe('cycling')
+  })
+
+  it('takes its icon from transit whenever transit is involved', () => {
+    expect(
+      tripType([
+        { mode: 'transit', duration: 900 },
+        { mode: 'cycling', duration: 300, sharedMobilityDetails: { vehicleType: 'bike' } },
+      ]),
+    ).toEqual({ key: 'transitBikeShare', iconMode: 'transit' })
+  })
+})
+
+describe('longestTransitSegment', () => {
+  it('picks the longest ride, ignoring other modes', () => {
+    const seg = longestTransitSegment([
+      { mode: 'walking', duration: 9999 },
+      { mode: 'transit', duration: 300 },
+      { mode: 'transit', duration: 800 },
+    ])
+    expect(seg?.duration).toBe(800)
+  })
+
+  it('is null when nothing is ridden', () => {
+    expect(longestTransitSegment([{ mode: 'walking', duration: 300 }])).toBeNull()
+  })
+})

--- a/web/src/lib/directions/trip-type.ts
+++ b/web/src/lib/directions/trip-type.ts
@@ -1,0 +1,85 @@
+/**
+ * Trip type — the combination pattern, not the longest mode. A subway trip
+ * with two long walks is still a transit trip ("Transit & Walking"), a drive
+ * to the station is "Park & Ride". Mirrors the trip-combination taxonomy the
+ * planner generates from.
+ */
+import { movingDuration } from './trip-display'
+
+export interface TripTypeSegment {
+  mode: string
+  duration?: number
+  waitSeconds?: number
+  routeType?: string
+  sharedMobilityDetails?: { vehicleType?: string } | null
+}
+
+export interface TripType {
+  /** i18n key under `directions.tripTypes` */
+  key: string
+  /** Mode the type's icon comes from */
+  iconMode: string
+}
+
+/**
+ * Walking below this in motion is access or transfer, not a journey of its
+ * own — a transit trip stays "Transit" rather than "Transit & Walking".
+ */
+const SIGNIFICANT_WALK_SEC = 900
+
+function sharedKind(segments: TripTypeSegment[]): 'scooter' | 'bike' | null {
+  const shared = segments.find(s => s.sharedMobilityDetails)
+  if (!shared) return null
+  return shared.sharedMobilityDetails?.vehicleType === 'scooter'
+    ? 'scooter'
+    : 'bike'
+}
+
+export function tripType(segments: TripTypeSegment[]): TripType {
+  const has = (m: string) => segments.some(s => s.mode === m)
+  const shared = sharedKind(segments)
+
+  if (!has('transit')) {
+    if (shared) {
+      return {
+        key: shared === 'scooter' ? 'scootershare' : 'bikeshare',
+        iconMode: 'cycling',
+      }
+    }
+    if (has('rideshare')) return { key: 'rideshare', iconMode: 'rideshare' }
+    if (has('driving')) return { key: 'driving', iconMode: 'driving' }
+    if (has('cycling')) return { key: 'cycling', iconMode: 'cycling' }
+    return { key: 'walking', iconMode: 'walking' }
+  }
+
+  if (has('driving')) return { key: 'parkAndRide', iconMode: 'transit' }
+  if (has('rideshare')) return { key: 'transitRideshare', iconMode: 'transit' }
+  if (shared) {
+    return {
+      key: shared === 'scooter' ? 'transitScooter' : 'transitBikeShare',
+      iconMode: 'transit',
+    }
+  }
+  if (has('cycling')) return { key: 'transitBike', iconMode: 'transit' }
+
+  const walkSec = segments.reduce(
+    (sum, s) => sum + (s.mode === 'walking' ? movingDuration(s) : 0),
+    0,
+  )
+  return {
+    key: walkSec >= SIGNIFICANT_WALK_SEC ? 'transitWalking' : 'transit',
+    iconMode: 'transit',
+  }
+}
+
+/** The transit segment the trip's icon should represent. */
+export function longestTransitSegment<T extends { mode: string; duration: number }>(
+  segments: T[],
+): T | null {
+  let longest: T | null = null
+  for (const seg of segments) {
+    if (seg.mode !== 'transit') continue
+    if (!longest || seg.duration > longest.duration) longest = seg
+  }
+  return longest
+}

--- a/web/src/stores/directions.store.ts
+++ b/web/src/stores/directions.store.ts
@@ -2,7 +2,7 @@ import { ref, computed, watch } from 'vue'
 import { defineStore } from 'pinia'
 import { Directions, TripsResponse } from '@/types/directions.types'
 import { Waypoint } from '@/types/map.types'
-import { RoutingPreferences, SelectedMode, SortPreference } from '@/types/multimodal.types'
+import { RoutingPreferences, SelectedMode, SortPreference, TripView } from '@/types/multimodal.types'
 import { getTimezoneWarning, type TimezoneWarning } from '@/lib/timezone-warning'
 
 // Rideshare has no working integration yet, so the mode is hidden everywhere it
@@ -141,6 +141,12 @@ export const useDirectionsStore = defineStore('directions', () => {
   }
 
   const selectedMode = ref<SelectedMode>(loadSelectedMode())
+
+  const loadTripView = (): TripView =>
+    localStorage.getItem('tripView') === 'list' ? 'list' : 'timeline'
+
+  /** How suggestions are drawn: the time-scaled timeline, or a plain list. */
+  const tripView = ref<TripView>(loadTripView())
   const sortPreference = ref<SortPreference | null>(null)
   const departureTime = ref<string | null>(null) // ISO 8601 or null for "now"
   const isLoading = ref(false)
@@ -192,6 +198,10 @@ export const useDirectionsStore = defineStore('directions', () => {
   // Watch and save selected mode to localStorage
   watch(selectedMode, newVal => {
     localStorage.setItem('selectedMode', newVal)
+  })
+
+  watch(tripView, newVal => {
+    localStorage.setItem('tripView', newVal)
   })
 
   function setDirections(directions_: Directions) {
@@ -271,6 +281,7 @@ export const useDirectionsStore = defineStore('directions', () => {
     trips,
     waypoints,
     selectedMode,
+    tripView,
     sortPreference,
     departureTime,
     isLoading,

--- a/web/src/types/multimodal.types.ts
+++ b/web/src/types/multimodal.types.ts
@@ -30,6 +30,9 @@ export type SelectedMode =
   | 'transit'
   | 'rideshare'
 
+/** How trip suggestions are laid out in the results panel. */
+export type TripView = 'timeline' | 'list'
+
 export type SortPreference =
   | 'shortest'
   | 'earliest_arrival'

--- a/web/src/views/directions/Directions.vue
+++ b/web/src/views/directions/Directions.vue
@@ -10,7 +10,9 @@ import {
   BusFrontIcon,
   CarFrontIcon,
   CarTaxiFrontIcon,
+  ChartNoAxesGanttIcon,
   ClockIcon,
+  ListIcon,
   FootprintsIcon,
   ShuffleIcon,
   SlidersHorizontalIcon,
@@ -22,6 +24,7 @@ import { useDirectionsStore, RIDESHARE_ENABLED } from '@/stores/directions.store
 import { storeToRefs } from 'pinia'
 import WaypointInput from '@/components/directions/WaypointInput.vue'
 import TripsList from '@/components/directions/TripsList.vue'
+import TripList from '@/components/directions/TripList.vue'
 import RoutingPreferences from '@/components/directions/preferences/RoutingPreferences.vue'
 import DirectionsLoading from '@/components/directions/DirectionsLoading.vue'
 import { useElementSize } from '@vueuse/core'
@@ -48,8 +51,12 @@ const route = useRoute()
 const directionsService = useDirectionsService()
 const directionsStore = useDirectionsStore()
 
-const { waypoints, trips, selectedMode, departureTime, sortPreference, isLoading, timezoneWarning } =
+const { waypoints, trips, selectedMode, departureTime, sortPreference, tripView, isLoading, timezoneWarning } =
   storeToRefs(directionsStore)
+
+function toggleTripView() {
+  tripView.value = tripView.value === 'timeline' ? 'list' : 'timeline'
+}
 
 const showPreferences = ref(false)
 
@@ -290,6 +297,17 @@ useMapListener(
           </SelectContent>
         </Select>
 
+        <Button
+          variant="outline"
+          size="sm"
+          class="h-7 w-7 p-0 shrink-0"
+          :title="tripView === 'timeline' ? 'Show as a list' : 'Show as a timeline'"
+          @click="toggleTripView"
+        >
+          <ListIcon v-if="tripView === 'timeline'" class="size-3.5" />
+          <ChartNoAxesGanttIcon v-else class="size-3.5" />
+        </Button>
+
         <ResponsivePopover
           v-model:open="showPreferences"
           side="bottom"
@@ -348,13 +366,16 @@ useMapListener(
       <DirectionsLoading />
     </div>
 
-    <!-- Trips results (full-bleed timeline) -->
-    <TripsList
-      v-else-if="trips"
-      :trips="trips"
-      :sticky-top="controlsHeight"
-      class="-mx-3"
-    />
+    <!-- Trips results — the time-scaled timeline, or a plain list -->
+    <template v-else-if="trips">
+      <TripsList
+        v-if="tripView === 'timeline'"
+        :trips="trips"
+        :sticky-top="controlsHeight"
+        class="-mx-3"
+      />
+      <TripList v-else :trips="trips" class="-mx-3" />
+    </template>
 
     <!-- No results -->
     <div


### PR DESCRIPTION
Adds a second way to read trip suggestions: a classic Google/Apple Maps style list, alongside the existing timeline. A toggle next to the sort control switches between them, and the choice is remembered.

Each list row shows the trip's duration, its departure–arrival window, a strip of leg chips (walk minutes › route badge › walk minutes), and the same type / distance / cost / CO₂ meta line the timeline shows.

**Shared instead of duplicated**

The two views were going to restate a lot of the timeline's logic, so it moved out first (first commit, no behaviour change):

* `lib/directions/trip-type.ts` — the trip-combination taxonomy, previously an untyped computed inside `TripItem.vue`
* `lib/directions/trip-chips.ts` — the leg strip
* `TripMeta.vue` — the type / cost / CO₂ line and the headsign line, now rendered by both views
* `TripRows.vue` — ranking, dividers and the staggered entrance
* `composables/directions/useTripNavigation.ts` — opening a suggestion, including the snapshot POST
* `formatTimeRange` in `trip-display.ts`, which keeps both am/pm markers when a trip crosses noon

`TripItem.vue` also loses its duplicate `formatCo2`, which already lived in `trip-display.ts`.

Tests cover the extracted rules: trip type (including that an absorbed wait doesn't count as walking), chip building, and the time range.