### PR TITLE
Green bike surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@
   name that wraps reads as one block instead of separate lines
 * Street names shrink to small spaced capitals as you zoom in, so the shops and
   stations you're looking for carry the map
+* Cycleways and paths where bikes are designated now show as a green road
+  surface rather than a dotted line laid over the street, exactly as wide as
+  the road itself at every zoom
+* Bike lanes, tracks and sharrows are redrawn as thin markings along the street
+  they're painted on, with each form a different weight so a protected track
+  reads apart from a shared lane
+* Signed bike routes now show as a soft corridor behind the network instead of
+  another green line competing with it
+* The cycling layer now draws under place names and under transit lines, so a
+  train crossing a bike lane passes over it
 
 ### Fixed
 
@@ -30,6 +40,7 @@
   font it has never had, and silently drew nothing
 * Station names on a line's own page now follow the map's theme instead of
   always being dark text in a white halo
+* Bike route labels no longer sit on top of the places you're looking at
 * The trip suggestions timeline scrolls sideways, so a trip that runs past the
   visible range can be followed to its end. Each suggestion's type and route
   description stay pinned at the edge so you can tell the rows apart.

--- a/server/src/constants/default-layers/cycling.ts
+++ b/server/src/constants/default-layers/cycling.ts
@@ -4,1118 +4,254 @@ import { LayerType } from '../../schema/layers.schema'
 /**
  * Cycling default layer templates.
  *
- * Convention: layer `order` values are spaced in intervals of 10 within each
- * subgroup (110, 120, 130, …) so that user-driven reorders can slot new
- * templates or clones between existing ones without immediately needing a
- * full re-index. When adjusting values, keep the spacing consistent so the
- * client-side sort stays predictable.
+ * The network is drawn in two halves, and which half a way belongs to is the
+ * whole design.
+ *
+ * A way that **is** cycling infrastructure — a cycleway, a path where bikes
+ * are designated — is drawn by the BASEMAP, which repaints that road's own
+ * surface green at exactly the width it already draws it; see
+ * `addCyclingSurface` in `web/scripts/convert-basemap-style.mjs`. A bike path
+ * is a road you ride on, so it is painted like one rather than traced with a
+ * dotted line laid over the top. Those layers switch on with this group
+ * through `basemapGroup` on the group template.
+ *
+ * A way that merely **carries** cycling infrastructure — a street with a lane
+ * or a protected track down one side — is drawn here, from Barrelman, as a
+ * thin line along the street. The lane is part of the road, not the road, and
+ * tinting the whole carriageway for it would claim the traffic lanes too.
+ *
+ * Everything here slots to `bottom`: the network is ground, so it draws under
+ * the labels and under the transit lines that cross above it.
  */
