### PR TITLE
Hide transit network for non-transit trips; keep dim across layer toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@
 
 ### Changed
 
+* Viewing a trip now fades the surrounding transit network so the route you're
+  taking stands out, matching how a line's own page already looks
+* Live vehicles on a trip are limited to the lines it rides, with the specific
+  train or bus you're catching held at full strength and the rest faded back
+
 ### Fixed
 
 * One-finger double-tap zoom no longer opens a place underneath the gesture,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
   taking stands out, matching how a line's own page already looks
 * A trip now shows just the train or bus you're actually catching on each leg,
   instead of every vehicle running those lines
+* Trips that don't ride transit at all now hide the transit network entirely
+  rather than dimming it, including while you hover a suggestion in the list
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,8 @@
 
 * Viewing a trip now fades the surrounding transit network so the route you're
   taking stands out, matching how a line's own page already looks
-* Live vehicles on a trip are limited to the lines it rides, with the specific
-  train or bus you're catching held at full strength and the rest faded back
+* A trip now shows just the train or bus you're actually catching on each leg,
+  instead of every vehicle running those lines
 
 ### Fixed
 

--- a/web/src/components/map/layers/transit-vehicles-layer.ts
+++ b/web/src/components/map/layers/transit-vehicles-layer.ts
@@ -24,7 +24,7 @@ import {
 } from './base-marker-layer'
 import { useLayersStore } from '@/stores/layers.store'
 import { useTransitVehiclesStore } from '@/stores/transit-vehicles.store'
