### PR TITLE
Park the bike before boarding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 
 ### Fixed
 
+* Trips that ride a bike to transit now park it at a real bike rack and walk
+  you in, instead of leaving the bike unaccounted for once you board.
+
 ## [0.11.5] - 2026-09-09
 
 ### Added

--- a/server/src/services/trip.service.test.ts
+++ b/server/src/services/trip.service.test.ts
@@ -1626,6 +1626,115 @@ describe('TripService — scoring', () => {
     })
   })
 
+  // ── Bike parking before boarding ────────────────────────────────────────────
+
+  describe('bike parking before boarding transit', () => {
+    const stationRack = {
+      geometry: { value: { center: { lat: 35.2103, lng: -80.8496 } } },
+      name: { value: 'Stop A bike rack' },
+      tags: {},
+    }
+    const bikeVehicle = {
+      id: 'bike-1',
+      type: 'bike' as const,
+      location: { lat: 35.209, lng: -80.861 },
+    }
+
+    /** MOTIS rides the bike to Stop A and says nothing about parking it. */
+    function mockBikeAccessItinerary() {
+      mockGetIntermodalRoute.mockImplementation(async (req: any) => {
+        if (req.preTransitModes?.includes('BIKE')) {
+          const itinerary = makeTransitItinerary()
+          itinerary.legs[0] = {
+            ...itinerary.legs[0],
+            mode: 'BIKE',
+            distance: 2000,
+            duration: 600,
+            startTime: '2026-01-15T07:55:00Z',
+            endTime: '2026-01-15T08:05:00Z',
+          }
+          return { itineraries: [itinerary], metadata: { searchWindow: 3600 } }
+        }
+        return {
+          itineraries: [makeTransitItinerary()],
+          metadata: { searchWindow: 3600 },
+        }
+      })
+    }
+
+    function bikeTransitTrip(response: any) {
+      return response.trips.find(
+        (t: any) =>
+          t.trip.segments.some((s: any) => s.mode === 'biking') &&
+          t.trip.segments.some((s: any) => s.mode === 'transit'),
+      )
+    }
+
+    const plan = (useKnownParkingLocations: boolean) =>
+      tripService.planTrip({
+        waypoints: [CHARLOTTE_ORIGIN, CHARLOTTE_DEST],
+        selectedMode: 'transit',
+        availableVehicles: [bikeVehicle],
+        routingPreferences: { useKnownParkingLocations },
+        preferredDepartureTime: '2026-01-15T08:00:00Z',
+      })
+
+    test('the ride ends at a rack and walks in to the stop', async () => {
+      mockBikeAccessItinerary()
+      mockSearchByCategory.mockImplementation(async () => [stationRack])
+      mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(300, 240))
+
+      const trip = bikeTransitTrip(await plan(true))
+      expect(trip).toBeDefined()
+
+      const segs = trip!.trip.segments
+      const rideIdx = segs.findIndex((s: any) => s.mode === 'biking')
+      expect(segs[rideIdx].end.label).toBe('Stop A bike rack')
+      expect(segs[rideIdx + 1].mode).toBe('walking')
+      expect(segs[rideIdx + 2].mode).toBe('transit')
+
+      expect(trip!.trip.parkedVehicles?.[0].location).toEqual(
+        stationRack.geometry.value.center,
+      )
+    })
+
+    test('locks the bike, then walks in without missing the boarding', async () => {
+      mockBikeAccessItinerary()
+      mockSearchByCategory.mockImplementation(async () => [stationRack])
+      mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(300, 240))
+
+      const segs = bikeTransitTrip(await plan(true))!.trip.segments
+      const rideIdx = segs.findIndex((s: any) => s.mode === 'biking')
+      const ride = segs[rideIdx]
+      const walkIn = segs[rideIdx + 1]
+      const board = segs.find((s: any) => s.mode === 'transit')!
+
+      const at = (t: string) => new Date(t).getTime()
+      expect(at(walkIn.startTime) - at(ride.endTime)).toBe(60_000)
+      expect(at(walkIn.endTime)).toBeLessThanOrEqual(at(board.startTime))
+    })
+
+    test('drops the trip when the stop has no rack', async () => {
+      mockBikeAccessItinerary()
+      mockSearchByCategory.mockImplementation(async () => [])
+      mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(300, 240))
+
+      expect(bikeTransitTrip(await plan(true))).toBeUndefined()
+    })
+
+    test('leaves the ride alone when known parking locations are off', async () => {
+      mockBikeAccessItinerary()
+      mockSearchByCategory.mockImplementation(async () => [stationRack])
+      mockGetRoute.mockImplementation(async () => makeBasicWalkRoute(300, 240))
+
+      const trip = bikeTransitTrip(await plan(false))
+      expect(trip).toBeDefined()
+      const segs = trip!.trip.segments
+      const rideIdx = segs.findIndex((s: any) => s.mode === 'biking')
+      expect(segs[rideIdx + 1].mode).toBe('transit')
+    })
+  })
+
   // ── Parking-aware driving ───────────────────────────────────────────────────
 
   describe('parking-aware driving', () => {

--- a/server/src/services/trip.service.ts
+++ b/server/src/services/trip.service.ts
@@ -2250,6 +2250,7 @@ export class TripService {
         from, to, startTime, dataSources, preferences,
       )
 
+      const kept: TripResponse[] = []
       for (const trip of trips) {
         // Tag the MOTIS ride leg with the user's vehicle
         const rideSeg = trip.segments.find(s => s.mode === rideMode)
@@ -2282,6 +2283,13 @@ export class TripService {
           }
         }
 
+        // A bike ridden to the station has to be left somewhere. Gated on the
+        // same preference as parking-aware driving, which is what asks for
+        // real parking to be routed to at all.
+        if (rideMode === 'biking' && preferences?.useKnownParkingLocations) {
+          if (!(await this.parkBikeBeforeBoarding(trip, vehicle, preferences))) continue
+        }
+
         if (walkToVehicle) {
           // Back-time the walk from the itinerary's first leg. MOTIS departs
           // no earlier than queryTime (= startTime + walk duration), so the
@@ -2304,13 +2312,176 @@ export class TripService {
             (trip.tripStats.totalWalkingDistance ?? 0) + walk.distance
           trip.earliestStartTime = walk.startTime
         }
+
+        kept.push(trip)
       }
 
-      return trips
+      return kept
     } catch (error) {
       logError(`Vehicle-access (${vehicle?.type ?? rideMode}) transit query failed`, error)
       return []
     }
+  }
+
+  /** Search radius for a bike rack at the boarding stop (meters). */
+  private static readonly STATION_RACK_RADIUS_M = 250
+
+  /** Time to lock a bike to a rack before walking away. */
+  private static readonly BIKE_LOCK_DELAY_SEC = 60
+
+  /** Cached nearest-rack lookups — bicycle parking is static OSM data. */
+  private stationRackCache = new Map<string, Promise<Place | null>>()
+  private static readonly STATION_RACK_CACHE_MAX = 200
+
+  private cachedStationRack(at: Coordinate): Promise<Place | null> {
+    const key = `${at.lat.toFixed(5)},${at.lng.toFixed(5)}`
+    let hit = this.stationRackCache.get(key)
+    if (!hit) {
+      hit = this.searchNearbyParking(
+        at,
+        TripService.STATION_RACK_RADIUS_M,
+        'amenity/bicycle_parking',
+      ).then(places =>
+        places.reduce<Place | null>(
+          (best, p) =>
+            !best ||
+            TripService.haversineDistance(p.geometry.value.center, at) <
+              TripService.haversineDistance(best.geometry.value.center, at)
+              ? p
+              : best,
+          null,
+        ),
+      )
+      this.stationRackCache.set(key, hit)
+      if (this.stationRackCache.size > TripService.STATION_RACK_CACHE_MAX) {
+        const oldest = this.stationRackCache.keys().next().value
+        if (oldest) this.stationRackCache.delete(oldest)
+      }
+    }
+    return hit
+  }
+
+  /**
+   * Rewrite a bike-access transit trip so the ride ends locked to a real rack.
+   *
+   * MOTIS's BIKE access mode rides to the boarding stop and says nothing about
+   * what becomes of the bike, so everything after it walks away from a bike it
+   * never put down. Re-aims the ride at the nearest rack and walks in from
+   * there, back-timed off the original hand-off so boarding time is unchanged
+   * — the rider sets off earlier instead.
+   *
+   * Returns false when the stop has no reachable rack: there is nowhere to
+   * leave the bike, so it isn't a trip the rider could actually take.
+   */
+  private async parkBikeBeforeBoarding(
+    trip: TripResponse,
+    vehicle: Vehicle | null,
+    preferences: any,
+  ): Promise<boolean> {
+    const rideIdx = trip.segments.findIndex(s => s.mode === 'biking')
+    const boardIdx = trip.segments.findIndex(s => s.mode === 'transit')
+    if (rideIdx === -1 || boardIdx === -1 || rideIdx > boardIdx) return true
+
+    const ride = trip.segments[rideIdx]
+    const rack = await this.cachedStationRack(ride.end.location)
+    if (!rack) return false
+
+    const rackWaypoint: Waypoint = {
+      location: rack.geometry.value.center,
+      type: 'via',
+      label: rack.name?.value || 'Bike parking',
+      place: rack,
+    }
+
+    const legTo = (
+      start: Coordinate,
+      end: Coordinate,
+      profile: 'bicycle' | 'pedestrian',
+    ) =>
+      routingService
+        .getRoute(
+          [
+            { type: 'coordinates', value: [start.lat, start.lng] },
+            { type: 'coordinates', value: [end.lat, end.lng] },
+          ],
+          profile,
+          preferences,
+        )
+        .then(r => r.routes[0]?.legs[0] ?? null)
+        .catch(() => null)
+
+    const [toRack, toStop] = await Promise.all([
+      legTo(ride.start.location, rackWaypoint.location, 'bicycle'),
+      legTo(rackWaypoint.location, ride.end.location, 'pedestrian'),
+    ])
+
+    // A routing outage says nothing about whether the rack is usable, so the
+    // trip stands as MOTIS planned it rather than vanishing over a blip.
+    if (!toRack || !toStop) return true
+    // Rack snapped across a barrier — walking in from it would teleport.
+    if (!this.segmentsConnect(toRack.geometry, toStop.geometry)) return false
+
+    const handoff = new Date(ride.endTime).getTime()
+    const walkStart = handoff - toStop.duration * 1000
+    const rideEnd = walkStart - TripService.BIKE_LOCK_DELAY_SEC * 1000
+    const rideStart = rideEnd - toRack.duration * 1000
+
+    const parkedRide: TripSegment = {
+      ...ride,
+      end: rackWaypoint,
+      startTime: new Date(rideStart).toISOString(),
+      endTime: new Date(rideEnd).toISOString(),
+      duration: toRack.duration,
+      distance: toRack.distance,
+      geometry: toRack.geometry,
+      instructions: toRack.instructions,
+      totalElevationGain: toRack.totalElevationGain,
+      totalElevationLoss: toRack.totalElevationLoss,
+      maxElevation: toRack.maxElevation,
+      minElevation: toRack.minElevation,
+      edgeSegments: toRack.edgeSegments,
+    }
+
+    const walkIn: TripSegment = {
+      segmentIndex: 0,
+      mode: 'walking',
+      start: rackWaypoint,
+      end: ride.end,
+      startTime: new Date(walkStart).toISOString(),
+      endTime: new Date(handoff).toISOString(),
+      duration: toStop.duration,
+      distance: toStop.distance,
+      geometry: toStop.geometry,
+      instructions: toStop.instructions,
+      co2: 0,
+      totalElevationGain: toStop.totalElevationGain,
+      totalElevationLoss: toStop.totalElevationLoss,
+      maxElevation: toStop.maxElevation,
+      minElevation: toStop.minElevation,
+      edgeSegments: toStop.edgeSegments,
+    }
+
+    trip.segments.splice(rideIdx, 1, parkedRide, walkIn)
+    trip.segments.forEach((seg, idx) => { seg.segmentIndex = idx })
+
+    // Incremental, not recomputed — calculateStats would drop the
+    // itinerary-level fare already folded into totalCost.
+    trip.tripStats.totalDuration += (handoff - rideStart) / 1000 - ride.duration
+    trip.tripStats.totalDistance +=
+      toRack.distance + toStop.distance - ride.distance
+    trip.tripStats.totalWalkingDistance =
+      (trip.tripStats.totalWalkingDistance ?? 0) + toStop.distance
+    trip.earliestStartTime = parkedRide.startTime
+
+    if (vehicle) {
+      trip.parkedVehicles = [{
+        vehicle,
+        location: rackWaypoint.location,
+        parkedAt: parkedRide.endTime,
+      }]
+    }
+
+    return true
   }
 
   /**


### PR DESCRIPTION
Stacked on #498. Fixes the bike+transit trips being wrong: they ride a bike to the station and then walk away from it, with nothing saying where the bike went.

## The defect

MOTIS's `BIKE` access mode rides to the boarding stop and models no parking event — `BIKE` is a plain street mode, not a park-and-ride mode like `CAR_PARKING`. We passed that through untouched, so the timeline read *cycle 19m → board the F → walk 9m*, a trip nobody can actually take.

## The fix

The bike ride is re-aimed at the nearest `amenity/bicycle_parking` within 250m of the boarding stop, followed by a short walk in:

```
biking (origin → rack) → lock → walking (rack → stop) → transit → …
```

Both new legs are **back-timed off MOTIS's original hand-off**, so the boarding time never moves — the rider sets off earlier instead of missing the train. A 60s lock-up gap sits between the ride and the walk. When a bike is registered, `parkedVehicles` records the rack, so a return trip knows where it is.

Rack lookups are cached per stop (itineraries share boarding stops), and reuse `searchNearbyParking` + the `segmentsConnect` barrier guard that parking-aware driving already uses.

## Two judgement calls worth your input

**Gated on `useKnownParkingLocations`.** That preference is already the contract for "route me to real parking", and it bounds the added search to users who opted in. With it off, the trip stays as MOTIS planned it — still unparked. Flipping this to always-on is a one-line change; say so if you'd rather the trip never lie regardless of preference.

**No rack → the trip is dropped.** There is nowhere to leave the bike, so it isn't a trip you could take. A *failed* lookup is treated differently and leaves the trip alone, so a routing outage doesn't silently delete options.

## Your preferred variant — bike on board, park at the far end

You said "preferably after". That needs bike carriage on the transit leg, and I checked what the data supports rather than guessing:

* MOTIS does have `requireBikeTransport`, and the composition works end to end. Verified against Seastreak (`BIKE > FERRY > BIKE`, 48 min).
* **Only 2 of the 44 loaded GTFS feeds declare `bikes_allowed=1`** — Seastreak and Concord Coach. None of the MTA feeds do, so `requireBikeTransport=true` returns **zero** itineraries for your Brooklyn → Manhattan trip while the same query without the flag returns five.

So carry-on is blocked by feed data, not by routing. Bikes genuinely are allowed on the NYC subway; the feed just doesn't say so. Closing that needs a `bikes_allowed` policy injection in barrelman (same shape as the existing Fares v2 synthesis) plus a passthrough for the parameter — a production data change, so I've left it for you to call. Tracked against PAR-252.

## Verification

* 151 tests pass. The 3 new behavioural tests fail on the parent branch and pass here; the 4th pins the preference-off path.
* `tsc`: 324 errors, identical to the parent baseline — none in the new code.
* **Not yet verified end to end.** Street routing is down on both paths right now: hosted GraphHopper is returning "Minutely API limit heavily violated", and barrelman's own GraphHopper on vega2 is not running, so `/route`, `/directions` and `/isochrone` are all reporting unavailable. Both new legs need street routing, so the preview will show the untouched trip until one recovers.