+
+const SOURCE = {
+  id: 'bicycle-ways',
+  type: 'vector' as const,
+  tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
+  maxzoom: 16,
+}
+
+/**
+ * The on-street palette, keyed to how much of a bike's own space a form is.
+ *
+ * A protected track is a lane of the street given over to bikes, and takes the
+ * deepest green; a painted lane is a line on the asphalt and sits a step back;
+ * a sharrow is a marking on a lane shared with traffic and is dashed, because
+ * that is honestly what it offers. `permitted` is a road bikes may use and no
+ * more, which is most of the residential grid — faint, and off unless asked
+ * for.
+ *
+ * Every one of them lands between the basemap's road surface and its casing in
+ * value, so a green line reads as painted ON the street rather than as another
+ * street. The night values are lifted rather than inverted: the roads are dark
+ * there and the marking still has to be the brighter of the two.
+ */
+const INK = {
+  track: { light: 'hsl(152, 62%, 31%)', dark: 'hsl(150, 52%, 60%)' },
+  lane: { light: 'hsl(150, 55%, 38%)', dark: 'hsl(148, 46%, 56%)' },
+  shared: { light: 'hsl(150, 32%, 50%)', dark: 'hsl(148, 26%, 56%)' },
+  permitted: { light: 'hsl(150, 24%, 62%)', dark: 'hsl(148, 18%, 48%)' },
+  route: { light: 'hsl(146, 52%, 40%)', dark: 'hsl(148, 44%, 54%)' },
+  proposed: { light: 'hsl(150, 18%, 58%)', dark: 'hsl(150, 14%, 52%)' },
+  construction: { light: 'hsl(36, 78%, 48%)', dark: 'hsl(38, 72%, 60%)' },
+}
+
+/**
+ * A light/dark pair, as the expression both engines understand.
+ *
+ * Mapbox reads `measure-light` natively; on MapLibre `stripMapboxExpressions`
+ * resolves it against the app theme, darkest stop first. Written once here
+ * because it was written out longhand fourteen times.
+ */
+const themed = (pair: { light: string; dark: string }) => [
+  'interpolate',
+  ['linear'],
+  ['measure-light', 'brightness'],
+  0.25,
+  pair.dark,
+  0.3,
+  pair.light,
+]
+
+/** A width ramp, as (zoom, px) pairs. */
+const width = (...stops: number[]) => [
+  'interpolate',
+  ['linear'],
+  ['zoom'],
+  ...stops,
+]
+
+interface WayLayer {
+  id: string
+  name: string
+  group: string
+  order: number
+  minzoom: number
+  filter: any
+  color: any
+  width: any
+  dash?: number[]
+  opacity?: number
+  visible?: boolean
+}
+
+/** Everything drawn from Barrelman's `bicycle_ways`, as one shape. */
+function wayLayer(l: WayLayer): DefaultLayerTemplate {
+  return {
+    templateId: `default:${l.id}`,
+    name: l.name,
+    type: LayerType.CUSTOM,
+    engine: ['mapbox', 'maplibre'],
+    icon: 'BikeIcon',
+    showInLayerSelector: false,
+    visible: l.visible ?? false,
+    order: l.order,
+    groupId: `default:group:cycling:${l.group}`,
+    isSubLayer: true,
+    integrationId: 'barrelman',
+    configuration: {
+      id: l.id,
+      type: 'line',
+      slot: 'bottom',
+      source: SOURCE,
+      'source-layer': 'bicycle_ways',
+      minzoom: l.minzoom,
+      filter: l.filter,
+      paint: {
+        'line-color': l.color,
+        'line-width': l.width,
+        ...(l.dash ? { 'line-dasharray': l.dash } : {}),
+        'line-opacity': l.opacity ?? 1,
+        'line-emissive-strength': 1,
+      },
+      layout: { 'line-cap': l.dash ? 'butt' : 'round', 'line-join': 'round' },
+    },
+  }
+}
+
+/** Barrelman marks a way's state; absent means it is built and open. */
+const BUILT = ['!has', 'state']
+
 export const CYCLING_LAYER_TEMPLATES: DefaultLayerTemplate[] = [
-  // ── Bicycle routes (relations: icn, ncn, rcn, lcn) ─────────
-  {
-    templateId: 'default:bicycle-routes',
+  /**
+   * Signed route relations (icn / ncn / rcn / lcn), as a soft corridor under
+   * the network rather than a line in it.
+   *
+   * A signed route is not a piece of infrastructure — it is a recommendation
+   * laid over whatever infrastructure exists, and often over none. Drawing it
+   * as another green line put it in competition with the lanes it runs along;
+   * a wide, pale band behind them says "this way is signed" without claiming
+   * to be the thing you ride on.
+   */
+  wayLayer({
+    id: 'bicycle-routes',
     name: 'Bike Routes',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 110,
-    groupId: 'default:group:cycling:bike-routes',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-routes',
-      type: 'line',
-      source: {
-        id: 'bicycle-routes',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_routes/{z}/{x}/{y}'],
-        maxzoom: 14,
-      },
-      'source-layer': 'bicycle_routes',
-      minzoom: 5,
-      filter: ['!=', ['get', 'state'], 'proposed'],
-      paint: {
-        'line-color': [
-          'match',
-          ['get', 'network'],
-          'icn',
-          '#145a32',
-          'ncn',
-          '#1a7a3a',
-          'rcn',
-          '#276749',
-          'lcn',
-          '#2d8a4e',
-          '#2d8a4e',
-        ],
-        'line-width': [
-          'interpolate',
-          ['exponential', 1.5],
-          ['zoom'],
-          5,
-          1,
-          8,
-          1.5,
-          10,
-          2,
-          12,
-          3,
-          14,
-          4,
-          16,
-          5,
-        ],
-        'line-opacity': 0.3,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
+    group: 'bike-routes',
+    order: 10,
+    minzoom: 5,
+    filter: ['!=', ['get', 'state'], 'proposed'],
+    color: themed(INK.route),
+    width: width(5, 3, 10, 6, 14, 10, 16, 14),
+    opacity: 0.16,
+  }),
 
-  // Dedicated cycleways (highway=cycleway) — casing (outline)
-  {
-    templateId: 'default:bicycle-cycleways-casing',
-    name: 'Cycleways Casing',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 30,
-    groupId: 'default:group:cycling:cycleways',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-cycleways-casing',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 10,
-      filter: ['all', ['==', 'infra_type', 'cycleway'], ['!has', 'state']],
-      paint: {
-        'line-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#1a2a1f',
-          0.3,
-          '#ffffff',
-        ],
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          10,
-          2.5,
-          14,
-          5,
-          16,
-          8,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.5,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Dedicated cycleways — fill (paved)
-  {
-    templateId: 'default:bicycle-cycleways',
-    name: 'Cycleways Paved',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 31,
-    groupId: 'default:group:cycling:cycleways',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-cycleways',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 10,
-      filter: [
-        'all',
-        ['==', 'infra_type', 'cycleway'],
-        ['!has', 'state'],
-        [
-          '!in',
-          'surface',
-          'gravel',
-          'dirt',
-          'grass',
-          'ground',
-          'earth',
-          'sand',
-          'mud',
-          'unpaved',
-          'fine_gravel',
-          'compacted',
-        ],
-      ],
-      paint: {
-        'line-color': '#1a7a3a',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          10,
-          1.5,
-          14,
-          3.5,
-          16,
-          6,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Dedicated cycleways — fill (unpaved surfaces)
-  {
-    templateId: 'default:bicycle-cycleways-unpaved',
-    name: 'Cycleways Unpaved',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 32,
-    groupId: 'default:group:cycling:cycleways',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-cycleways-unpaved',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 10,
-      filter: [
-        'all',
-        ['==', 'infra_type', 'cycleway'],
-        ['!has', 'state'],
-        [
-          'in',
-          'surface',
-          'gravel',
-          'dirt',
-          'grass',
-          'ground',
-          'earth',
-          'sand',
-          'mud',
-          'unpaved',
-          'fine_gravel',
-          'compacted',
-        ],
-      ],
-      paint: {
-        'line-color': '#2d8a4e',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          10,
-          1.5,
-          14,
-          3.5,
-          16,
-          6,
-        ],
-        'line-dasharray': [4, 2],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-
-  // Cycle tracks (physically separated, cycleway=track)
-  {
-    templateId: 'default:bicycle-tracks',
+  // Protected tracks: a lane of the street, kerbed or posted off for bikes.
+  wayLayer({
+    id: 'bicycle-tracks',
     name: 'Cycle Tracks',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
+    group: 'cycle-tracks',
     order: 40,
-    groupId: 'default:group:cycling:cycle-tracks',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-tracks',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: ['all', ['==', 'infra_type', 'cycle_track'], ['!has', 'state']],
-      paint: {
-        'line-color': '#2d8a4e',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          1.2,
-          14,
-          3,
-          16,
-          5,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
+    minzoom: 11,
+    filter: ['all', ['==', 'infra_type', 'cycle_track'], BUILT],
+    color: themed(INK.track),
+    width: width(11, 0.9, 14, 1.8, 16, 2.6, 19, 4),
+  }),
 
-  // Bike lanes — casing
-  {
-    templateId: 'default:bicycle-lanes-casing',
-    name: 'Bike Lanes Casing',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 50,
-    groupId: 'default:group:cycling:bike-lanes',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-lanes-casing',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 12,
-      filter: ['all', ['==', 'infra_type', 'cycle_lane'], ['!has', 'state']],
-      paint: {
-        'line-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#1a2a1f',
-          0.3,
-          '#ffffff',
-        ],
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          12,
-          1,
-          14,
-          2.5,
-          16,
-          4.5,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.5,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Dedicated painted bike lanes (cycle_lane only)
-  {
-    templateId: 'default:bicycle-lanes',
+  // Painted lanes.
+  wayLayer({
+    id: 'bicycle-lanes',
     name: 'Bike Lanes',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 51,
-    groupId: 'default:group:cycling:bike-lanes',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-lanes',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 12,
-      filter: ['all', ['==', 'infra_type', 'cycle_lane'], ['!has', 'state']],
-      paint: {
-        'line-color': '#38a169',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          12,
-          1,
-          14,
-          2.5,
-          16,
-          4.5,
-        ],
-        'line-dasharray': [0.1, 1.5],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
+    group: 'bike-lanes',
+    order: 50,
+    minzoom: 12,
+    filter: ['all', ['==', 'infra_type', 'cycle_lane'], BUILT],
+    color: themed(INK.lane),
+    width: width(12, 0.8, 14, 1.5, 16, 2.2, 19, 3.4),
+  }),
 
-  // Shared lanes (sharrows, shoulders, bus-lanes) — casing
-  {
-    templateId: 'default:bicycle-shared-lanes-casing',
-    name: 'Shared Lanes Casing',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 52,
-    groupId: 'default:group:cycling:shared-lanes',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-shared-lanes-casing',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 12,
-      filter: [
-        'all',
-        [
-          'in',
-          'infra_type',
-          'shared_lane',
-          'opposite',
-          'shoulder',
-          'share_busway',
-        ],
-        ['!has', 'state'],
-      ],
-      paint: {
-        'line-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#1a2a1f',
-          0.3,
-          '#ffffff',
-        ],
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          12,
-          1,
-          14,
-          2.5,
-          16,
-          4.5,
-        ],
-        'line-opacity': 0.55,
-        'line-emissive-strength': 0.5,
-      },
-      layout: {
-        'line-cap': 'butt',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Shared lanes — fill
-  {
-    templateId: 'default:bicycle-shared-lanes',
+  // Sharrows, shoulders and contraflows — a marking on a shared lane, so a
+  // dash, which is what the paint on the road is.
+  wayLayer({
+    id: 'bicycle-shared-lanes',
     name: 'Shared Lanes',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 53,
-    groupId: 'default:group:cycling:shared-lanes',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-shared-lanes',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 12,
-      filter: [
-        'all',
-        [
-          'in',
-          'infra_type',
-          'shared_lane',
-          'opposite',
-          'shoulder',
-          'share_busway',
-        ],
-        ['!has', 'state'],
-      ],
-      paint: {
-        'line-color': '#9ae6b4',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          12,
-          1,
-          14,
-          2.5,
-          16,
-          4.5,
-        ],
-        'line-dasharray': [2, 3],
-        'line-opacity': 0.55,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'butt',
-        'line-join': 'round',
-      },
-    },
-  },
+    group: 'shared-lanes',
+    order: 52,
+    minzoom: 13,
+    filter: [
+      'all',
+      ['in', 'infra_type', 'shared_lane', 'opposite', 'shoulder', 'share_busway'],
+      BUILT,
+    ],
+    color: themed(INK.shared),
+    width: width(13, 0.8, 15, 1.4, 18, 2.2),
+    dash: [2, 2.5],
+  }),
 
-  // Bicycle paths (footway/path with bicycle=designated) — paved
-  {
-    templateId: 'default:bicycle-paths',
-    name: 'Bicycle Paths Paved',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 60,
-    groupId: 'default:group:cycling:bicycle-paths',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-paths',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: [
-        'all',
-        ['in', 'infra_type', 'path_bicycle', 'steps_bicycle'],
-        ['!has', 'state'],
-        [
-          '!in',
-          'surface',
-          'gravel',
-          'dirt',
-          'grass',
-          'ground',
-          'earth',
-          'sand',
-          'mud',
-          'unpaved',
-          'fine_gravel',
-          'compacted',
-        ],
-      ],
-      paint: {
-        'line-color': '#2f855a',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          1,
-          14,
-          2.5,
-          16,
-          4,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Bicycle paths — unpaved casing
-  {
-    templateId: 'default:bicycle-paths-unpaved-casing',
-    name: 'Bicycle Paths Unpaved Casing',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 61,
-    groupId: 'default:group:cycling:bicycle-paths',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-paths-unpaved-casing',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: [
-        'all',
-        ['in', 'infra_type', 'path_bicycle', 'steps_bicycle'],
-        ['!has', 'state'],
-        [
-          'in',
-          'surface',
-          'gravel',
-          'dirt',
-          'grass',
-          'ground',
-          'earth',
-          'sand',
-          'mud',
-          'unpaved',
-          'fine_gravel',
-          'compacted',
-        ],
-      ],
-      paint: {
-        'line-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#1a2a1f',
-          0.3,
-          '#ffffff',
-        ],
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          1,
-          14,
-          2.5,
-          16,
-          4,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.5,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Bicycle paths — unpaved
-  {
-    templateId: 'default:bicycle-paths-unpaved',
-    name: 'Bicycle Paths Unpaved',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 62,
-    groupId: 'default:group:cycling:bicycle-paths',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-paths-unpaved',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: [
-        'all',
-        ['in', 'infra_type', 'path_bicycle', 'steps_bicycle'],
-        ['!has', 'state'],
-        [
-          'in',
-          'surface',
-          'gravel',
-          'dirt',
-          'grass',
-          'ground',
-          'earth',
-          'sand',
-          'mud',
-          'unpaved',
-          'fine_gravel',
-          'compacted',
-        ],
-      ],
-      paint: {
-        'line-color': '#68d391',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          1,
-          14,
-          2.5,
-          16,
-          4,
-        ],
-        'line-dasharray': [3, 2],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-
-  // Bicycle roads & cycle streets
-  {
-    templateId: 'default:bicycle-roads',
+  // Bicycle roads and cycle streets: a street where bikes have priority over
+  // the traffic on it. `bicycle_designated` is deliberately not here — that is
+  // the basemap's green surface, and drawing both doubles it.
+  wayLayer({
+    id: 'bicycle-roads',
     name: 'Bicycle Roads',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
+    group: 'bicycle-roads',
     order: 70,
-    groupId: 'default:group:cycling:bicycle-roads',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-roads',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 12,
-      filter: [
-        'all',
-        [
-          'in',
-          'infra_type',
-          'bicycle_road',
-          'cycle_street',
-          'bicycle_designated',
-        ],
-        ['!has', 'state'],
-      ],
-      paint: {
-        'line-color': '#276749',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          12,
-          1.2,
-          14,
-          3,
-          16,
-          5,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
+    minzoom: 12,
+    filter: ['all', ['in', 'infra_type', 'bicycle_road', 'cycle_street'], BUILT],
+    color: themed(INK.track),
+    width: width(12, 1.2, 14, 2.2, 16, 3.2, 19, 5),
+  }),
 
-  // Bicycle permitted — casing
-  {
-    templateId: 'default:bicycle-permitted-casing',
-    name: 'Bicycle Permitted Casing',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 80,
-    groupId: 'default:group:cycling:bicycle-permitted',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-permitted-casing',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 13,
-      filter: ['all', ['==', 'infra_type', 'bicycle_yes'], ['!has', 'state']],
-      paint: {
-        'line-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#1a2a1f',
-          0.3,
-          '#ffffff',
-        ],
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          13,
-          0.8,
-          15,
-          2,
-          16,
-          3.5,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.5,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Bicycle permitted (bicycle=yes on roads)
-  {
-    templateId: 'default:bicycle-permitted',
+  // Roads bikes are merely allowed on. Off by default: it is most of the
+  // residential grid, and switching it on paints a whole neighbourhood green
+  // while saying nothing about where it is good to ride.
+  wayLayer({
+    id: 'bicycle-permitted',
     name: 'Bicycle Permitted',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 81,
-    groupId: 'default:group:cycling:bicycle-permitted',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-permitted',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 13,
-      filter: ['all', ['==', 'infra_type', 'bicycle_yes'], ['!has', 'state']],
-      paint: {
-        'line-color': '#9ae6b4',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          13,
-          0.8,
-          15,
-          2,
-          16,
-          3.5,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
+    group: 'bicycle-permitted',
+    order: 80,
+    minzoom: 14,
+    filter: ['all', ['==', 'infra_type', 'bicycle_yes'], BUILT],
+    color: themed(INK.permitted),
+    width: width(14, 0.6, 16, 1, 19, 1.6),
+    dash: [1, 3],
+  }),
 
-  // ── Proposed / Under construction bikeways ──────────────────
-  // Proposed — casing
-  {
-    templateId: 'default:bicycle-proposed-casing',
-    name: 'Proposed Bikeways Casing',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 100,
-    groupId: 'default:group:cycling:proposed-bikeways',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-proposed-casing',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: ['==', 'state', 'proposed'],
-      paint: {
-        'line-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#261a36',
-          0.3,
-          '#9c7ec4',
-        ],
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          0.8,
-          14,
-          1.5,
-          16,
-          2.5,
-        ],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.5,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Proposed bikeways
-  {
-    templateId: 'default:bicycle-proposed',
+  // Not built yet. Both are dashed and quiet — a plan is not a route — and the
+  // only one that takes a warm colour is the one with a machine on it.
+  wayLayer({
+    id: 'bicycle-proposed',
     name: 'Proposed Bikeways',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 101,
-    groupId: 'default:group:cycling:proposed-bikeways',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-proposed',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: ['==', 'state', 'proposed'],
-      paint: {
-        'line-color': '#873beb',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          0.8,
-          14,
-          1.5,
-          16,
-          2.5,
-        ],
-        'line-dasharray': [1, 3],
-        'line-opacity': 1,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Under construction — casing
-  {
-    templateId: 'default:bicycle-construction-casing',
-    name: 'Under Construction Casing',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 102,
-    groupId: 'default:group:cycling:proposed-bikeways',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-construction-casing',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: ['==', 'state', 'construction'],
-      paint: {
-        'line-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#1a2a1f',
-          0.3,
-          '#f79107',
-        ],
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          1,
-          14,
-          2,
-          16,
-          3,
-        ],
-        'line-opacity': 0.8,
-        'line-emissive-strength': 0.5,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Under construction bikeways
-  {
-    templateId: 'default:bicycle-construction',
+    group: 'proposed-bikeways',
+    order: 100,
+    minzoom: 11,
+    filter: ['==', 'state', 'proposed'],
+    color: themed(INK.proposed),
+    width: width(11, 0.8, 14, 1.4, 16, 2.2),
+    dash: [1, 3],
+  }),
+  wayLayer({
+    id: 'bicycle-construction',
     name: 'Under Construction',
-    type: LayerType.CUSTOM,
-    engine: ['mapbox', 'maplibre'],
-    icon: 'BikeIcon',
-    showInLayerSelector: false,
-    visible: false,
-    order: 103,
-    groupId: 'default:group:cycling:proposed-bikeways',
-    isSubLayer: true,
-    integrationId: 'barrelman',
-    configuration: {
-      id: 'bicycle-construction',
-      type: 'line',
-      source: {
-        id: 'bicycle-ways',
-        type: 'vector',
-        tiles: ['{PROXY_URL}/barrelman/bicycle_ways/{z}/{x}/{y}'],
-        maxzoom: 16,
-      },
-      'source-layer': 'bicycle_ways',
-      minzoom: 11,
-      filter: ['==', 'state', 'construction'],
-      paint: {
-        'line-color': '#FC8',
-        'line-width': [
-          'interpolate',
-          ['linear'],
-          ['zoom'],
-          11,
-          1,
-          14,
-          2,
-          16,
-          3,
-        ],
-        'line-dasharray': [0.2, 2],
-        'line-opacity': 0.8,
-        'line-emissive-strength': 0.8,
-      },
-      layout: {
-        'line-cap': 'round',
-        'line-join': 'round',
-      },
-    },
-  },
-  // Bicycle route labels
+    group: 'proposed-bikeways',
+    order: 102,
+    minzoom: 11,
+    filter: ['==', 'state', 'construction'],
+    color: themed(INK.construction),
+    width: width(11, 1, 14, 1.8, 16, 2.6),
+    dash: [1.5, 1.5],
+  }),
+
+  // Route names along the corridor they belong to.
   {
     templateId: 'default:bicycle-routes-labels',
     name: 'Bike Routes Labels',
@@ -1124,7 +260,7 @@ export const CYCLING_LAYER_TEMPLATES: DefaultLayerTemplate[] = [
     icon: 'BikeIcon',
     showInLayerSelector: false,
     visible: false,
-    order: 999,
+    order: 110,
     groupId: 'default:group:cycling:bike-routes',
     isSubLayer: true,
     integrationId: 'barrelman',
@@ -1141,24 +277,8 @@ export const CYCLING_LAYER_TEMPLATES: DefaultLayerTemplate[] = [
       minzoom: 10,
       filter: ['any', ['has', 'name'], ['has', 'ref']],
       paint: {
-        'text-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#4ade80',
-          0.3,
-          '#1a7a3a',
-        ],
-        'text-halo-color': [
-          'interpolate',
-          ['linear'],
-          ['measure-light', 'brightness'],
-          0.25,
-          '#0a1f14',
-          0.3,
-          '#ffffff',
-        ],
+        'text-color': themed(INK.route),
+        'text-halo-color': themed({ light: '#ffffff', dark: '#0d1016' }),
         'text-halo-width': 1.5,
         // Soft rather than traced, like every other label on the map.
         'text-halo-blur': 0.4,
@@ -1171,7 +291,7 @@ export const CYCLING_LAYER_TEMPLATES: DefaultLayerTemplate[] = [
         'text-transform': 'uppercase',
         // Capitals need opening up; 0.01 set them as tight as mixed case.
         'text-letter-spacing': 0.08,
-        'text-size': ['interpolate', ['linear'], ['zoom'], 10, 10, 14, 13],
+        'text-size': ['interpolate', ['linear'], ['zoom'], 10, 10, 14, 12],
         'text-max-angle': 30,
         'text-padding': 30,
       },

--- a/server/src/constants/default-layers/groups.ts
+++ b/server/src/constants/default-layers/groups.ts
@@ -9,20 +9,16 @@ export const DEFAULT_LAYER_GROUPS: DefaultLayerGroupTemplate[] = [
     icon: 'BikeIcon',
     showInLayerSelector: true,
     visible: false,
-    order: 0,
+    // Under transit. A bike network is ground you ride on and the transit
+    // network is drawn above the ground it runs over, so where the two cross
+    // the train should pass over the bike lane, not under it.
+    order: 3,
     parentGroupId: null,
+    // The green road surface; see `addCyclingSurface` in
+    // `web/scripts/convert-basemap-style.mjs`.
+    basemapGroup: 'cycling',
   },
   // Cycling subgroups
-  {
-    templateId: 'default:group:cycling:cycleways',
-    name: 'Cycleways',
-    icon: 'BikeIcon',
-    showInLayerSelector: true,
-    visible: false,
-    order: 0,
-    parentGroupId: 'default:group:cycling',
-    integrationId: 'barrelman',
-  },
   {
     templateId: 'default:group:cycling:cycle-tracks',
     name: 'Cycle Tracks',
@@ -50,16 +46,6 @@ export const DEFAULT_LAYER_GROUPS: DefaultLayerGroupTemplate[] = [
     showInLayerSelector: true,
     visible: false,
     order: 3,
-    parentGroupId: 'default:group:cycling',
-    integrationId: 'barrelman',
-  },
-  {
-    templateId: 'default:group:cycling:bicycle-paths',
-    name: 'Bicycle Paths',
-    icon: 'BikeIcon',
-    showInLayerSelector: true,
-    visible: false,
-    order: 4,
     parentGroupId: 'default:group:cycling',
     integrationId: 'barrelman',
   },

--- a/server/src/types/layers.types.ts
+++ b/server/src/types/layers.types.ts
@@ -79,6 +79,16 @@ export interface DefaultLayerGroupTemplate extends DefaultTemplateBase {
   showInLayerSelector: boolean
   visible: boolean
   fadeBasemap?: boolean
+  /**
+   * A group of the basemap's own layers this group switches on with itself,
+   * named as a key of the client's `layerGroups` (`web/src/lib/map-style`).
+   *
+   * For cartography the basemap is the only place that can draw correctly —
+   * the cycling tint has to be exactly as wide as the road under it at every
+   * zoom, which only the layer that draws that road can promise. Template-only
+   * and never user-editable, so unlike `fadeBasemap` it needs no column.
+   */
+  basemapGroup?: string
   icon?: string | null
   order: number
   parentGroupId?: string | null

--- a/web/scripts/convert-basemap-style.mjs
+++ b/web/scripts/convert-basemap-style.mjs
@@ -48,6 +48,7 @@ const OUT_TOKENS_DARK = resolve(WEB, 'src/lib/map-style/tokens.dark.json')
 
 import { buildingColor, BUILDING_TINT } from '../src/lib/map-style/building-color.mjs'
 import { isTransitPoi } from '../src/lib/map-style/transit-poi.mjs'
+import { CYCLING_SUFFIX, isCyclingWay } from '../src/lib/map-style/cycling.mjs'
 
 const SOURCE = 'openmaptiles'
 
@@ -1054,6 +1055,88 @@ function toExpressionFilter(f) {
 }
 
 // ---------------------------------------------------------------------------
+// Cycling surface
+// ---------------------------------------------------------------------------
+
+/**
+ * The cycling network, as a tint on the road itself.
+ *
+ * A bike map usually draws its network *over* the roads — a dotted or dashed
+ * line riding the centreline. At street zooms that line is a second object on
+ * top of a first: it hides the road's own casing, it never quite lines up with
+ * the curve underneath, and a dense grid of them reads as hatching rather than
+ * as streets you can ride.
+ *
+ * So the road is painted green instead. These layers are twins of the basemap's
+ * own surface and casing layers — same source, same filter with a cycling
+ * clause added, same geometry, and critically the same `line-width` expression,
+ * copied by reference rather than by hand. A green road is therefore exactly as
+ * wide as the road it replaces at every zoom, because it IS that road's width;
+ * there is no second ramp that can drift out of step with the first.
+ *
+ * Each twin is spliced directly above the layer it derives from, so casings
+ * stay under surfaces and the whole set stays below every label and everything
+ * any overlay draws.
+ *
+ * Hidden until the cycling group asks for them; see `layerGroups.cycling`.
+ */
+
+/** Surface layers that take the tint, and the casing under each. */
+const CYCLING_TINTED = [
+  ['Minor road outline', '@cycling_casing'],
+  ['Major road outline', '@cycling_casing'],
+  ['Highway outline', '@cycling_casing'],
+  ['Path outline', '@cycling_casing'],
+  ['Path outline bridge', '@cycling_casing'],
+  ['Minor road', '@cycling_surface'],
+  ['Major road', '@cycling_surface'],
+  ['Highway', '@cycling_surface'],
+  [PATH_LAYER, '@cycling_surface'],
+  ['Path bridge', '@cycling_surface'],
+]
+
+function addCyclingSurface(layers) {
+  const missing = CYCLING_TINTED.filter(([id]) => !layers.some(l => l.id === id))
+  if (missing.length) {
+    throw new Error(`cycling tint names absent layers: ${missing.map(m => m[0]).join(', ')}`)
+  }
+
+  for (const [id, color] of CYCLING_TINTED) {
+    const at = layers.findIndex(l => l.id === id)
+    const road = layers[at]
+    // The road filters are MapTiler's legacy syntax; the cycling clause is an
+    // expression, and the two cannot be mixed — a legacy filter wrapping an
+    // expression makes the validator read the whole thing as legacy.
+    const filter = road.filter
+      ? ['all', toExpressionFilter(road.filter), isCyclingWay()]
+      : isCyclingWay()
+    layers.splice(at + 1, 0, {
+      ...road,
+      id: road.id + CYCLING_SUFFIX,
+      filter,
+      // Spread, so a retune of the road's width or dashes reaches its twin.
+      // Only the colour is the twin's own.
+      paint: { ...road.paint, 'line-color': color },
+      layout: { ...road.layout, visibility: 'none' },
+    })
+  }
+}
+
+/**
+ * What a cycling way is painted.
+ *
+ * A pale green that sits at the road's own value rather than above or below
+ * it, so switching the layer on recolours the network without redrawing its
+ * hierarchy — a residential street stays as quiet as it was, it is just green
+ * now. The casing goes a good deal deeper, because the tint is doing the work
+ * a dashed line used to and it needs an edge to be a shape at all.
+ */
+const CYCLING_INK = {
+  cycling_surface: { light: 'hsl(146, 44%, 90%)', dark: 'hsl(152, 28%, 36%)' },
+  cycling_casing: { light: 'hsl(146, 34%, 71%)', dark: 'hsl(152, 26%, 25%)' },
+}
+
+// ---------------------------------------------------------------------------
 // Typography
 // ---------------------------------------------------------------------------
 
@@ -1727,6 +1810,9 @@ async function main() {
     })
   }
   orderPedestrianSurfaces(layers)
+  // After every pass that touches a road's width or its place in the stack,
+  // so the twins inherit the widths the roads actually ship with.
+  addCyclingSurface(layers)
   applyTypography(layers)
 
   // The roofline edge, for the plan view.
@@ -1773,6 +1859,12 @@ async function main() {
   for (const t of orphaned) {
     delete tokens.light[t]
     delete tokens.dark[t]
+  }
+
+  // The cycling network's tint; see `addCyclingSurface`.
+  for (const [name, value] of Object.entries(CYCLING_INK)) {
+    tokens.light[name] = value.light
+    tokens.dark[name] = value.dark
   }
 
   // The label system's ink and halo; see `TYPOGRAPHY`.

--- a/web/src/lib/map-style/build.ts
+++ b/web/src/lib/map-style/build.ts
@@ -12,6 +12,7 @@ import {
 } from './detail-layers'
 import { buildingColor, BUILDING_TINT } from './building-color.mjs'
 import { TRANSIT_POI_CLASSES } from './transit-poi.mjs'
+import { CYCLING_SUFFIX } from './cycling.mjs'
 import { barrelmanBuildingsReady } from './barrelman-buildings'
 import lightTokens from './tokens.light.json'
 import darkTokens from './tokens.dark.json'
@@ -317,6 +318,12 @@ export const layerGroups = {
    */
   transit: idsWhere(isTransitStopLayer),
   placeLabels: idsWhere(l => l.type === 'symbol' && l['source-layer'] === 'place'),
+  /**
+   * The green twins of the road layers; see `addCyclingSurface` in
+   * `convert-basemap-style.mjs`. They ship hidden, so nothing switches them on
+   * but the cycling layer group.
+   */
+  cycling: idsWhere(l => l.id.endsWith(CYCLING_SUFFIX)),
   building3d: specLayers.find(l => l.type === 'fill-extrusion')?.id ?? 'Building 3D',
 }
 

--- a/web/src/lib/map-style/cycling.d.ts
+++ b/web/src/lib/map-style/cycling.d.ts
@@ -1,0 +1,2 @@
+export declare const CYCLING_SUFFIX: string
+export declare function isCyclingWay(): unknown[]

--- a/web/src/lib/map-style/cycling.mjs
+++ b/web/src/lib/map-style/cycling.mjs
@@ -1,0 +1,32 @@
+/**
+ * Which ways the map paints as cycling infrastructure, and how those layers
+ * are named.
+ *
+ * Shared between the style generator, which builds a green twin of every road
+ * surface, and the app, which switches them on with the cycling layer group.
+ * Both have to agree on the naming or the toggle finds nothing to toggle.
+ */
+
+/** Appended to the id of the road layer a cycling twin is derived from. */
+export const CYCLING_SUFFIX = ' (cycling)'
+
+/**
+ * A way that is cycling infrastructure in its own right.
+ *
+ * `subclass = cycleway` is `highway=cycleway` — a way built for bikes, which
+ * is designated whether or not anyone tagged it so. `bicycle = designated`
+ * is the same statement made about a road or a footpath that also carries
+ * other traffic.
+ *
+ * Deliberately NOT `bicycle = yes`. That is permission, not provision, and it
+ * is on most of the residential grid — tinting it paints whole neighbourhoods
+ * green and says nothing, which is the failure mode of every bike map that
+ * draws access rather than infrastructure.
+ */
+export function isCyclingWay() {
+  return [
+    'any',
+    ['==', ['get', 'subclass'], 'cycleway'],
+    ['==', ['get', 'bicycle'], 'designated'],
+  ]
+}

--- a/web/src/lib/map-style/map-style.test.ts
+++ b/web/src/lib/map-style/map-style.test.ts
@@ -1500,6 +1500,45 @@ describe('cycling surface', () => {
     }
   })
 
+  /**
+   * The filters, run against real OpenMapTiles features — the shapes the
+   * Brooklyn tiles actually carry. A tint that selects nothing is invisible
+   * and a tint that selects everything is a green map, and neither shows up
+   * in a filter that merely compiles.
+   */
+  describe('what the tint selects', () => {
+    const matches = (layerId: string, properties: Record<string, unknown>) => {
+      const l = layers.find(x => x.id === layerId)!
+      const f = featureFilter(l.filter, `${layerId}.filter`)
+      return f.filter(
+        { zoom: 16 } as any,
+        { type: 2, properties } as any,
+        {} as any,
+      )
+    }
+
+    test.each([
+      ['a dedicated cycleway', 'Path (cycling)', { class: 'path', subclass: 'cycleway' }, true],
+      ['a footpath bikes are designated on', 'Path (cycling)', { class: 'path', subclass: 'footway', bicycle: 'designated' }, true],
+      ['a plain footpath', 'Path (cycling)', { class: 'path', subclass: 'footway' }, false],
+      ['a street bikes are designated on', 'Minor road (cycling)', { class: 'minor', bicycle: 'designated' }, true],
+      ['a street bikes are merely allowed on', 'Minor road (cycling)', { class: 'minor', bicycle: 'yes' }, false],
+      ['a street with nothing said about bikes', 'Minor road (cycling)', { class: 'minor' }, false],
+      ['a road told to use the sidepath', 'Minor road (cycling)', { class: 'minor', bicycle: 'use_sidepath' }, false],
+    ])('%s', (_what, layerId, properties, expected) => {
+      expect(matches(layerId as string, properties as any)).toBe(expected)
+    })
+
+    /**
+     * The road's own filter still applies. A tunnel is not drawn by the layer
+     * this twin derives from, so the twin must not draw one either — a green
+     * ribbon through a hillside with no road under it.
+     */
+    test('a designated way in a tunnel stays untinted, as its road does', () => {
+      expect(matches('Minor road (cycling)', { class: 'minor', bicycle: 'designated', brunnel: 'tunnel' })).toBe(false)
+    })
+  })
+
   /** A casing has to be darker than the surface it edges, or it is not an edge. */
   test('the casing is deeper than the surface', () => {
     for (const tokens of [lightTokens, darkTokens] as Record<string, string>[]) {

--- a/web/src/lib/map-style/map-style.test.ts
+++ b/web/src/lib/map-style/map-style.test.ts
@@ -26,6 +26,7 @@ import { BUILDING_3D_SOURCE, BUILDING_3D_TILES } from './detail-layers'
 import { setBarrelmanBuildingsReady } from './barrelman-buildings'
 import spec from './spec.json'
 import { TRANSIT_POI_CLASSES } from './transit-poi.mjs'
+import { CYCLING_SUFFIX } from './cycling.mjs'
 import { BUILDING_TINT } from './building-color.mjs'
 import { terrainSource } from './terrain'
 import { TREE_OPACITY } from './detail-layers'
@@ -1413,3 +1414,97 @@ function contrastRatio(a: string, b: string): number {
   const [x, y] = [relativeLuminance(a), relativeLuminance(b)].sort((p, q) => q - p)
   return (x + 0.05) / (y + 0.05)
 }
+
+/**
+ * The cycling network, painted onto the road instead of over it.
+ *
+ * The guarantee the whole approach rests on: a green road is exactly as wide
+ * as the road it replaces, at every zoom, because it is drawn with that road's
+ * own width expression rather than a second ramp cut to look similar. These
+ * tests assert that on the generated spec, so a hand-edit that breaks the
+ * link — or a regenerated spec that renames a road layer — fails here.
+ */
+describe('cycling surface', () => {
+  const twins = layers.filter(l => l.id.endsWith(CYCLING_SUFFIX))
+  const baseOf = (l: any) =>
+    layers.find(b => b.id === l.id.slice(0, -CYCLING_SUFFIX.length))
+
+  test('every road surface and casing has a twin', () => {
+    const ids = twins.map(t => t.id)
+    const TINTED = [
+      'Minor road', 'Minor road outline',
+      'Major road', 'Major road outline',
+      'Highway', 'Highway outline',
+      'Path', 'Path outline',
+      'Path bridge', 'Path outline bridge',
+    ]
+    expect(ids.slice().sort()).toEqual(TINTED.map(id => id + CYCLING_SUFFIX).sort())
+  })
+
+  test.each(twins.map(l => [l.id, l]))('%s: derives from a real road layer', (_id, l: any) => {
+    expect(baseOf(l)).toBeDefined()
+  })
+
+  /** The point of the exercise. */
+  test.each(twins.map(l => [l.id, l]))('%s: is exactly its road’s width', (_id, l: any) => {
+    const base = baseOf(l)!
+    expect(l.paint['line-width']).toEqual(base.paint['line-width'])
+    // The path casing draws its stroke outside a gap the width of the surface;
+    // a twin that dropped the gap would paint over the path it outlines.
+    expect(l.paint['line-gap-width']).toEqual(base.paint['line-gap-width'])
+  })
+
+  test.each(twins.map(l => [l.id, l]))('%s: sits directly above its road', (_id, l: any) => {
+    const at = layers.indexOf(l)
+    expect(layers[at - 1].id).toBe(baseOf(l)!.id)
+  })
+
+  test.each(twins.map(l => [l.id, l]))('%s: ships hidden', (_id, l: any) => {
+    expect(l.layout.visibility).toBe('none')
+  })
+
+  /**
+   * The twin draws where its road draws and nowhere else, so the cycling
+   * clause has to *narrow* the road's filter rather than replace it —
+   * otherwise a tinted tunnel appears under a map that draws no tunnel.
+   */
+  test.each(twins.map(l => [l.id, l]))('%s: narrows its road’s filter', (_id, l: any) => {
+    const base = baseOf(l)!
+    expect(l.filter[0]).toBe('all')
+    expect(JSON.stringify(l.filter)).toContain('"bicycle"')
+    expect(JSON.stringify(l.filter)).toContain('"designated"')
+    expect(JSON.stringify(l.filter)).toContain('"cycleway"')
+    if (base.filter) expect(l.filter.length).toBeGreaterThan(1)
+  })
+
+  /**
+   * Access is not provision. `bicycle=yes` is on most of the residential grid
+   * and tinting it paints whole neighbourhoods green while saying nothing
+   * about where it is good to ride.
+   */
+  test('permission alone does not tint a road', () => {
+    for (const l of twins) expect(JSON.stringify(l.filter)).not.toContain('"yes"')
+  })
+
+  test('the toggle finds every one of them', () => {
+    expect(layerGroups.cycling.slice().sort()).toEqual(twins.map(l => l.id).sort())
+  })
+
+  test('the tint is green in both flavors', () => {
+    for (const tokens of [lightTokens, darkTokens] as Record<string, string>[]) {
+      for (const name of ['cycling_surface', 'cycling_casing']) {
+        const hue = Number(/hsl\(\s*([\d.]+)/.exec(tokens[name])![1])
+        expect(hue, `${name} ${tokens[name]}`).toBeGreaterThan(100)
+        expect(hue, `${name} ${tokens[name]}`).toBeLessThan(180)
+      }
+    }
+  })
+
+  /** A casing has to be darker than the surface it edges, or it is not an edge. */
+  test('the casing is deeper than the surface', () => {
+    for (const tokens of [lightTokens, darkTokens] as Record<string, string>[]) {
+      const light = (n: string) => Number(/([\d.]+)%\)/.exec(tokens[n])![1])
+      expect(light('cycling_casing')).toBeLessThan(light('cycling_surface'))
+    }
+  })
+})

--- a/web/src/lib/map-style/spec.json
+++ b/web/src/lib/map-style/spec.json
@@ -1682,6 +1682,139 @@
    ]
   },
   {
+   "id": "Path outline (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 12,
+   "layout": {
+    "line-cap": "round",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_casing",
+    "line-width": [
+     "interpolate",
+     [
+      "exponential",
+      1.5
+     ],
+     [
+      "zoom"
+     ],
+     14,
+     1.2,
+     18,
+     3,
+     22,
+     4.5
+    ],
+    "line-gap-width": [
+     "interpolate",
+     [
+      "exponential",
+      1.5
+     ],
+     [
+      "zoom"
+     ],
+     12,
+     0,
+     18,
+     6,
+     22,
+     80
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "all",
+      [
+       "==",
+       [
+        "geometry-type"
+       ],
+       "LineString"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "class"
+       ],
+       [
+        "path",
+        "pedestrian"
+       ],
+       true,
+       false
+      ],
+      [
+       "!=",
+       [
+        "get",
+        "brunnel"
+       ],
+       "tunnel"
+      ]
+     ],
+     [
+      "all",
+      [
+       "!=",
+       [
+        "get",
+        "brunnel"
+       ],
+       "bridge"
+      ],
+      [
+       "<=",
+       [
+        "case",
+        [
+         "has",
+         "layer"
+        ],
+        [
+         "to-number",
+         [
+          "get",
+          "layer"
+         ]
+        ],
+        0
+       ],
+       0
+      ]
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
+    ]
+   ]
+  },
+  {
    "id": "Pedestrian",
    "type": "fill",
    "source": "openmaptiles",
@@ -1808,6 +1941,123 @@
        0
       ],
       0
+     ]
+    ]
+   ]
+  },
+  {
+   "id": "Path (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 12,
+   "layout": {
+    "line-cap": "round",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_surface",
+    "line-width": [
+     "interpolate",
+     [
+      "exponential",
+      1.5
+     ],
+     [
+      "zoom"
+     ],
+     12,
+     0,
+     18,
+     6,
+     22,
+     80
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "all",
+      [
+       "==",
+       [
+        "geometry-type"
+       ],
+       "LineString"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "class"
+       ],
+       [
+        "path",
+        "pedestrian"
+       ],
+       true,
+       false
+      ],
+      [
+       "!=",
+       [
+        "get",
+        "brunnel"
+       ],
+       "tunnel"
+      ]
+     ],
+     [
+      "all",
+      [
+       "!=",
+       [
+        "get",
+        "brunnel"
+       ],
+       "bridge"
+      ],
+      [
+       "<=",
+       [
+        "case",
+        [
+         "has",
+         "layer"
+        ],
+        [
+         "to-number",
+         [
+          "get",
+          "layer"
+         ]
+        ],
+        0
+       ],
+       0
+      ]
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
      ]
     ]
    ]
@@ -1962,6 +2212,190 @@
    ]
   },
   {
+   "id": "Minor road outline (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 4,
+   "layout": {
+    "line-cap": "butt",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_casing",
+    "line-opacity": 1,
+    "line-width": [
+     "interpolate",
+     [
+      "linear",
+      2
+     ],
+     [
+      "zoom"
+     ],
+     6,
+     0,
+     7,
+     0.75,
+     12,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary",
+       "tertiary"
+      ],
+      2.73,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      2.5,
+      2.5
+     ],
+     14,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary"
+      ],
+      6.9,
+      [
+       "tertiary"
+      ],
+      5.4,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      4.5,
+      4.5
+     ],
+     16,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary"
+      ],
+      10.4,
+      [
+       "tertiary"
+      ],
+      10.4,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      8,
+      8
+     ],
+     20,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary"
+      ],
+      34.2,
+      [
+       "tertiary"
+      ],
+      34.2,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      27,
+      27
+     ]
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "!=",
+      [
+       "get",
+       "brunnel"
+      ],
+      "tunnel"
+     ],
+     [
+      "!",
+      [
+       "match",
+       [
+        "get",
+        "class"
+       ],
+       [
+        "aerialway",
+        "bridge",
+        "ferry",
+        "minor_construction",
+        "motorway",
+        "motorway_construction",
+        "path",
+        "path_construction",
+        "pier",
+        "primary",
+        "primary_construction",
+        "rail",
+        "secondary_construction",
+        "service_construction",
+        "tertiary_construction",
+        "track_construction",
+        "transit",
+        "trunk_construction"
+       ],
+       true,
+       false
+      ]
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
+    ]
+   ]
+  },
+  {
    "id": "Major road outline",
    "type": "line",
    "source": "openmaptiles",
@@ -2075,6 +2509,155 @@
      "class",
      "primary",
      "trunk"
+    ]
+   ]
+  },
+  {
+   "id": "Major road outline (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 4,
+   "layout": {
+    "line-cap": "butt",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_casing",
+    "line-opacity": 1,
+    "line-width": [
+     "interpolate",
+     [
+      "linear",
+      2
+     ],
+     [
+      "zoom"
+     ],
+     6,
+     0,
+     7,
+     0.5,
+     10,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      2.4,
+      0
+     ],
+     12,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      3,
+      0.5
+     ],
+     14,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk"
+      ],
+      4,
+      [
+       "primary"
+      ],
+      6,
+      3
+     ],
+     16,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      10,
+      4
+     ],
+     20,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      26,
+      18
+     ]
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "!=",
+      [
+       "get",
+       "brunnel"
+      ],
+      "tunnel"
+     ],
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "primary",
+       "trunk"
+      ],
+      true,
+      false
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
     ]
    ]
   },