-import { useRouteDetailStore } from '@/stores/route-detail.store'
+import { useTransitFocusStore } from '@/stores/transit-focus.store'
 import {
   buildPolylineDistances,
   distanceMeters,
@@ -192,7 +192,7 @@ const pendingShapeFetches = new Set<string>()
 export class TransitVehiclesLayer extends BaseMarkerLayer {
   private layersStore = useLayersStore()
   private transitVehiclesStore = useTransitVehiclesStore()
-  private routeDetailStore = useRouteDetailStore()
+  private transitFocusStore = useTransitFocusStore()
 
   private tracks = new Map<string, TransitTrack>()
   private lastRendered = new Map<string, { lat: number; lng: number }>()
@@ -212,10 +212,10 @@ export class TransitVehiclesLayer extends BaseMarkerLayer {
 
   constructor() {
     const layersStore = useLayersStore()
-    const routeDetailStore = useRouteDetailStore()
+    const transitFocusStore = useTransitFocusStore()
     const isEnabled = computed(() => {
-      // Enable when route detail is active (isolated line view)
-      if (routeDetailStore.isActive) return true
+      // Enable whenever a route or an itinerary is the map's subject
+      if (transitFocusStore.isActive) return true
       // Or when the legacy layer toggle is on
       const layer = layersStore.layers.find(
         (l) => l.configuration?.id === 'transit-vehicles',
@@ -258,26 +258,22 @@ export class TransitVehiclesLayer extends BaseMarkerLayer {
   }
 
   protected getData(): MarkerData[] {
-    // When route detail is active, use its filtered vehicles
-    let vehicleEntries: TransitVehiclePosition[]
-    if (this.routeDetailStore.isActive) {
-      // Only show vehicles matching the selected direction
-      const dirFilter = this.routeDetailStore.directionFilteredVehicleIds
-      vehicleEntries = Array.from(this.routeDetailStore.vehicles.values())
-        .filter(v => dirFilter.has(v.vehicleId))
-    } else {
-      vehicleEntries = Array.from(this.transitVehiclesStore.vehicles.values())
-    }
+    const focus = this.transitFocusStore
+    // A focused route or itinerary supplies its own vehicles, already
+    // scoped to the lines it rides; otherwise the viewport feed answers.
+    const visible = focus.visibleVehicleIds
+    const vehicleEntries: TransitVehiclePosition[] = focus.isActive
+      ? Array.from(focus.vehicles.values()).filter(v => visible.has(v.vehicleId))
+      : Array.from(this.transitVehiclesStore.vehicles.values())
 
-    const selectedId = this.routeDetailStore.selectedVehicleId
-    const hasSelection = !!selectedId
+    // Empty emphasis means nothing on screen can be called the rider's, and
+    // so nothing fades: every train at full strength beats the wrong one lit.
+    const emphasized = focus.emphasizedVehicleIds
+    const hasEmphasis = emphasized.size > 0
 
-    // When in route detail mode, use the route's type (from the route-detail
-    // API which has correct data) instead of the vehicle's type (from the
-    // vehicles enrichment cache which may have stale/wrong GTFS data).
-    const routeTypeOverride = this.routeDetailStore.isActive
-      ? this.routeDetailStore.activeRoute?.routeType
-      : undefined
+    // The focused view's own data is the authority on a line's mode; the
+    // vehicle feed's enrichment cache can be stale about it.
+    const routeTypeOverride = focus.routeTypeOverride
 
     return vehicleEntries.map((v: TransitVehiclePosition) => ({
       id: v.vehicleId,
@@ -290,9 +286,9 @@ export class TransitVehiclesLayer extends BaseMarkerLayer {
         routeType: routeTypeOverride ?? v.routeType,
         bearing: v.bearing,
         timestamp: v.timestamp,
-        selected: v.vehicleId === selectedId,
-        dimmed: hasSelection && v.vehicleId !== selectedId,
-        onSelect: (id: string) => this.routeDetailStore.selectVehicle(id),
+        selected: emphasized.has(v.vehicleId),
+        dimmed: hasEmphasis && !emphasized.has(v.vehicleId),
+        onSelect: (id: string) => focus.selectVehicle(id),
       },
     }))
   }
@@ -309,9 +305,9 @@ export class TransitVehiclesLayer extends BaseMarkerLayer {
     this.pollingWatchStop = watch(
       this.enabled,
       (visible) => {
-        if (visible && !this.routeDetailStore.isActive) {
-          // Only subscribe to the global WS feed when NOT in route-detail
-          // mode. Route-detail has its own HTTP polling via the store.
+        if (visible && !this.transitFocusStore.isActive) {
+          // Only subscribe to the global WS feed when nothing is focused.
+          // A focused route or trip does its own HTTP polling.
           this.transitVehiclesStore.subscribe(getBounds)
         } else if (!visible) {
           this.transitVehiclesStore.unsubscribe()
@@ -365,8 +361,8 @@ export class TransitVehiclesLayer extends BaseMarkerLayer {
     this.samplesWatchStop = watch(
       () => {
         // Read from whichever store is providing vehicle data
-        const source = this.routeDetailStore.isActive
-          ? this.routeDetailStore.vehicles
+        const source = this.transitFocusStore.isActive
+          ? this.transitFocusStore.vehicles
           : this.transitVehiclesStore.vehicles
 
         return Array.from(source.values()).map(
@@ -754,8 +750,8 @@ export class TransitVehiclesLayer extends BaseMarkerLayer {
     cumulativeDistances: number[],
     totalLength: number,
   ): number | null {
-    if (!stopId || !this.routeDetailStore.activeRoute) return null
-    const stops = this.routeDetailStore.activeRoute.stops
+    const stops = this.transitFocusStore.focusedStops
+    if (!stopId || !stops.length) return null
     // Try exact match and stripped-suffix match (e.g. "101N" → "101")
     const stop = stops.find(s => s.stopId === stopId)
       ?? stops.find(s => stopId.startsWith(s.stopId))

--- a/web/src/lib/transit-focus.test.ts
+++ b/web/src/lib/transit-focus.test.ts
@@ -1,0 +1,167 @@
+import { describe, it, expect } from 'vitest'
+import {
+  focusedLegs,
+  routeIdsByFeed,
+  localTripId,
+  vehiclesOnFocusedRoutes,
+  yourVehicleIds,
+} from './transit-focus'
+import type { TransitVehiclePosition } from '@/types/multimodal.types'
+
+/**
+ * Reducing an itinerary to what the map has to know about it.
+ *
+ * The trap here is the feed prefix. A route or trip id arrives as
+ * `feedId_localId` from the planner and the boards, bare from the realtime
+ * feed's own point of view, and the two vocabularies only agree once the
+ * prefix is off. Getting it wrong lights up a different agency's line of
+ * the same number — Metro-North's 2 for the LIRR's.
+ */
+
+const vehicle = (v: Partial<TransitVehiclePosition>): TransitVehiclePosition => ({
+  vehicleId: 'v1',
+  feedId: 'f1',
+  position: { lat: 0, lng: 0 },
+  timestamp: '2026-09-09T16:00:00Z',
+  ...v,
+})
+
+const transitSegment = (over: Record<string, unknown> = {}) => ({
+  mode: 'transit',
+  transitDetails: {
+    route: { id: 'f1_A' },
+    trip: { id: 'f1_trip-7' },
+    stops: [
+      { id: 'f1_s1', location: { lat: 1, lng: 2 } },
+      { id: 'f1_s2', location: { lat: 3, lng: 4 } },
+    ],
+    ...(over as Record<string, unknown>),
+  },
+})
+
+describe('focusedLegs', () => {
+  it('strips the feed prefix off route, trip and stop ids', () => {
+    const [leg] = focusedLegs({ segments: [transitSegment()] })
+    expect(leg.feedId).toBe('f1')
+    expect(leg.routeIds).toEqual(['A'])
+    expect(leg.tripId).toBe('trip-7')
+    expect(leg.stops).toEqual([
+      { stopId: 's1', lat: 1, lng: 2 },
+      { stopId: 's2', lat: 3, lng: 4 },
+    ])
+  })
+
+  it('keeps interchangeable lines, which are one leg to the rider', () => {
+    const [leg] = focusedLegs({
+      segments: [
+        transitSegment({
+          route: { id: 'f1_4' },
+          routeOptions: [{ id: 'f1_4' }, { id: 'f1_5' }],
+        }),
+      ],
+    })
+    expect(leg.routeIds).toEqual(['4', '5'])
+  })
+
+  it('skips walking legs and legs with no route', () => {
+    const legs = focusedLegs({
+      segments: [
+        { mode: 'walking' },
+        { mode: 'transit', transitDetails: {} },
+        transitSegment(),
+      ],
+    })
+    expect(legs).toHaveLength(1)
+    expect(legs[0].segmentIndex).toBe(2)
+  })
+
+  it('drops an unprefixed route rather than guess its feed', () => {
+    expect(focusedLegs({ segments: [transitSegment({ route: { id: 'A' } })] })).toEqual([])
+  })
+
+  it('survives a trip with no segments at all', () => {
+    expect(focusedLegs(null)).toEqual([])
+    expect(focusedLegs({})).toEqual([])
+  })
+
+  it('drops stops with no usable position', () => {
+    const [leg] = focusedLegs({
+      segments: [
+        transitSegment({
+          stops: [{ id: 'f1_s1' }, { id: 'f1_s2', location: { lat: 3, lng: 4 } }],
+        }),
+      ],
+    })
+    expect(leg.stops).toEqual([{ stopId: 's2', lat: 3, lng: 4 }])
+  })
+})
+
+describe('routeIdsByFeed', () => {
+  it('unions a feed\'s lines across legs without repeating them', () => {
+    const legs = focusedLegs({
+      segments: [
+        transitSegment({ route: { id: 'f1_A' } }),
+        transitSegment({ route: { id: 'f1_A' } }),
+        transitSegment({ route: { id: 'f2_C' } }),
+      ],
+    })
+    expect(routeIdsByFeed(legs)).toEqual(new Map([['f1', ['A']], ['f2', ['C']]]))
+  })
+})
+
+describe('localTripId', () => {
+  it('strips only its own feed\'s prefix', () => {
+    expect(localTripId(vehicle({ tripId: 'f1_trip-7' }))).toBe('trip-7')
+    expect(localTripId(vehicle({ tripId: 'f2_trip-7' }))).toBe('f2_trip-7')
+    expect(localTripId(vehicle({}))).toBeNull()
+  })
+})
+
+describe('vehiclesOnFocusedRoutes', () => {
+  const legs = focusedLegs({ segments: [transitSegment({ route: { id: 'f1_A' } })] })
+
+  it('matches by route id or by the short name the feed publishes', () => {
+    const ids = vehiclesOnFocusedRoutes(legs, [
+      vehicle({ vehicleId: 'byId', routeId: 'A' }),
+      vehicle({ vehicleId: 'byName', routeShortName: 'A' }),
+      vehicle({ vehicleId: 'otherLine', routeId: 'C' }),
+    ])
+    expect(ids).toEqual(new Set(['byId', 'byName']))
+  })
+
+  it('will not match another feed\'s line of the same name', () => {
+    const ids = vehiclesOnFocusedRoutes(legs, [
+      vehicle({ vehicleId: 'wrongFeed', feedId: 'f2', routeId: 'A' }),
+    ])
+    expect(ids.size).toBe(0)
+  })
+})
+
+describe('yourVehicleIds', () => {
+  it('picks out the run each leg is booked on', () => {
+    const legs = focusedLegs({
+      segments: [
+        transitSegment({ route: { id: 'f1_A' }, trip: { id: 'f1_trip-7' } }),
+        transitSegment({ route: { id: 'f1_C' }, trip: { id: 'f1_trip-9' } }),
+      ],
+    })
+    const ids = yourVehicleIds(legs, [
+      vehicle({ vehicleId: 'mine-a', tripId: 'f1_trip-7' }),
+      vehicle({ vehicleId: 'mine-c', tripId: 'f1_trip-9' }),
+      vehicle({ vehicleId: 'someone-else', tripId: 'f1_trip-8' }),
+    ])
+    expect(ids).toEqual(new Set(['mine-a', 'mine-c']))
+  })
+
+  // The caller reads empty as "dim nothing" — every train at full strength
+  // beats three of them faded behind a fourth that is not the rider's.
+  it('is empty when no leg can name its run', () => {
+    const legs = focusedLegs({ segments: [transitSegment({ trip: {} })] })
+    expect(yourVehicleIds(legs, [vehicle({ tripId: 'f1_trip-7' })]).size).toBe(0)
+  })
+
+  it('is empty when the run is named but no vehicle is reporting it', () => {
+    const legs = focusedLegs({ segments: [transitSegment()] })
+    expect(yourVehicleIds(legs, [vehicle({ tripId: 'f1_trip-99' })]).size).toBe(0)
+  })
+})

--- a/web/src/lib/transit-focus.test.ts
+++ b/web/src/lib/transit-focus.test.ts
@@ -3,7 +3,6 @@ import {
   focusedLegs,
   routeIdsByFeed,
   localTripId,
-  vehiclesOnFocusedRoutes,
   yourVehicleIds,
 } from './transit-focus'
 import type { TransitVehiclePosition } from '@/types/multimodal.types'
@@ -114,26 +113,6 @@ describe('localTripId', () => {
     expect(localTripId(vehicle({ tripId: 'f1_trip-7' }))).toBe('trip-7')
     expect(localTripId(vehicle({ tripId: 'f2_trip-7' }))).toBe('f2_trip-7')
     expect(localTripId(vehicle({}))).toBeNull()
-  })
-})
-
-describe('vehiclesOnFocusedRoutes', () => {
-  const legs = focusedLegs({ segments: [transitSegment({ route: { id: 'f1_A' } })] })
-
-  it('matches by route id or by the short name the feed publishes', () => {
-    const ids = vehiclesOnFocusedRoutes(legs, [
-      vehicle({ vehicleId: 'byId', routeId: 'A' }),
-      vehicle({ vehicleId: 'byName', routeShortName: 'A' }),
-      vehicle({ vehicleId: 'otherLine', routeId: 'C' }),
-    ])
-    expect(ids).toEqual(new Set(['byId', 'byName']))
-  })
-
-  it('will not match another feed\'s line of the same name', () => {
-    const ids = vehiclesOnFocusedRoutes(legs, [
-      vehicle({ vehicleId: 'wrongFeed', feedId: 'f2', routeId: 'A' }),
-    ])
-    expect(ids.size).toBe(0)
   })
 })
 

--- a/web/src/lib/transit-focus.ts
+++ b/web/src/lib/transit-focus.ts
@@ -1,0 +1,156 @@
+/**
+ * What the map is focused on when a transit itinerary is open.
+ *
+ * A trip is a sequence of legs, each riding one line for part of its
+ * length. These helpers reduce a trip to the two things the map needs:
+ * which lines to keep at full strength, and which vehicles on them are
+ * the ones the rider is actually catching.
+ */
+
+import { splitFeedId } from '@/lib/transit-alerts'
+import type { TransitVehiclePosition } from '@/types/multimodal.types'
+
+/** A stop the map may have to place, in the one shape both a route's stop
+ *  list and a leg's stop list reduce to. */
+export interface FocusedStop {
+  stopId: string
+  lat: number
+  lng: number
+}
+
+/** One transit leg, in the terms the vehicle feed is keyed by. */
+export interface FocusedLeg {
+  segmentIndex: number
+  feedId: string
+  /** The leg's line plus its interchangeable alternates (the 4 and the 5),
+   *  which are one leg to the rider and must both stay lit. */
+  routeIds: string[]
+  /** The run the rider is booked on, feed-local. Null until something can
+   *  name it. */
+  tripId: string | null
+  /** Every stop the leg calls at, ends included. */
+  stops: FocusedStop[]
+}
+
+/** Feed-local id, or null when there is nothing to strip. */
+function local(id: string | undefined | null): string | null {
+  if (!id) return null
+  const { localId } = splitFeedId(id)
+  return localId || null
+}
+
+/**
+ * The transit legs of a trip, or an empty list for a trip with none.
+ *
+ * Legs whose route carries no feed prefix are dropped: an unprefixed id
+ * addresses whichever feed happens to be first, and lighting up the wrong
+ * agency's line is worse than lighting up none.
+ */
+export function focusedLegs(trip: { segments?: unknown[] } | null | undefined): FocusedLeg[] {
+  const segments = (trip?.segments ?? []) as Array<Record<string, any>>
+  const out: FocusedLeg[] = []
+
+  segments.forEach((seg, segmentIndex) => {
+    if (seg.mode !== 'transit') return
+    const td = seg.transitDetails
+    const routeId: string | undefined = td?.route?.id
+    if (!routeId) return
+    const { feedId, localId } = splitFeedId(routeId)
+    if (!feedId || !localId) return
+
+    const routeIds = [
+      localId,
+      ...((td?.routeOptions ?? []) as Array<{ id?: string }>)
+        .map((r) => local(r.id))
+        .filter(Boolean) as string[],
+    ]
+
+    const stops: FocusedStop[] = ((td?.stops ?? []) as Array<Record<string, any>>)
+      .map((s) => ({
+        stopId: local(s?.id) ?? '',
+        lat: s?.location?.lat,
+        lng: s?.location?.lng,
+      }))
+      .filter((s) => s.stopId && Number.isFinite(s.lat) && Number.isFinite(s.lng))
+
+    out.push({
+      segmentIndex,
+      feedId,
+      routeIds: [...new Set(routeIds)],
+      tripId: local(td?.trip?.id),
+      stops,
+    })
+  })
+
+  return out
+}
+
+/** The legs' lines grouped by the feed that publishes them. */
+export function routeIdsByFeed(legs: FocusedLeg[]): Map<string, string[]> {
+  const byFeed = new Map<string, Set<string>>()
+  for (const leg of legs) {
+    const set = byFeed.get(leg.feedId) ?? new Set<string>()
+    for (const id of leg.routeIds) set.add(id)
+    byFeed.set(leg.feedId, set)
+  }
+  return new Map([...byFeed].map(([feedId, ids]) => [feedId, [...ids]]))
+}
+
+/** GTFS-RT prefixes a vehicle's trip with its feed; the boards do not. */
+export function localTripId(vehicle: TransitVehiclePosition): string | null {
+  if (!vehicle.tripId) return null
+  return vehicle.tripId.startsWith(`${vehicle.feedId}_`)
+    ? vehicle.tripId.slice(vehicle.feedId.length + 1)
+    : vehicle.tripId
+}
+
+/** Vehicles running any of the trip's lines, on the feeds that publish them. */
+export function vehiclesOnFocusedRoutes(
+  legs: FocusedLeg[],
+  vehicles: Iterable<TransitVehiclePosition>,
+): Set<string> {
+  const wanted = new Map<string, Set<string>>()
+  for (const [feedId, ids] of routeIdsByFeed(legs)) wanted.set(feedId, new Set(ids))
+
+  const out = new Set<string>()
+  for (const v of vehicles) {
+    const routes = wanted.get(v.feedId)
+    if (!routes) continue
+    if ((v.routeId && routes.has(v.routeId)) ||
+        (v.routeShortName && routes.has(v.routeShortName))) {
+      out.add(v.vehicleId)
+    }
+  }
+  return out
+}
+
+/**
+ * The vehicles the rider is actually catching — one per leg, matched by
+ * the run's trip id.
+ *
+ * Empty when no leg can be matched, and the caller must read that as "do
+ * not dim anything": every A train on screen is better than three of them
+ * faded behind a fourth that is not the rider's.
+ */
+export function yourVehicleIds(
+  legs: FocusedLeg[],
+  vehicles: Iterable<TransitVehiclePosition>,
+): Set<string> {
+  const wanted = new Map<string, Set<string>>()
+  for (const leg of legs) {
+    if (!leg.tripId) continue
+    const set = wanted.get(leg.feedId) ?? new Set<string>()
+    set.add(leg.tripId)
+    wanted.set(leg.feedId, set)
+  }
+  if (!wanted.size) return new Set()
+
+  const out = new Set<string>()
+  for (const v of vehicles) {
+    const trips = wanted.get(v.feedId)
+    if (!trips) continue
+    const tripId = localTripId(v)
+    if (tripId && trips.has(tripId)) out.add(v.vehicleId)
+  }
+  return out
+}

--- a/web/src/lib/transit-focus.ts
+++ b/web/src/lib/transit-focus.ts
@@ -104,33 +104,13 @@ export function localTripId(vehicle: TransitVehiclePosition): string | null {
     : vehicle.tripId
 }
 
-/** Vehicles running any of the trip's lines, on the feeds that publish them. */
-export function vehiclesOnFocusedRoutes(
-  legs: FocusedLeg[],
-  vehicles: Iterable<TransitVehiclePosition>,
-): Set<string> {
-  const wanted = new Map<string, Set<string>>()
-  for (const [feedId, ids] of routeIdsByFeed(legs)) wanted.set(feedId, new Set(ids))
-
-  const out = new Set<string>()
-  for (const v of vehicles) {
-    const routes = wanted.get(v.feedId)
-    if (!routes) continue
-    if ((v.routeId && routes.has(v.routeId)) ||
-        (v.routeShortName && routes.has(v.routeShortName))) {
-      out.add(v.vehicleId)
-    }
-  }
-  return out
-}
-
 /**
  * The vehicles the rider is actually catching — one per leg, matched by
  * the run's trip id.
  *
- * Empty when no leg can be matched, and the caller must read that as "do
- * not dim anything": every A train on screen is better than three of them
- * faded behind a fourth that is not the rider's.
+ * Empty when no leg can be matched. Showing the whole line's service
+ * instead is not the fallback: it puts a field of trains on the map with
+ * the rider's somewhere among them, which is what this replaced.
  */
 export function yourVehicleIds(
   legs: FocusedLeg[],

--- a/web/src/lib/transit-vehicle-fetch.ts
+++ b/web/src/lib/transit-vehicle-fetch.ts
@@ -1,0 +1,49 @@
+/**
+ * Live positions for a named set of lines.
+ *
+ * Both the route panel and an open itinerary want the same thing — every
+ * vehicle running these routes, wherever they are — which is not what the
+ * viewport feed answers. The route endpoint answers it directly; the bbox
+ * fallback covers instances whose server predates it.
+ */
+
+import { api } from '@/lib/api'
+import type { TransitVehiclePosition } from '@/types/multimodal.types'
+
+export interface VehicleBounds {
+  north: number
+  south: number
+  east: number
+  west: number
+}
+
+export async function fetchVehiclesOnRoutes(
+  feedId: string,
+  routeIds: string[],
+  fallbackBounds?: () => VehicleBounds | null,
+): Promise<TransitVehiclePosition[]> {
+  if (!feedId || !routeIds.length) return []
+
+  try {
+    const { data } = await api.get<{ vehicles: TransitVehiclePosition[] }>(
+      '/transit/route-vehicles',
+      { params: { routeIds: routeIds.join(','), feedId } },
+    )
+    if (data?.vehicles) return data.vehicles
+  } catch {
+    // Endpoint not available — fall through to the bbox feed
+  }
+
+  const bounds = fallbackBounds?.()
+  if (!bounds) return []
+  const { data } = await api.get<{ vehicles: TransitVehiclePosition[] }>(
+    '/transit/vehicles',
+    { params: bounds },
+  )
+  const wanted = new Set(routeIds)
+  return (data?.vehicles ?? []).filter(
+    (v) =>
+      (v.routeId && wanted.has(v.routeId)) ||
+      (v.routeShortName && wanted.has(v.routeShortName)),
+  )
+}

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -237,6 +237,13 @@ let isolatedRoute: string | null = null
 let networkDimmed = false
 
 /**
+ * Whether the network is out of the way entirely, rather than merely
+ * stepped back — a trip that rides no transit at all, where the ribbons
+ * are not context for the line on top of them but clutter beside it.
+ */
+let networkHidden = false
+
+/**
  * How far the rest of the network steps back while one route is isolated.
  * Low enough to read as background, high enough that the network is still
  * legibly there.
@@ -309,6 +316,7 @@ export function usePortolanTransitService() {
     setClassVisibility,
     setIsolatedRoute,
     setNetworkDim,
+    setNetworkHidden,
     setIsolatedRouteStops,
     setIsolatedRouteGeometry,
     setStopService,
@@ -342,6 +350,35 @@ function setNetworkDim(on: boolean) {
   networkDimmed = on
   applyRibbonDim()
   applyStationDim()
+}
+
+/** Take the whole network off the map, or put it back. */
+function setNetworkHidden(on: boolean) {
+  if (networkHidden === on) return
+  networkHidden = on
+  applyNetworkVisibility()
+}
+
+/** Nothing else in the renderer touches layout visibility, so this can own
+ *  it outright: class toggles gate through filters, station zooms through
+ *  setLayerZoomRange. */
+function applyNetworkVisibility() {
+  if (!map) return
+  const v = networkHidden ? 'none' : 'visible'
+  let layers: any[] = []
+  try {
+    layers = map.getStyle()?.layers ?? []
+  } catch {
+    return // style not ready — the mount path re-applies
+  }
+  for (const layer of layers) {
+    if (!layer.id.startsWith('portolan-')) continue
+    try {
+      map.setLayoutProperty(layer.id, 'visibility', v)
+    } catch {
+      // layer went away mid-sweep
+    }
+  }
 }
 
 /** Stops on the isolated route's RUNNING path, [lng, lat]. */
@@ -884,7 +921,6 @@ function teardownPortolanTransit() {
   map = null
   activeStrategy = null
   isolatedRoute = null
-  networkDimmed = false
   clearHydration()
   clearMounts()
   inkDark = null
@@ -1466,6 +1502,9 @@ function addSourcesAndLayers(regions: PortolanIndexEntry[]) {
 
   ribbonAnchor = anchor
   addSymbolLayers()
+  // Freshly mounted layers know nothing of a dim or a hide already in force.
+  if (networkDimmed) applyStationDim()
+  if (networkHidden) applyNetworkVisibility()
 }
 
 /**

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -224,6 +224,19 @@ let classesOff = new Set<string>()
 let isolatedRoute: string | null = null
 
 /**
+ * Whether the whole network is stepped back behind something drawn over
+ * it — an itinerary's own line, which is its own layer and not a ribbon.
+ *
+ * Unlike isolation there is no favoured route: everything dims together.
+ * It lives HERE rather than as a paint override from outside because the
+ * ribbons mount progressively as tiles hydrate, and on MapLibre each one
+ * is two layers. Anything painted over them from outside catches only the
+ * layers that happened to exist at that instant; folded into the opacity
+ * expression, every ribbon is born dimmed and stays dimmed across rebuilds.
+ */
+let networkDimmed = false
+
+/**
  * How far the rest of the network steps back while one route is isolated.
  * Low enough to read as background, high enough that the network is still
  * legibly there.
@@ -295,6 +308,7 @@ export function usePortolanTransitService() {
     setServiceTime,
     setClassVisibility,
     setIsolatedRoute,
+    setNetworkDim,
     setIsolatedRouteStops,
     setIsolatedRouteGeometry,
     setStopService,
@@ -320,6 +334,14 @@ function setIsolatedRoute(routeId: string | null) {
   applyStations()
   applyStationZoomRelax()
   applyStationScale()
+}
+
+/** Step the whole network back, or restore it. */
+function setNetworkDim(on: boolean) {
+  if (networkDimmed === on) return
+  networkDimmed = on
+  applyRibbonDim()
+  applyStationDim()
 }
 
 /** Stops on the isolated route's RUNNING path, [lng, lat]. */
@@ -807,7 +829,8 @@ function initializePortolanTransit(mapStrategy: MapStrategy | undefined) {
   themeDark = mapStrategy.options.theme === MapTheme.DARK
   // the dim is theme-dependent — re-derive it rather than leave the light
   // value painted on a dark map
-  if (isolatedRoute) applyRibbonDim()
+  if (isolatedRoute || networkDimmed) applyRibbonDim()
+  if (networkDimmed) applyStationDim()
   const fork =
     mapStrategy.options.engine === MapEngine.MAPLIBRE &&
     getVersion().includes('transit')
@@ -861,6 +884,7 @@ function teardownPortolanTransit() {
   map = null
   activeStrategy = null
   isolatedRoute = null
+  networkDimmed = false
   clearHydration()
   clearMounts()
   inkDark = null
@@ -2019,7 +2043,11 @@ function isolationOpacity(base: Expr, ghost: boolean): Expr {
   const occluded: Expr = ghost
     ? (['*', base, OCCLUDED_OPACITY] as unknown as Expr)
     : base
-  if (!isolatedRoute) return occluded
+  if (!isolatedRoute) {
+    return networkDimmed
+      ? (['*', occluded, isolationDim()] as unknown as Expr)
+      : occluded
+  }
   // With a geometry override up, the override line IS the route on the
   // map: the tile ribbon's copy of it dims into the network like
   // everything else, because its geometry is what the override corrects.
@@ -2120,6 +2148,34 @@ function applyRibbonDim() {
       map.setPaintProperty(id, 'line-color', ribbonColorWithAlpha(p.color, o))
     } else {
       map.setPaintProperty(id, 'line-opacity', o)
+    }
+  }
+}
+
+/**
+ * The network dim, applied to the stations, bullets and labels.
+ *
+ * The ribbons carry theirs inside an opacity expression; the symbol layers
+ * have no such expression to fold into, so their opacity is set flat. They
+ * are enumerated off the style for the same reason the dim targets are:
+ * the set is per-feed and per-band, never fixed.
+ */
+function applyStationDim() {
+  if (!map) return
+  const o = networkDimmed && !isolatedRoute ? isolationDim() : 1
+  let layers: any[] = []
+  try {
+    layers = map.getStyle()?.layers ?? []
+  } catch {
+    return // style not ready — the mount path re-applies
+  }
+  for (const layer of layers) {
+    if (!layer.id.startsWith('portolan-') || layer.type !== 'symbol') continue
+    try {
+      map.setPaintProperty(layer.id, 'icon-opacity', o)
+      map.setPaintProperty(layer.id, 'text-opacity', o)
+    } catch {
+      // layer went away mid-sweep
     }
   }
 }

--- a/web/src/services/layers/features/route-isolation.service.ts
+++ b/web/src/services/layers/features/route-isolation.service.ts
@@ -16,6 +16,10 @@ import { densifyLine } from '@/lib/geo-densify'
 import { projectAlong, sliceAlong } from '@/lib/geo-line'
 import { widthExpr } from '@/services/layers/features/portolan/portolan-expressions'
 import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
+import {
+  fadeTransitNetwork,
+  networkDimOpacity,
+} from '@/services/layers/features/transit-network-dim'
 import type { FitBoundsFn } from '@/types/map.types'
 
 const ROUTE_SOURCE_ID = 'route-detail-shape'
@@ -23,54 +27,6 @@ const ROUTE_LAYER_ID = 'route-detail-line'
 const STOPS_SOURCE_ID = 'route-detail-stops'
 const STOPS_LAYER_ID = 'route-detail-stops-circles'
 const STOPS_LABELS_LAYER_ID = 'route-detail-stops-labels'
-
-/** Transitland layer IDs that should be faded when isolating (retired from
- *  the default template — kept for user-cloned copies still on the map).
- *  Excludes `transitland-route-active` — it's a hover utility layer with
- *  a feature-state opacity expression that breaks if overridden flat.
- *  Portolan layers are NOT listed: they're enumerated live off the style
- *  by their `portolan-` prefix, since the set (per-feed, per-band) is
- *  dynamic. */
-const TRANSIT_LAYER_IDS = [
-  'transitland-rail',
-  'transitland-rail-outline',
-  'transitland-bus-low',
-  'transitland-bus-low-outline',
-  'transitland-bus-medium',
-  'transitland-bus-medium-outline',
-  'transitland-tram',
-  'transitland-tram-outline',
-  'transitland-metro',
-  'transitland-metro-outline',
-  'transitland-other',
-  'transitland-other-outline',
-  'transitland-tram-labels',
-  'transitland-metro-labels',
-  'transitland-rail-labels',
-  'transitland-bus-medium-labels',
-  'transitland-other-labels',
-  'transitland-stops',
-  'transitland-stops-labels',
-]
-
-/** How far the rest of the network steps back while a route is isolated —
- *  dimmed, not hidden, so the line still reads inside its network. Matches
- *  portolan's own ISOLATION_DIM — keep the two in step. */
-const NETWORK_DIM_LIGHT = 0.25
-const NETWORK_DIM_DARK = 0.42
-/** Theme-dependent for the same reason portolan's is: the same alpha reads
- *  as "gone" against a near-black basemap. */
-const NETWORK_DIM = () =>
-  document.documentElement.classList.contains('dark')
-    ? NETWORK_DIM_DARK
-    : NETWORK_DIM_LIGHT
-
-/** Which opacity paint props carry a layer type's fade. */
-const OPACITY_PROPS: Record<string, string[]> = {
-  line: ['line-opacity'],
-  circle: ['circle-opacity', 'circle-stroke-opacity'],
-  symbol: ['text-opacity', 'icon-opacity'],
-}
 
 export function useRouteIsolationService() {
   const routeDetailStore = useRouteDetailStore()
@@ -257,8 +213,8 @@ export function useRouteIsolationService() {
       if (!portolanIsolated) {
         portolanIsolated = true
         // re-derive: the overlay pass faded portolan's layers flat
-        fadeTransitLayers(null)
-        fadeTransitLayers(NETWORK_DIM(), { skipPortolan: true })
+        fadeTransitNetwork(mapInstance, null)
+        fadeTransitNetwork(mapInstance, networkDimOpacity(), { skipPortolan: true })
       }
       removeRouteOverlay()
     }
@@ -271,9 +227,9 @@ export function useRouteIsolationService() {
       if (portolanIsolated) {
         portolan.setIsolatedRoute(null)
         portolanIsolated = false
-        fadeTransitLayers(null)
+        fadeTransitNetwork(mapInstance, null)
       }
-      fadeTransitLayers(NETWORK_DIM())
+      fadeTransitNetwork(mapInstance, networkDimOpacity())
       const coords = runningSlice(route) ?? route.coordinates
       if (coords && coords.length >= 2) {
         addRouteShape(coords, route.routeColor)
@@ -408,7 +364,7 @@ export function useRouteIsolationService() {
     portolan.setIsolatedRouteGeometry(null)
 
     // Restore transit layer opacity
-    fadeTransitLayers(null)
+    fadeTransitNetwork(mapInstance, null)
 
     removeRouteOverlay()
 
@@ -460,61 +416,6 @@ export function useRouteIsolationService() {
         { padding: 60, duration: 800 },
       )
     } catch { /* fitBounds can throw on degenerate bounds */ }
-  }
-
-  /** Opacity paints recorded before fading, keyed `layerId|prop`. The
-   *  portolan ribbons carry opacity EXPRESSIONS (per-feed style manifests),
-   *  so restore must put back exactly what was there — resetting to null
-   *  would flatten them to the spec default. */
-  const savedOpacity = new Map<string, any>()
-
-  /** Every layer the isolation dims: the (retired) transitland ids that may
-   *  survive as user clones, plus every portolan layer in the current style,
-   *  enumerated by prefix — the set is per-feed and per-band, never fixed. */
-  function fadeTargetLayerIds(): string[] {
-    const ids = [...TRANSIT_LAYER_IDS]
-    try {
-      for (const layer of mapInstance?.getStyle()?.layers ?? []) {
-        if (layer.id.startsWith('portolan-')) ids.push(layer.id)
-      }
-    } catch {
-      // style not ready — the transitland list still applies
-    }
-    return ids
-  }
-
-  function fadeTransitLayers(
-    opacity: number | null,
-    { skipPortolan = false }: { skipPortolan?: boolean } = {},
-  ) {
-    if (!mapInstance) return
-
-    for (const layerId of fadeTargetLayerIds()) {
-      // when portolan IS the isolation, dimming it would dim the very
-      // line being shown
-      if (skipPortolan && layerId.startsWith('portolan-')) continue
-      try {
-        const layer = mapInstance.getLayer(layerId)
-        if (!layer) continue
-        const props = OPACITY_PROPS[layer.type] ?? []
-
-        for (const prop of props) {
-          const key = `${layerId}|${prop}`
-          if (opacity === null) {
-            // Restore the recorded paint (undefined → null clears cleanly)
-            mapInstance.setPaintProperty(layerId, prop, savedOpacity.get(key) ?? null)
-          } else {
-            if (!savedOpacity.has(key)) {
-              savedOpacity.set(key, mapInstance.getPaintProperty(layerId, prop))
-            }
-            mapInstance.setPaintProperty(layerId, prop, opacity)
-          }
-        }
-      } catch {
-        // Layer might not exist in current map style
-      }
-    }
-    if (opacity === null) savedOpacity.clear()
   }
 
   function addRouteShape(coordinates: [number, number][], color: string | null) {

--- a/web/src/services/layers/features/transit-network-dim.ts
+++ b/web/src/services/layers/features/transit-network-dim.ts
@@ -1,0 +1,122 @@
+/**
+ * Transit Network Dim
+ *
+ * Steps the transit network back so one thing on top of it — an isolated
+ * line, or an itinerary's own polyline — reads as the subject. Dimmed
+ * rather than hidden: a line followed through a city still belongs to
+ * that city, and the ribbons it crosses are what make the next transfer
+ * visible.
+ *
+ * One dimmer for the whole map. Two of them would each record the other's
+ * faded paint as the value to restore, and the network would never come
+ * back.
+ */
+
+/** Transitland layer IDs that should be faded (retired from the default
+ *  template — kept for user-cloned copies still on the map). Excludes
+ *  `transitland-route-active` — it's a hover utility layer with a
+ *  feature-state opacity expression that breaks if overridden flat.
+ *  Portolan layers are NOT listed: they're enumerated live off the style
+ *  by their `portolan-` prefix, since the set (per-feed, per-band) is
+ *  dynamic. */
+const TRANSIT_LAYER_IDS = [
+  'transitland-rail',
+  'transitland-rail-outline',
+  'transitland-bus-low',
+  'transitland-bus-low-outline',
+  'transitland-bus-medium',
+  'transitland-bus-medium-outline',
+  'transitland-tram',
+  'transitland-tram-outline',
+  'transitland-metro',
+  'transitland-metro-outline',
+  'transitland-other',
+  'transitland-other-outline',
+  'transitland-tram-labels',
+  'transitland-metro-labels',
+  'transitland-rail-labels',
+  'transitland-bus-medium-labels',
+  'transitland-other-labels',
+  'transitland-stops',
+  'transitland-stops-labels',
+]
+
+/** How far the network steps back — dimmed, not hidden. Matches portolan's
+ *  own ISOLATION_DIM; keep the two in step. */
+const NETWORK_DIM_LIGHT = 0.25
+const NETWORK_DIM_DARK = 0.42
+
+/** Theme-dependent for the same reason portolan's is: the same alpha reads
+ *  as "gone" against a near-black basemap. */
+export const networkDimOpacity = () =>
+  document.documentElement.classList.contains('dark')
+    ? NETWORK_DIM_DARK
+    : NETWORK_DIM_LIGHT
+
+/** Which opacity paint props carry a layer type's fade. */
+const OPACITY_PROPS: Record<string, string[]> = {
+  line: ['line-opacity'],
+  circle: ['circle-opacity', 'circle-stroke-opacity'],
+  symbol: ['text-opacity', 'icon-opacity'],
+}
+
+/** Opacity paints recorded before fading, keyed `layerId|prop`. The
+ *  portolan ribbons carry opacity EXPRESSIONS (per-feed style manifests),
+ *  so restore must put back exactly what was there — resetting to null
+ *  would flatten them to the spec default. */
+const savedOpacity = new Map<string, unknown>()
+
+/** Every layer the dim touches: the (retired) transitland ids that may
+ *  survive as user clones, plus every portolan layer in the current
+ *  style, enumerated by prefix — the set is per-feed and per-band. */
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function dimTargetLayerIds(map: any): string[] {
+  const ids = [...TRANSIT_LAYER_IDS]
+  try {
+    for (const layer of map?.getStyle()?.layers ?? []) {
+      if (layer.id.startsWith('portolan-')) ids.push(layer.id)
+    }
+  } catch {
+    // style not ready — the transitland list still applies
+  }
+  return ids
+}
+
+/**
+ * Fade the network to `opacity`, or restore it with null.
+ *
+ * `skipPortolan` is for the case where portolan's own ribbons ARE the
+ * highlight: dimming them would dim the very line being shown.
+ */
+export function fadeTransitNetwork(
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  map: any,
+  opacity: number | null,
+  { skipPortolan = false }: { skipPortolan?: boolean } = {},
+) {
+  if (!map) return
+
+  for (const layerId of dimTargetLayerIds(map)) {
+    if (skipPortolan && layerId.startsWith('portolan-')) continue
+    try {
+      const layer = map.getLayer(layerId)
+      if (!layer) continue
+
+      for (const prop of OPACITY_PROPS[layer.type] ?? []) {
+        const key = `${layerId}|${prop}`
+        if (opacity === null) {
+          map.setPaintProperty(layerId, prop, savedOpacity.get(key) ?? null)
+        } else {
+          if (!savedOpacity.has(key)) {
+            savedOpacity.set(key, map.getPaintProperty(layerId, prop))
+          }
+          map.setPaintProperty(layerId, prop, opacity)
+        }
+      }
+    } catch {
+      // Layer might not exist in the current map style
+    }
+  }
+
+  if (opacity === null) savedOpacity.clear()
+}

--- a/web/src/services/layers/features/trip-isolation.service.ts
+++ b/web/src/services/layers/features/trip-isolation.service.ts
@@ -1,0 +1,56 @@
+/**
+ * Trip Isolation Service
+ *
+ * Steps the transit network back while an itinerary is on the map, so the
+ * trip's own polyline reads as the subject instead of competing with
+ * every line it crosses.
+ *
+ * That is all it does. The route panel lifts its line out of portolan's
+ * ribbons; a trip must not, because portolan draws bundled routes at
+ * parallel slot offsets — an isolated A would land beside the trip line
+ * rather than under it, the same line drawn twice in two styles. The trip
+ * line is already the highlight; the dim is the other half of it.
+ *
+ * Stands down entirely when the route panel is the focus: that view owns
+ * the dim, and two owners would fight over the paint they restore.
+ */
+
+import { watch, type WatchStopHandle } from 'vue'
+import { useTransitFocusStore } from '@/stores/transit-focus.store'
+import {
+  fadeTransitNetwork,
+  networkDimOpacity,
+} from '@/services/layers/features/transit-network-dim'
+
+export function useTripIsolationService() {
+  const focus = useTransitFocusStore()
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let mapInstance: any = null
+  let watchStop: WatchStopHandle | null = null
+  let dimmed = false
+
+  function apply(active: boolean) {
+    if (!mapInstance || active === dimmed) return
+    dimmed = active
+    fadeTransitNetwork(mapInstance, active ? networkDimOpacity() : null)
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  function initialize(map: any) {
+    mapInstance = map
+    watchStop = watch(
+      () => focus.source === 'trip',
+      apply,
+      { immediate: true },
+    )
+  }
+
+  function destroy() {
+    apply(false)
+    watchStop?.()
+    watchStop = null
+    mapInstance = null
+  }
+
+  return { initialize, destroy }
+}

--- a/web/src/services/layers/features/trip-isolation.service.ts
+++ b/web/src/services/layers/features/trip-isolation.service.ts
@@ -13,10 +13,16 @@
  *
  * Stands down entirely when the route panel is the focus: that view owns
  * the dim, and two owners would fight over the paint they restore.
+ *
+ * Portolan dims its own ribbons rather than being painted over: they mount
+ * progressively as tiles hydrate, and a one-shot override catches only the
+ * layers that exist the instant it runs. The flat override is left to the
+ * retired transitland layers, which are static when they are there at all.
  */
 
 import { watch, type WatchStopHandle } from 'vue'
 import { useTransitFocusStore } from '@/stores/transit-focus.store'
+import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
 import {
   fadeTransitNetwork,
   networkDimOpacity,
@@ -24,6 +30,7 @@ import {
 
 export function useTripIsolationService() {
   const focus = useTransitFocusStore()
+  const portolan = usePortolanTransitService()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mapInstance: any = null
   let watchStop: WatchStopHandle | null = null
@@ -32,7 +39,10 @@ export function useTripIsolationService() {
   function apply(active: boolean) {
     if (!mapInstance || active === dimmed) return
     dimmed = active
-    fadeTransitNetwork(mapInstance, active ? networkDimOpacity() : null)
+    portolan.setNetworkDim(active)
+    fadeTransitNetwork(mapInstance, active ? networkDimOpacity() : null, {
+      skipPortolan: true,
+    })
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/web/src/services/layers/features/trip-isolation.service.ts
+++ b/web/src/services/layers/features/trip-isolation.service.ts
@@ -1,9 +1,14 @@
 /**
  * Trip Isolation Service
  *
- * Steps the transit network back while an itinerary is on the map, so the
- * trip's own polyline reads as the subject instead of competing with
- * every line it crosses.
+ * Decides what the transit network does while an itinerary is on the map,
+ * hovered in the list or opened.
+ *
+ * A trip that rides transit steps the network back, so the trip's own
+ * polyline reads as the subject instead of competing with every line it
+ * crosses. A trip that rides none takes it off the map altogether: there
+ * the ribbons are not context for a walking or driving line, just clutter
+ * beside it.
  *
  * That is all it does. The route panel lifts its line out of portolan's
  * ribbons; a trip must not, because portolan draws bundled routes at
@@ -21,7 +26,10 @@
  */
 
 import { watch, type WatchStopHandle } from 'vue'
-import { useTransitFocusStore } from '@/stores/transit-focus.store'
+import {
+  useTransitFocusStore,
+  type TransitNetworkMode,
+} from '@/stores/transit-focus.store'
 import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
 import {
   fadeTransitNetwork,
@@ -34,29 +42,28 @@ export function useTripIsolationService() {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mapInstance: any = null
   let watchStop: WatchStopHandle | null = null
-  let dimmed = false
+  let mode: TransitNetworkMode = 'normal'
 
-  function apply(active: boolean) {
-    if (!mapInstance || active === dimmed) return
-    dimmed = active
-    portolan.setNetworkDim(active)
-    fadeTransitNetwork(mapInstance, active ? networkDimOpacity() : null, {
-      skipPortolan: true,
-    })
+  function apply(next: TransitNetworkMode) {
+    if (!mapInstance || next === mode) return
+    mode = next
+    portolan.setNetworkDim(next === 'dimmed')
+    portolan.setNetworkHidden(next === 'hidden')
+    // The retired transitland layers have no renderer of their own to ask,
+    // so they take the flat override — zero opacity is how they hide.
+    const opacity =
+      next === 'dimmed' ? networkDimOpacity() : next === 'hidden' ? 0 : null
+    fadeTransitNetwork(mapInstance, opacity, { skipPortolan: true })
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   function initialize(map: any) {
     mapInstance = map
-    watchStop = watch(
-      () => focus.source === 'trip',
-      apply,
-      { immediate: true },
-    )
+    watchStop = watch(() => focus.networkMode, apply, { immediate: true })
   }
 
   function destroy() {
-    apply(false)
+    apply('normal')
     watchStop?.()
     watchStop = null
     mapInstance = null

--- a/web/src/services/layers/markers/marker-layers.service.ts
+++ b/web/src/services/layers/markers/marker-layers.service.ts
@@ -22,6 +22,7 @@ import {
 import { useDirectionsStore } from '@/stores/directions.store'
 import { useTransitVehiclesStore } from '@/stores/transit-vehicles.store'
 import { useRouteIsolationService } from '@/services/layers/features/route-isolation.service'
+import { useTripIsolationService } from '@/services/layers/features/trip-isolation.service'
 import type { FitBoundsFn } from '@/types/map.types'
 import { watch, Component, type WatchStopHandle } from 'vue'
 
@@ -41,6 +42,7 @@ export function useMarkerLayersService() {
   let watchStops: WatchStopHandle[] = []
   let moveEndCleanup: (() => void) | null = null
   let routeIsolation: ReturnType<typeof useRouteIsolationService> | null = null
+  let tripIsolation: ReturnType<typeof useTripIsolationService> | null = null
 
   // ============================================================================
   // INITIALIZATION
@@ -120,6 +122,10 @@ export function useMarkerLayersService() {
     routeIsolation = useRouteIsolationService()
     routeIsolation.initialize(mapStrategy.mapInstance, fitBounds)
 
+    // Trip isolation: dims the network behind an open itinerary's line
+    tripIsolation = useTripIsolationService()
+    tripIsolation.initialize(mapStrategy.mapInstance)
+
     // Set up watchers for reactive updates
     setupMarkerLayerWatchers()
   }
@@ -178,6 +184,8 @@ export function useMarkerLayersService() {
     moveEndCleanup = null
     routeIsolation?.destroy()
     routeIsolation = null
+    tripIsolation?.destroy()
+    tripIsolation = null
 
     waypointsLayer?.destroy()
     friendLocationsLayer?.destroy()

--- a/web/src/stores/route-detail.store.ts
+++ b/web/src/stores/route-detail.store.ts
@@ -8,6 +8,7 @@
 import { ref, computed } from 'vue'
 import { defineStore } from 'pinia'
 import { api } from '@/lib/api'
+import { fetchVehiclesOnRoutes } from '@/lib/transit-vehicle-fetch'
 import type { TransitVehiclePosition } from '@/types/multimodal.types'
 import type { TransitDeparture } from '@/types/place.types'
 import type { AlertServiceOverrides } from '@/lib/alert-service-overrides'
@@ -731,34 +732,11 @@ export const useRouteDetailStore = defineStore('route-detail', () => {
     if (routeIds.length === 0) return
 
     try {
-      // Try the route-specific endpoint first (no bounds needed)
-      let vehicleData: TransitVehiclePosition[] | null = null
-
-      try {
-        const { data } = await api.get<{ vehicles: TransitVehiclePosition[] }>(
-          '/transit/route-vehicles',
-          { params: { routeIds: routeIds.join(','), feedId: activeRoute.value.feedId } },
-        )
-        vehicleData = data?.vehicles ?? null
-      } catch {
-        // Endpoint not available (server needs restart) — fall back to bbox
-      }
-
-      // Fallback: use the bbox vehicles endpoint with a wide bounds
-      if (!vehicleData) {
-        const bounds = routeBounds()
-        if (!bounds) return
-        const { data } = await api.get<{ vehicles: TransitVehiclePosition[] }>(
-          '/transit/vehicles',
-          { params: bounds },
-        )
-        // Filter to our routes client-side
-        const routeIdSet = new Set(routeIds)
-        vehicleData = (data?.vehicles ?? []).filter(v =>
-          (v.routeId && routeIdSet.has(v.routeId)) ||
-          (v.routeShortName && routeIdSet.has(v.routeShortName)),
-        )
-      }
+      const vehicleData = await fetchVehiclesOnRoutes(
+        activeRoute.value.feedId,
+        routeIds,
+        routeBounds,
+      )
 
       const updated = new Map<string, TransitVehiclePosition>()
       for (const v of vehicleData) {

--- a/web/src/stores/transit-focus.store.ts
+++ b/web/src/stores/transit-focus.store.ts
@@ -24,6 +24,16 @@ import type { TransitVehiclePosition } from '@/types/multimodal.types'
 
 export type TransitFocusSource = 'route' | 'trip'
 
+/**
+ * What the transit network should be doing behind whatever is on top of it.
+ *
+ * `hidden` is for a trip that rides no transit at all: the ribbons are not
+ * context for a walking or driving line, just clutter beside it. A trip
+ * that does ride transit gets `dimmed`, because there the surrounding
+ * network is what makes the next transfer legible.
+ */
+export type TransitNetworkMode = 'normal' | 'dimmed' | 'hidden'
+
 const NO_IDS: ReadonlySet<string> = new Set()
 const NO_VEHICLES: ReadonlyMap<string, TransitVehiclePosition> = new Map()
 
@@ -36,6 +46,13 @@ export const useTransitFocusStore = defineStore('transit-focus', () => {
   )
 
   const isActive = computed(() => source.value !== null)
+
+  const networkMode = computed<TransitNetworkMode>(() => {
+    // The route panel runs its own isolation over the same layers.
+    if (routeDetail.isActive) return 'normal'
+    if (!tripFocus.hasFocusedTrip) return 'normal'
+    return tripFocus.isActive ? 'dimmed' : 'hidden'
+  })
 
   /** Where the vehicles on screen come from. Each owner polls its own
    *  routes, so neither has to care about the viewport. */
@@ -100,6 +117,7 @@ export const useTransitFocusStore = defineStore('transit-focus', () => {
   return {
     source,
     isActive,
+    networkMode,
     vehicles,
     visibleVehicleIds,
     emphasizedVehicleIds,

--- a/web/src/stores/transit-focus.store.ts
+++ b/web/src/stores/transit-focus.store.ts
@@ -1,0 +1,110 @@
+/**
+ * Transit Focus Store
+ *
+ * The one answer to "is the map showing a particular piece of transit,
+ * and which vehicles belong to it" — asked by the vehicle layer and by
+ * the network dim, answered by whichever page owns the map.
+ *
+ * Two pages can own it: the route panel, which lifts one line out of the
+ * network, and an open itinerary, which rides several. They differ in
+ * what they highlight; they agree on how vehicles read, which is why that
+ * part lives here rather than in either of them.
+ *
+ * The route panel wins a tie. Opening a line from inside a trip is a
+ * deliberate narrowing, and the narrower view is the one the rider asked
+ * for.
+ */
+
+import { computed } from 'vue'
+import { defineStore } from 'pinia'
+import { useRouteDetailStore } from '@/stores/route-detail.store'
+import { useTripFocusStore } from '@/stores/trip-focus.store'
+import type { FocusedStop } from '@/lib/transit-focus'
+import type { TransitVehiclePosition } from '@/types/multimodal.types'
+
+export type TransitFocusSource = 'route' | 'trip'
+
+const NO_IDS: ReadonlySet<string> = new Set()
+const NO_VEHICLES: ReadonlyMap<string, TransitVehiclePosition> = new Map()
+
+export const useTransitFocusStore = defineStore('transit-focus', () => {
+  const routeDetail = useRouteDetailStore()
+  const tripFocus = useTripFocusStore()
+
+  const source = computed<TransitFocusSource | null>(() =>
+    routeDetail.isActive ? 'route' : tripFocus.isActive ? 'trip' : null,
+  )
+
+  const isActive = computed(() => source.value !== null)
+
+  /** Where the vehicles on screen come from. Each owner polls its own
+   *  routes, so neither has to care about the viewport. */
+  const vehicles = computed<ReadonlyMap<string, TransitVehiclePosition>>(() => {
+    if (source.value === 'route') return routeDetail.vehicles
+    if (source.value === 'trip') return tripFocus.vehicles
+    return NO_VEHICLES
+  })
+
+  /** Vehicles allowed on the map at all. */
+  const visibleVehicleIds = computed<ReadonlySet<string>>(() => {
+    if (source.value === 'route') return routeDetail.directionFilteredVehicleIds
+    if (source.value === 'trip') return tripFocus.visibleVehicleIds
+    return NO_IDS
+  })
+
+  /**
+   * The vehicles that are the rider's. Non-empty means every other
+   * visible vehicle renders dimmed; empty means none of them do — a page
+   * that cannot say which train is yours must not fade the others behind
+   * a guess.
+   */
+  const emphasizedVehicleIds = computed<ReadonlySet<string>>(() => {
+    if (source.value === 'route') {
+      return routeDetail.selectedVehicleId
+        ? new Set([routeDetail.selectedVehicleId])
+        : NO_IDS
+    }
+    if (source.value === 'trip') return tripFocus.emphasizedVehicleIds
+    return NO_IDS
+  })
+
+  /**
+   * Stops the focused transit calls at, so the vehicle animation can
+   * constrain a run to the stop it is next due at rather than free-run it
+   * along the shape. A trip contributes every leg's stops; ids are
+   * feed-local on both sides, and a lookup is by id, so the union is safe.
+   */
+  const focusedStops = computed<FocusedStop[]>(() => {
+    if (source.value === 'route') {
+      return (routeDetail.activeRoute?.stops ?? []).map((s) => ({
+        stopId: s.stopId,
+        lat: s.lat,
+        lng: s.lng,
+      }))
+    }
+    if (source.value === 'trip') return tripFocus.legs.flatMap((leg) => leg.stops)
+    return []
+  })
+
+  /** The route panel's own route data is the authority on a line's mode;
+   *  the vehicle feed's enrichment cache can be stale about it. */
+  const routeTypeOverride = computed(() =>
+    source.value === 'route' ? routeDetail.activeRoute?.routeType ?? undefined : undefined,
+  )
+
+  /** Route detail alone owns a selection the rider can change. */
+  function selectVehicle(vehicleId: string | null) {
+    if (source.value === 'route') routeDetail.selectVehicle(vehicleId)
+  }
+
+  return {
+    source,
+    isActive,
+    vehicles,
+    visibleVehicleIds,
+    emphasizedVehicleIds,
+    focusedStops,
+    routeTypeOverride,
+    selectVehicle,
+  }
+})

--- a/web/src/stores/trip-focus.store.ts
+++ b/web/src/stores/trip-focus.store.ts
@@ -19,7 +19,6 @@ import { fetchVehiclesOnRoutes } from '@/lib/transit-vehicle-fetch'
 import {
   focusedLegs,
   routeIdsByFeed,
-  vehiclesOnFocusedRoutes,
   yourVehicleIds,
   type FocusedLeg,
 } from '@/lib/transit-focus'
@@ -69,13 +68,19 @@ export const useTripFocusStore = defineStore('trip-focus', () => {
 
   const isActive = computed(() => legs.value.length > 0)
 
-  const visibleVehicleIds = computed(() =>
-    vehiclesOnFocusedRoutes(legs.value, vehicles.value.values()),
-  )
-
+  /**
+   * Only the runs the rider is actually catching — one per leg.
+   *
+   * The whole line's service is fetched (it is how the rider's own run is
+   * found at all), but drawing it turned the map into a field of trains
+   * with the relevant one somewhere among them. A leg whose run cannot be
+   * named contributes nothing rather than falling back to its whole line.
+   */
   const emphasizedVehicleIds = computed(() =>
     yourVehicleIds(legs.value, vehicles.value.values()),
   )
+
+  const visibleVehicleIds = emphasizedVehicleIds
 
   // ── polling ──────────────────────────────────────────────────────
   let pollTimer: ReturnType<typeof setInterval> | null = null

--- a/web/src/stores/trip-focus.store.ts
+++ b/web/src/stores/trip-focus.store.ts
@@ -66,6 +66,11 @@ export const useTripFocusStore = defineStore('trip-focus', () => {
     })),
   )
 
+  /** A trip is on the map at all — hovered in the list or opened — whether
+   *  or not any of it is ridden on transit. */
+  const hasFocusedTrip = computed(() => !!focusedTrip.value)
+
+  /** ...and some of it is transit, which is what the map has to react to. */
   const isActive = computed(() => legs.value.length > 0)
 
   /**
@@ -137,6 +142,7 @@ export const useTripFocusStore = defineStore('trip-focus', () => {
   return {
     focusedTrip,
     legs,
+    hasFocusedTrip,
     isActive,
     vehicles,
     visibleVehicleIds,

--- a/web/src/stores/trip-focus.store.ts
+++ b/web/src/stores/trip-focus.store.ts
@@ -1,0 +1,141 @@
+/**
+ * Trip Focus Store
+ *
+ * The map's view of an open itinerary: which lines it rides, and where
+ * their vehicles are. The trip's own polyline is drawn by the directions
+ * layer group — this store only supplies what has to fade behind it and
+ * what has to stay live on top of it.
+ *
+ * Deliberately NOT a portolan isolation like the route panel's: portolan
+ * bundles routes at parallel slot offsets, so lifting the A out of the
+ * tiles would draw it beside the trip line rather than under it. The trip
+ * line is the subject here; the network just steps back.
+ */
+
+import { computed, ref, watch } from 'vue'
+import { defineStore } from 'pinia'
+import { useDirectionsStore } from '@/stores/directions.store'
+import { fetchVehiclesOnRoutes } from '@/lib/transit-vehicle-fetch'
+import {
+  focusedLegs,
+  routeIdsByFeed,
+  vehiclesOnFocusedRoutes,
+  yourVehicleIds,
+  type FocusedLeg,
+} from '@/lib/transit-focus'
+import type { TransitVehiclePosition } from '@/types/multimodal.types'
+
+/** Matches the route panel's cadence, so the two pages animate alike. */
+const VEHICLE_POLL_MS = 5_000
+
+export const useTripFocusStore = defineStore('trip-focus', () => {
+  const directionsStore = useDirectionsStore()
+
+  const vehicles = ref<Map<string, TransitVehiclePosition>>(new Map())
+
+  /**
+   * Trip ids resolved from a leg's departure board, by segment index.
+   *
+   * MOTIS names a run with its own encoded token, which the realtime feed
+   * has never heard of; the board names it with the feed's own trip id,
+   * which is exactly what a vehicle carries. The trip page pushes what its
+   * board resolved, and that outranks the planner's id — including after a
+   * rebooking, where the planner's id is the run the rider just abandoned.
+   */
+  const boardTripIds = ref<Record<number, string>>({})
+
+  /** Whole map at once — the page resolves every leg's board together, and
+   *  one write keeps the poll key from churning per leg. */
+  function setLegTripIds(ids: Record<number, string>) {
+    boardTripIds.value = ids
+  }
+
+  /** The trip on the map: the rider's pick, else the one the map defaults
+   *  to when a fresh set of results lands. */
+  const focusedTrip = computed(() => {
+    const list = directionsStore.trips?.trips
+    if (!list?.length) return null
+    const selected = directionsStore.selectedTripId
+    if (selected) return list.find((t) => t.id === selected) ?? null
+    return list.find((t) => t.isRecommended) ?? list[0] ?? null
+  })
+
+  const legs = computed<FocusedLeg[]>(() =>
+    focusedLegs(focusedTrip.value).map((leg) => ({
+      ...leg,
+      tripId: boardTripIds.value[leg.segmentIndex] ?? leg.tripId,
+    })),
+  )
+
+  const isActive = computed(() => legs.value.length > 0)
+
+  const visibleVehicleIds = computed(() =>
+    vehiclesOnFocusedRoutes(legs.value, vehicles.value.values()),
+  )
+
+  const emphasizedVehicleIds = computed(() =>
+    yourVehicleIds(legs.value, vehicles.value.values()),
+  )
+
+  // ── polling ──────────────────────────────────────────────────────
+  let pollTimer: ReturnType<typeof setInterval> | null = null
+  /** Bumps on every leg change, so a slow feed's answer for a trip the
+   *  rider has already left never lands. */
+  let fetchGeneration = 0
+
+  async function fetchVehicles() {
+    const byFeed = routeIdsByFeed(legs.value)
+    if (!byFeed.size) return
+    const gen = fetchGeneration
+
+    const results = await Promise.all(
+      [...byFeed].map(([feedId, routeIds]) =>
+        fetchVehiclesOnRoutes(feedId, routeIds).catch(() => []),
+      ),
+    )
+    if (gen !== fetchGeneration) return
+
+    const next = new Map<string, TransitVehiclePosition>()
+    for (const list of results) {
+      for (const v of list) next.set(v.vehicleId, v)
+    }
+    vehicles.value = next
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearInterval(pollTimer)
+      pollTimer = null
+    }
+  }
+
+  // Keyed on the lines rather than the trip: switching between two
+  // itineraries that ride the same trains should not blank the map.
+  watch(
+    () => [...routeIdsByFeed(legs.value)]
+      .map(([feedId, ids]) => `${feedId}:${[...ids].sort().join(',')}`)
+      .sort()
+      .join('|'),
+    (key) => {
+      fetchGeneration++
+      stopPolling()
+      if (!key) {
+        vehicles.value = new Map()
+        return
+      }
+      void fetchVehicles()
+      pollTimer = setInterval(fetchVehicles, VEHICLE_POLL_MS)
+    },
+    { immediate: true },
+  )
+
+  return {
+    focusedTrip,
+    legs,
+    isActive,
+    vehicles,
+    visibleVehicleIds,
+    emphasizedVehicleIds,
+    setLegTripIds,
+  }
+})

--- a/web/src/views/directions/TripDetail.vue
+++ b/web/src/views/directions/TripDetail.vue
@@ -4,6 +4,7 @@ import { useRoute, useRouter, onBeforeRouteLeave } from 'vue-router'
 import { api } from '@/lib/api'
 import { applyDepartureChange } from '@/lib/trip-rebooking'
 import { useDirectionsStore } from '@/stores/directions.store'
+import { useTripFocusStore } from '@/stores/trip-focus.store'
 import { useDirectionsService } from '@/services/directions.service'
 import { useMapService } from '@/services/map.service'
 import { useGeolocationService } from '@/services/geolocation.service'
@@ -71,6 +72,7 @@ import { useI18n } from 'vue-i18n'
 const route = useRoute()
 const router = useRouter()
 const directionsStore = useDirectionsStore()
+const tripFocusStore = useTripFocusStore()
 const directionsService = useDirectionsService()
 const mapService = useMapService()
 const themeStore = useThemeStore()
@@ -804,6 +806,30 @@ watch(
   { immediate: true },
 )
 
+/**
+ * Tell the map which run each leg is riding.
+ *
+ * The planner names a run with its own encoded token, which the realtime
+ * feed has never heard of; the board names it with the feed's own trip id,
+ * which is exactly what a vehicle carries. Matching by departure time is
+ * what ties the two together — and it re-ties after a rebooking, so the
+ * highlighted vehicle follows the train the rider actually picked.
+ */
+watch(
+  [trip, segmentDepartures],
+  ([t]) => {
+    const ids: Record<number, string> = {}
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;((t?.segments ?? []) as any[]).forEach((seg, idx) => {
+      if (seg.mode !== 'transit') return
+      const run = departuresFor(idx).find((d) => isCurrentDeparture(seg, d.ms))
+      if (run?.tripId) ids[idx] = splitFeedId(run.tripId).localId
+    })
+    tripFocusStore.setLegTripIds(ids)
+  },
+  { immediate: true },
+)
+
 // Keep the URL's id canonical after a signature match, so departure
 // rebooking and further shares reference the live trip object.
 watch(trip, (t) => {
@@ -865,6 +891,8 @@ onBeforeRouteLeave(to => {
 // the service's syncUrl watcher, whose router.replace cancels the outgoing
 // navigation. `route.name` is the committed destination here.
 onUnmounted(() => {
+  // The board's run ids belong to this page's boards; the list page has none.
+  tripFocusStore.setLegTripIds({})
   if (route.name === AppRoute.DIRECTIONS) return
   directionsService.clearWaypoints()
   directionsStore.unsetTrips()


### PR DESCRIPTION
A live preview of this branch is running on the author's development
machine, hot-reloading on every push. The link is on a private network and is
deliberately not published here.