@@ -2210,6 +2793,169 @@
      "==",
      "class",
      "motorway"
+    ]
+   ]
+  },
+  {
+   "id": "Highway outline (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 4,
+   "layout": {
+    "line-cap": "butt",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_casing",
+    "line-opacity": 1,
+    "line-width": [
+     "interpolate",
+     [
+      "linear",
+      2
+     ],
+     [
+      "zoom"
+     ],
+     6,
+     0,
+     7,
+     0.5,
+     10,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "ramp"
+       ],
+       1,
+       0,
+       2.5
+      ],
+      0
+     ],
+     12,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "ramp"
+       ],
+       1,
+       2,
+       6
+      ],
+      0.5
+     ],
+     14,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "ramp"
+       ],
+       1,
+       5,
+       8
+      ],
+      3
+     ],
+     16,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      10,
+      4
+     ],
+     20,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      26,
+      18
+     ]
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "!=",
+      [
+       "get",
+       "brunnel"
+      ],
+      "tunnel"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "class"
+      ],
+      "motorway"
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
     ]
    ]
   },
@@ -2631,6 +3377,189 @@
    ]
   },
   {
+   "id": "Minor road (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 4,
+   "layout": {
+    "line-cap": "butt",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_surface",
+    "line-width": [
+     "interpolate",
+     [
+      "linear",
+      2
+     ],
+     [
+      "zoom"
+     ],
+     5,
+     0.75,
+     10,
+     1.5,
+     12,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary",
+       "tertiary"
+      ],
+      1.73,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      1.5,
+      1.5
+     ],
+     14,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary"
+      ],
+      4.6,
+      [
+       "tertiary"
+      ],
+      3.9,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      3,
+      3
+     ],
+     16,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary"
+      ],
+      8.05,
+      [
+       "tertiary"
+      ],
+      7.8,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      6,
+      6
+     ],
+     20,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "secondary"
+      ],
+      31.2,
+      [
+       "tertiary"
+      ],
+      31.2,
+      [
+       "minor",
+       "service",
+       "track"
+      ],
+      24,
+      24
+     ]
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "!=",
+      [
+       "get",
+       "brunnel"
+      ],
+      "tunnel"
+     ],
+     [
+      "!",
+      [
+       "match",
+       [
+        "get",
+        "class"
+       ],
+       [
+        "aerialway",
+        "bridge",
+        "ferry",
+        "minor_construction",
+        "motorway",
+        "motorway_construction",
+        "path",
+        "path_construction",
+        "pier",
+        "primary",
+        "primary_construction",
+        "rail",
+        "secondary_construction",
+        "service_construction",
+        "tertiary_construction",
+        "track_construction",
+        "transit",
+        "trunk_construction"
+       ],
+       true,
+       false
+      ]
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
+    ]
+   ]
+  },
+  {
    "id": "Major road",
    "type": "line",
    "source": "openmaptiles",
@@ -2741,6 +3670,152 @@
      "class",
      "primary",
      "trunk"
+    ]
+   ]
+  },
+  {
+   "id": "Major road (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 4,
+   "layout": {
+    "line-cap": "butt",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_surface",
+    "line-width": [
+     "interpolate",
+     [
+      "linear",
+      2
+     ],
+     [
+      "zoom"
+     ],
+     6,
+     0.75,
+     10,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      1.5,
+      1
+     ],
+     12,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      2.5,
+      1
+     ],
+     14,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk"
+      ],
+      3,
+      [
+       "primary"
+      ],
+      5,
+      2
+     ],
+     16,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      8,
+      4
+     ],
+     20,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "trunk",
+       "primary"
+      ],
+      24,
+      16
+     ]
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "!=",
+      [
+       "get",
+       "brunnel"
+      ],
+      "tunnel"
+     ],
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "primary",
+       "trunk"
+      ],
+      true,
+      false
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
     ]
    ]
   },
@@ -2897,6 +3972,190 @@
      "==",
      "class",
      "motorway"
+    ]
+   ]
+  },
+  {
+   "id": "Highway (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 4,
+   "layout": {
+    "line-cap": "butt",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_surface",
+    "line-width": [
+     "interpolate",
+     [
+      "linear",
+      2
+     ],
+     [
+      "zoom"
+     ],
+     5,
+     0.5,
+     6,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "brunnel"
+       ],
+       [
+        "bridge"
+       ],
+       0,
+       1
+      ],
+      0
+     ],
+     10,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "ramp"
+       ],
+       1,
+       0,
+       2.5
+      ],
+      1
+     ],
+     12,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "ramp"
+       ],
+       1,
+       1,
+       4
+      ],
+      1
+     ],
+     14,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "ramp"
+       ],
+       1,
+       5,
+       6
+      ],
+      2
+     ],
+     16,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      8,
+      4
+     ],
+     20,
+     [
+      "match",
+      [
+       "get",
+       "class"
+      ],
+      [
+       "motorway"
+      ],
+      24,
+      16
+     ]
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "!=",
+      [
+       "get",
+       "brunnel"
+      ],
+      "tunnel"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "class"
+      ],
+      "motorway"
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
     ]
    ]
   },
@@ -3268,6 +4527,139 @@
    ]
   },
   {
+   "id": "Path outline bridge (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 12,
+   "layout": {
+    "line-cap": "round",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_casing",
+    "line-width": [
+     "interpolate",
+     [
+      "exponential",
+      1.5
+     ],
+     [
+      "zoom"
+     ],
+     14,
+     1.2,
+     18,
+     3,
+     22,
+     4.5
+    ],
+    "line-gap-width": [
+     "interpolate",
+     [
+      "exponential",
+      1.5
+     ],
+     [
+      "zoom"
+     ],
+     12,
+     0,
+     18,
+     6,
+     22,
+     80
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "all",
+      [
+       "==",
+       [
+        "geometry-type"
+       ],
+       "LineString"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "class"
+       ],
+       [
+        "path",
+        "pedestrian"
+       ],
+       true,
+       false
+      ],
+      [
+       "!=",
+       [
+        "get",
+        "brunnel"
+       ],
+       "tunnel"
+      ]
+     ],
+     [
+      "any",
+      [
+       "==",
+       [
+        "get",
+        "brunnel"
+       ],
+       "bridge"
+      ],
+      [
+       ">",
+       [
+        "case",
+        [
+         "has",
+         "layer"
+        ],
+        [
+         "to-number",
+         [
+          "get",
+          "layer"
+         ]
+        ],
+        0
+       ],
+       0
+      ]
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
+     ]
+    ]
+   ]
+  },
+  {
    "id": "Path bridge",
    "type": "line",
    "source": "openmaptiles",
@@ -3358,6 +4750,123 @@
        0
       ],
       0
+     ]
+    ]
+   ]
+  },
+  {
+   "id": "Path bridge (cycling)",
+   "type": "line",
+   "source": "openmaptiles",
+   "source-layer": "transportation",
+   "minzoom": 12,
+   "layout": {
+    "line-cap": "round",
+    "line-join": "round",
+    "visibility": "none"
+   },
+   "paint": {
+    "line-color": "@cycling_surface",
+    "line-width": [
+     "interpolate",
+     [
+      "exponential",
+      1.5
+     ],
+     [
+      "zoom"
+     ],
+     12,
+     0,
+     18,
+     6,
+     22,
+     80
+    ]
+   },
+   "filter": [
+    "all",
+    [
+     "all",
+     [
+      "all",
+      [
+       "==",
+       [
+        "geometry-type"
+       ],
+       "LineString"
+      ],
+      [
+       "match",
+       [
+        "get",
+        "class"
+       ],
+       [
+        "path",
+        "pedestrian"
+       ],
+       true,
+       false
+      ],
+      [
+       "!=",
+       [
+        "get",
+        "brunnel"
+       ],
+       "tunnel"
+      ]
+     ],
+     [
+      "any",
+      [
+       "==",
+       [
+        "get",
+        "brunnel"
+       ],
+       "bridge"
+      ],
+      [
+       ">",
+       [
+        "case",
+        [
+         "has",
+         "layer"
+        ],
+        [
+         "to-number",
+         [
+          "get",
+          "layer"
+         ]
+        ],
+        0
+       ],
+       0
+      ]
+     ]
+    ],
+    [
+     "any",
+     [
+      "==",
+      [
+       "get",
+       "subclass"
+      ],
+      "cycleway"
+     ],
+     [
+      "==",
+      [
+       "get",
+       "bicycle"
+      ],
+      "designated"
      ]
     ]
    ]

--- a/web/src/lib/map-style/tokens.dark.json
+++ b/web/src/lib/map-style/tokens.dark.json
@@ -59,6 +59,8 @@
  "airport_icon_color": "hsl(215, 99%, 65%)",
  "town_labels_icon_color": "hsl(0, 0%, 100%)",
  "town_labels_icon_halo_color": "hsl(0, 0%, 20%)",
+ "cycling_surface": "hsl(152, 28%, 36%)",
+ "cycling_casing": "hsl(152, 26%, 25%)",
  "label_halo": "rgba(13, 16, 22, 0.9)",
  "label_ink_strong": "hsl(222, 25%, 93%)",
  "label_ink_muted": "hsl(220, 12%, 76%)",

--- a/web/src/lib/map-style/tokens.light.json
+++ b/web/src/lib/map-style/tokens.light.json
@@ -59,6 +59,8 @@
  "airport_icon_color": "hsl(215, 83%, 53%)",
  "town_labels_icon_color": "hsl(0, 20%, 99%)",
  "town_labels_icon_halo_color": "hsl(0, 0%, 29%)",
+ "cycling_surface": "hsl(146, 44%, 90%)",
+ "cycling_casing": "hsl(146, 34%, 71%)",
  "label_halo": "rgba(255, 255, 255, 0.9)",
  "label_ink_strong": "hsl(222, 25%, 21%)",
  "label_ink_muted": "hsl(222, 10%, 46%)",

--- a/web/src/lib/map/layer-slots.test.ts
+++ b/web/src/lib/map/layer-slots.test.ts
@@ -1,0 +1,60 @@
+import { describe, test, expect } from 'vitest'
+import { groundBeforeId, slotBeforeId } from './layer-slots'
+
+/**
+ * The rule: ground draws under the labels AND under the transit network.
+ * Both halves shipped wrong — the cycling lanes went over the POI names, and
+ * over the train lines that are supposed to cross above them.
+ */
+describe('where a ground layer slots in', () => {
+  const STYLE = [
+    { id: 'Background', type: 'background' },
+    { id: 'Minor road', type: 'line' },
+    { id: 'Building', type: 'fill' },
+    { id: 'Oneway', type: 'symbol' },
+    { id: 'Road labels', type: 'symbol' },
+    { id: 'Food', type: 'symbol' },
+  ]
+
+  test('ground stops at the first label', () => {
+    expect(groundBeforeId(STYLE)).toBe('Oneway')
+  })
+
+  test('the transit network ends it sooner', () => {
+    const withTransit = [
+      ...STYLE.slice(0, 3),
+      { id: 'portolan-ribbon-14-steady', type: 'line' },
+      ...STYLE.slice(3),
+    ]
+    expect(groundBeforeId(withTransit)).toBe('portolan-ribbon-14-steady')
+  })
+
+  /**
+   * The transit overlay inserts its own labels above the basemap's, so a
+   * `portolan-` symbol must not be mistaken for the basemap's first label —
+   * that would anchor ground above the ribbons instead of below them.
+   */
+  test('an overlay label does not stand in for a basemap one', () => {
+    const layers = [
+      { id: 'Minor road', type: 'line' },
+      { id: 'portolan-station-labels', type: 'symbol' },
+    ]
+    expect(groundBeforeId(layers)).toBe('portolan-station-labels')
+  })
+
+  test('a style that is all ground has no anchor, so the layer goes on top', () => {
+    expect(groundBeforeId([{ id: 'Minor road', type: 'line' }])).toBeUndefined()
+  })
+
+  /**
+   * Only `bottom` is emulated. Anything else already means "above the
+   * basemap" on MapLibre, which is where an unanchored layer lands — giving
+   * those an anchor would move layers that are correct today.
+   */
+  test('only the ground slot resolves to an anchor', () => {
+    expect(slotBeforeId(STYLE, 'bottom')).toBe('Oneway')
+    expect(slotBeforeId(STYLE, 'middle')).toBeUndefined()
+    expect(slotBeforeId(STYLE, 'top')).toBeUndefined()
+    expect(slotBeforeId(STYLE, undefined)).toBeUndefined()
+  })
+})

--- a/web/src/lib/map/layer-slots.ts
+++ b/web/src/lib/map/layer-slots.ts
@@ -1,0 +1,46 @@
+/**
+ * Where an overlay layer slots into the basemap's stack.
+ *
+ * Mapbox Standard has this natively: a layer names a slot and the engine puts
+ * it in the right band of the style. MapLibre has no such thing — every
+ * `addLayer` without a `beforeId` goes on top of everything, which is how the
+ * cycling network ended up drawn over the POI labels and over the transit
+ * ribbons that are supposed to cross above it.
+ *
+ * So the same vocabulary is honoured on both engines: a layer that says
+ * `slot: 'bottom'` is ground, and gets a `beforeId` that keeps it there.
+ */
+
+type StyleLayer = { id: string; type: string }
+
+/** Anything the transit overlay draws, which is never basemap ground. */
+const OVERLAY_PREFIX = 'portolan-'
+
+/**
+ * The first layer that is no longer part of the ground.
+ *
+ * Two things end the ground, and it has to be whichever comes first. Labels
+ * are the obvious one — a POI name is above everything the map draws flat.
+ * The transit network is the other: its ribbons are inserted *below* the
+ * labels, so anchoring on labels alone would slot a bike lane above the train
+ * line it runs under and leave the crossing reading backwards.
+ */
+export function groundBeforeId(layers: readonly StyleLayer[]): string | undefined {
+  return layers.find(
+    l => l.id.startsWith(OVERLAY_PREFIX) || (l.type === 'symbol' && !l.id.startsWith(OVERLAY_PREFIX)),
+  )?.id
+}
+
+/**
+ * The `beforeId` a slot resolves to, or undefined to draw on top.
+ *
+ * Only `bottom` is emulated. `middle` and `top` already mean "above the
+ * basemap" on MapLibre, which is where an unanchored layer lands anyway, and
+ * inventing an anchor for them would move layers that are correct today.
+ */
+export function slotBeforeId(
+  layers: readonly StyleLayer[],
+  slot: string | undefined,
+): string | undefined {
+  return slot === 'bottom' ? groundBeforeId(layers) : undefined
+}

--- a/web/src/services/layers/core/layer-visibility.service.ts
+++ b/web/src/services/layers/core/layer-visibility.service.ts
@@ -173,6 +173,18 @@ export function useLayerVisibilityService() {
       })
       mapStrategy.setTransitLabels(!hasVisibleTransitLayers)
     }
+
+    // Groups whose cartography the basemap draws — the cycling tint is the
+    // road layer itself, recoloured, so only the basemap can switch it on.
+    // Every affected group, not just this one: toggling the parent has to
+    // reach a child that carries the flag.
+    if (mapStrategy && allLayerGroups) {
+      for (const g of allLayerGroups) {
+        if (g.basemapGroup && affectedGroupIds.has(g.id)) {
+          mapStrategy.setBasemapGroup(g.basemapGroup, visible)
+        }
+      }
+    }
   }
 
   /**

--- a/web/src/services/map/providers/map.strategy.ts
+++ b/web/src/services/map/providers/map.strategy.ts
@@ -199,6 +199,14 @@ export class MapStrategy {
    */
   setBasemapTransitPoisVisible(_visible: boolean) {}
   setPlaceLabels(value: boolean) {}
+
+  /**
+   * Show or hide a named group of the basemap's own layers, for an overlay
+   * group whose cartography the basemap has to draw; see `basemapGroup` on
+   * `DefaultLayerGroupTemplate`. A no-op on an engine whose basemap is not
+   * ours to address.
+   */
+  setBasemapGroup(name: string, value: boolean) {}
   setLandmarkIcons(value: boolean) {}
   setMapProjection(projection: MapProjection) {}
 

--- a/web/src/services/map/providers/maplibre.strategy.ts
+++ b/web/src/services/map/providers/maplibre.strategy.ts
@@ -82,6 +82,7 @@ import {
 } from '@/lib/map-style/barrelman-buildings'
 import { OBJECT_FLAT_LAYERS, TREE_OPACITY, BUILDING_3D_TILES } from '@/lib/map-style/detail-layers'
 import { loadGlb, type GlbModel } from '@/lib/map-objects/glb.mjs'
+import { slotBeforeId } from '@/lib/map/layer-slots'
 import {
   ObjectLayer,
   OBJECT_MODELS,
@@ -622,6 +623,12 @@ export class MaplibreStrategy extends MapStrategy {
 
   setPlaceLabels(value: boolean) {
     this.setLayerGroupVisibility(layerGroups.placeLabels, value)
+  }
+
+  setBasemapGroup(name: string, value: boolean) {
+    const ids = (layerGroups as Record<string, string | string[]>)[name]
+    if (!Array.isArray(ids)) return
+    this.setLayerGroupVisibility(ids, value)
   }
 
 
@@ -1183,13 +1190,21 @@ export class MaplibreStrategy extends MapStrategy {
     }
     if (!existingLayer || overwrite) {
       try {
-        this.mapInstance.addLayer({
-          ...(configuration as any),
-          layout: {
-            ...configuration.layout,
-            visibility: layer.visible ? 'visible' : 'none',
+        // MapLibre has no slots, so the one we honour is resolved to an anchor
+        // here; see `layer-slots.ts`. Without it every overlay lands on top of
+        // the whole style, labels included.
+        const { slot, ...spec } = configuration as any
+        const before = slotBeforeId(this.mapInstance.getStyle()?.layers ?? [], slot)
+        this.mapInstance.addLayer(
+          {
+            ...spec,
+            layout: {
+              ...configuration.layout,
+              visibility: layer.visible ? 'visible' : 'none',
+            },
           },
-        })
+          before && this.mapInstance.getLayer(before) ? before : undefined,
+        )
         if (layer.type === LayerType.STREET_VIEW) {
           this.streetViewLayerIds.add(configuration.id)
         }

--- a/web/src/stores/layers.store.ts
+++ b/web/src/stores/layers.store.ts
@@ -312,6 +312,7 @@ export const useLayersStore = defineStore('layers', () => {
         state?.showInLayerSelector ?? template.showInLayerSelector,
       visible: visibilityOverride ?? state?.visible ?? template.visible,
       fadeBasemap: template.fadeBasemap ?? false,
+      basemapGroup: template.basemapGroup ?? undefined,
       icon: template.icon ?? undefined,
       order: state?.order ?? template.order,
       parentGroupId:

--- a/web/src/types/map.types.ts
+++ b/web/src/types/map.types.ts
@@ -358,6 +358,8 @@ export interface LayerGroup {
   showInLayerSelector: boolean
   visible: boolean
   fadeBasemap?: boolean
+  /** Basemap layers this group draws with; see `DefaultLayerGroupTemplate`. */
+  basemapGroup?: string
   icon?: string
   order: number
   parentGroupId?: string | null


### PR DESCRIPTION
Stacked on #503 — it builds on that branch's basemap tokens and its
`TYPOGRAPHY` pass. Retarget to `dev` once #503 merges.

## The idea

A bike map usually draws its network *over* the roads: a dotted line riding the
centreline. At street zooms that line is a second object on top of a first — it
hides the road's own casing, it never quite follows the curve underneath, and a
dense grid reads as hatching rather than as streets you can ride. The second
screenshot in the request is that failure mode at city scale.

So **the road is painted green instead**.

## How the width match is guaranteed

`addCyclingSurface` in `convert-basemap-style.mjs` generates a twin of each road
surface and casing layer — `Minor road`, `Major road`, `Highway`, `Path`,
`Path bridge` and their outlines. A twin is the road layer spread, with:

* the same source, source-layer and geometry
* the road's filter **narrowed** by a cycling clause (not replaced — so a
  designated way in a tunnel stays untinted, exactly as its road does)
* the road's `line-width` and `line-gap-width` **copied by reference**
* one thing of its own: `line-color`

So a green road is exactly as wide as the road it replaces at every zoom,
because it *is* that road's width. There is no second ramp that can drift out of
step with the first, and a later retune of the roads reaches the twins for free.
A test asserts the width expressions are `toEqual` their base's.

Each twin splices directly above the layer it derives from, which means casings
stay under surfaces, a green minor road still draws below a major road, and the
whole set sits below every label and everything any overlay draws.

## What counts as cycling infrastructure

`subclass = cycleway` or `bicycle = designated`. Deliberately **not**
`bicycle = yes` — that is permission, not provision, and it is on most of the
residential grid; tinting it paints whole neighbourhoods green while saying
nothing about where it is good to ride. Tested against the real OpenMapTiles
property shapes, both the matches and the misses.

Our basemap tiles carry `bicycle`, `subclass`, `foot` and `surface` on
`transportation`, which is what makes this possible without a second source —
and means the green surface still draws when Barrelman is unreachable.

## The rest of the layer set

`cycling.ts` went from 1177 lines to ~280. Fourteen near-identical configs (each
with its own hand-written `measure-light` pair and width ramp) became one
`wayLayer` shape plus a palette, and the two halves the basemap now draws —
`cycleways` and `bicycle-paths`, six layers and two subgroups — are gone.

What's left is on-street infrastructure, which is *not* the whole road and so is
not tinted: a protected track takes the deepest green, a painted lane a step
back, a sharrow is dashed because that is honestly what it offers, and
`bicycle=yes` is faint and off by default. Signed routes became a soft wide
corridor *behind* the network rather than another green line competing with it.
The white casings are gone — they were most of what made the old rendering read
as hatching.

## Ordering

Both complaints had one cause: MapLibre `addLayer` with no `beforeId` puts a
layer on top of the entire style, labels included.

`layer-slots.ts` honours the slot vocabulary Mapbox Standard already has. A
layer that says `slot: 'bottom'` is ground, and gets an anchor that keeps it
there — before the first basemap label **or** the first `portolan-` layer,
whichever comes first, so a bike lane also stays under the train line that
crosses above it. Only `bottom` is emulated; `middle`/`top` already mean "above
the basemap" on MapLibre, and giving them anchors would move layers that are
correct today.

The cycling group also moved below transit (`order: 3`), and picked up
`basemapGroup: 'cycling'` — a template-only field (no migration) that lets an
overlay group switch on basemap layers, which is the only place cartography this
exact can be drawn.

## Tests

Web green: **2543** across 146 files. New coverage: the width-match guarantee
per twin, splice position, ship-hidden, filter narrowing, what the filter
selects and rejects against real feature shapes, the toggle finding every twin,
and six cases on slot anchoring including the overlay-label trap.

Server has the one pre-existing `dev` failure (`personal-blob.controller`),
untouched here.

## Not yet seen on a map

The browser automation channel dropped partway through, so **I have not looked
at this rendered** — the reasoning and the tests are solid but the colour values
are unverified by eye. The preview is up; `cycling_surface` / `cycling_casing`
in `tokens.*.json` are the two dials if the green is off.