### PR TITLE
Reconnect OSM account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@
   configured" error.
 * Quick edit's "connect your account" screen now has a button through to the
   OpenStreetMap integration in settings.
+* Connecting an OpenStreetMap account no longer leaves a second copy of the app
+  open in the sign-in window — it closes itself, and the confirmation appears in
+  the window you started from.
 
 ## [0.12.0] - 2026-09-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 ### Fixed
 
+* Reconnecting an OpenStreetMap account no longer fails with an "already
+  configured" error.
+* Quick edit's "connect your account" screen now has a button through to the
+  OpenStreetMap integration in settings.
+
 ## [0.12.0] - 2026-09-11
 
 ### Added

--- a/server/src/controllers/osm-oauth.controller.ts
+++ b/server/src/controllers/osm-oauth.controller.ts
@@ -8,7 +8,7 @@ import { db } from '../db'
 import { tokens } from '../schema/tokens.schema'
 import {
   createIntegration,
-  deleteIntegration,
+  deleteUserIntegrations,
   updateIntegration,
   getConfiguredIntegrations,
 } from '../services/integration.service'
@@ -184,14 +184,11 @@ publicApi.get(
         return oauthCallbackPage({ status: 'error', message: t('errors.osm.userDetailsFailed') })
       }
 
-      // Check if user already has an OSM integration and remove it
-      const existingIntegrations = await getConfiguredIntegrations(userId)
-      const existingOsm = existingIntegrations.find(
-        (i) => i.integrationId === IntegrationId.OPENSTREETMAP_ACCOUNT,
-      )
-      if (existingOsm) {
-        await deleteIntegration(existingOsm.id, userId)
-      }
+      // Clear any previous connection before writing the new one. This goes
+      // through the raw rows: an account connected under a retired encryption
+      // key is invisible to getConfiguredIntegrations, and leaving it in place
+      // makes every reconnect collide on the unique index.
+      await deleteUserIntegrations(userId, IntegrationId.OPENSTREETMAP_ACCOUNT)
 
       // Create the integration record
       const config = {
@@ -309,16 +306,14 @@ app.use(requireAuth).post(
   '/disconnect',
   async ({ user, status, t }) => {
     try {
-      const userIntegrations = await getConfiguredIntegrations(user.id)
-      const osmIntegration = userIntegrations.find(
-        (i) => i.integrationId === IntegrationId.OPENSTREETMAP_ACCOUNT,
+      const removed = await deleteUserIntegrations(
+        user.id,
+        IntegrationId.OPENSTREETMAP_ACCOUNT,
       )
 
-      if (!osmIntegration) {
+      if (!removed) {
         return status(404, { message: t('errors.osm.integrationNotFound') })
       }
-
-      await deleteIntegration(osmIntegration.id, user.id)
 
       return { success: true }
     } catch (error: any) {

--- a/server/src/controllers/osm-oauth.controller.ts
+++ b/server/src/controllers/osm-oauth.controller.ts
@@ -32,31 +32,31 @@ function getOsmClient() {
 }
 
 /**
- * Render a minimal HTML page that posts a message to the opener window and closes itself.
- * Used as the OAuth callback response so the SPA isn't disrupted by a redirect.
+ * Hand the OAuth result back to the app through a page on the *client* origin.
+ *
+ * OpenStreetMap serves `Cross-Origin-Opener-Policy: same-origin`, so the popup
+ * loses `window.opener` the moment it navigates there — postMessage from here
+ * can never arrive. `/oauth/osm.html` is same-origin with the app, so it can
+ * broadcast the result and close itself.
+ *
+ * This stays a 200 with a scripted redirect rather than a 302: the dev-mode
+ * workaround fetches this endpoint with axios and reads the embedded result.
  */
 function oauthCallbackPage(result: { status: 'connected' | 'error'; message?: string }) {
-  // Sanitize message for safe inline script embedding:
-  // - Escape </ to prevent </script> breakout
-  // - Use only the status enum for the fallback URL message to avoid injection
-  const safeMessage = JSON.stringify({ type: 'osm-oauth-callback', ...result })
+  const query = new URLSearchParams({ status: result.status })
+  if (result.message) query.set('message', result.message)
+  const target = `${clientOrigin}/oauth/osm.html?${query}`
+
+  const payload = JSON.stringify({ type: 'osm-oauth-callback', ...result })
     .replace(/</g, '\\u003c')
-  const safeOrigin = clientOrigin.replace(/'/g, "\\'")
-  const fallbackUrl = `${clientOrigin}/settings/integrations?osm=${encodeURIComponent(result.status)}${result.message ? `&message=${encodeURIComponent(result.message)}` : ''}`
-  const safeFallbackUrl = fallbackUrl.replace(/'/g, "\\'")
+
   return new Response(
     `<!DOCTYPE html>
 <html><head><title>Connecting...</title></head>
 <body>
-<script>
-  if (window.opener) {
-    window.opener.postMessage(${safeMessage}, '${safeOrigin}');
-    window.close();
-  } else {
-    window.location.href = '${safeFallbackUrl}';
-  }
-</script>
-<noscript>You can close this window.</noscript>
+<script type="application/json" id="osm-oauth-result">${payload}</script>
+<script>location.replace(${JSON.stringify(target)})</script>
+<noscript><a href="${target.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}">Continue</a></noscript>
 </body></html>`,
     { headers: { 'Content-Type': 'text/html' } },
   )

--- a/server/src/controllers/osm-oauth.controller.ts
+++ b/server/src/controllers/osm-oauth.controller.ts
@@ -13,7 +13,7 @@ import {
   getConfiguredIntegrations,
 } from '../services/integration.service'
 import { IntegrationId } from '../types/integration.types'
-import { getOsmConfig } from '../config/osm.config'
+import { getOsmConfig, type OsmConfig } from '../config/osm.config'
 import { generateId } from '../util'
 import { logError } from '../lib/logger'
 import { i18nPlugin } from '../lib/i18n/plugin'
@@ -31,35 +31,29 @@ function getOsmClient() {
   )
 }
 
+type OauthResult = { status: 'connected' | 'error'; message?: string }
+
 /**
- * Hand the OAuth result back to the app through a page on the *client* origin.
+ * Hand the OAuth result back to whoever asked for it.
  *
+ * A browser is sent on to `/oauth/osm.html` on the *client* origin.
  * OpenStreetMap serves `Cross-Origin-Opener-Policy: same-origin`, so the popup
- * loses `window.opener` the moment it navigates there — postMessage from here
- * can never arrive. `/oauth/osm.html` is same-origin with the app, so it can
- * broadcast the result and close itself.
+ * loses `window.opener` on the way through and can only report back from a
+ * page that shares the app's origin.
  *
- * This stays a 200 with a scripted redirect rather than a 302: the dev-mode
- * workaround fetches this endpoint with axios and reads the embedded result.
+ * When the app calls this itself — the manual flow below, for setups whose
+ * registered redirect URI isn't reachable — it asks for JSON instead.
  */
-function oauthCallbackPage(result: { status: 'connected' | 'error'; message?: string }) {
+function oauthCallbackResponse(result: OauthResult, wantsJson: boolean) {
+  if (wantsJson) return result
+
   const query = new URLSearchParams({ status: result.status })
   if (result.message) query.set('message', result.message)
-  const target = `${clientOrigin}/oauth/osm.html?${query}`
 
-  const payload = JSON.stringify({ type: 'osm-oauth-callback', ...result })
-    .replace(/</g, '\\u003c')
-
-  return new Response(
-    `<!DOCTYPE html>
-<html><head><title>Connecting...</title></head>
-<body>
-<script type="application/json" id="osm-oauth-result">${payload}</script>
-<script>location.replace(${JSON.stringify(target)})</script>
-<noscript><a href="${target.replace(/&/g, '&amp;').replace(/"/g, '&quot;')}">Continue</a></noscript>
-</body></html>`,
-    { headers: { 'Content-Type': 'text/html' } },
-  )
+  return new Response(null, {
+    status: 302,
+    headers: { Location: `${clientOrigin}/oauth/osm.html?${query}` },
+  })
 }
 
 /**
@@ -73,6 +67,23 @@ const publicApi = new Elysia({ prefix: '/integrations/osm' }).use(i18nPlugin)
 
 /** Everything that requires an authenticated session. */
 const app = new Elysia({ prefix: '/integrations/osm' }).use(i18nPlugin)
+
+/**
+ * Whether the browser can be expected to come back here on its own.
+ *
+ * OSM sends the user to the redirect URI registered on the OAuth application,
+ * which it will not vary per deployment. When that host isn't this server —
+ * a branch preview, or local dev behind a `localhost` URI — the popup
+ * dead-ends on an unreachable page and the code has to be handed over by hand.
+ */
+function needsManualCallback(config: OsmConfig): boolean {
+  if (!config.redirectUri || !serverOrigin) return false
+  try {
+    return new URL(config.redirectUri).origin !== new URL(serverOrigin).origin
+  } catch {
+    return false
+  }
+}
 
 /**
  * Initiate OSM OAuth2 authorization flow.
@@ -108,7 +119,7 @@ app.use(requireAuth).get(
         OSM_SCOPES,
       )
 
-      return { url: url.toString() }
+      return { url: url.toString(), manualCallback: needsManualCallback(osmCfg) }
     } catch (error: any) {
       return status(500, {
         message: error.message || 'Failed to initiate OAuth2 flow',
@@ -124,17 +135,23 @@ app.use(requireAuth).get(
 )
 
 /**
- * OAuth2 callback from OpenStreetMap.
- * Opens in a popup/new tab — posts result back to opener via postMessage.
- * Falls back to redirect if there's no opener (e.g. popup was blocked).
+ * OAuth2 callback from OpenStreetMap. Reached either as a browser navigation
+ * from the popup, or as a request from the app itself when the code had to be
+ * handed over by hand.
  */
 publicApi.get(
   '/callback',
-  async ({ query, t }) => {
+  async ({ query, request, t }) => {
+    const wantsJson = (request.headers.get('accept') ?? '').includes(
+      'application/json',
+    )
     const { code, state } = query
 
     if (!code || !state) {
-      return oauthCallbackPage({ status: 'error', message: t('errors.osm.missingCodeOrState') })
+      return oauthCallbackResponse(
+        { status: 'error', message: t('errors.osm.missingCodeOrState') },
+        wantsJson,
+      )
     }
 
     try {
@@ -145,7 +162,10 @@ publicApi.get(
         .where(and(eq(tokens.type, 'token'), eq(tokens.value, state)))
 
       if (matchingTokens.length === 0) {
-        return oauthCallbackPage({ status: 'error', message: t('errors.osm.invalidState') })
+        return oauthCallbackResponse(
+          { status: 'error', message: t('errors.osm.invalidState') },
+          wantsJson,
+        )
       }
 
       const stateToken = matchingTokens[0]
@@ -154,7 +174,10 @@ publicApi.get(
       // Check expiry
       if (stateToken.expires && new Date(stateToken.expires) < new Date()) {
         await db.delete(tokens).where(eq(tokens.id, stateToken.id))
-        return oauthCallbackPage({ status: 'error', message: t('errors.osm.authorizationExpired') })
+        return oauthCallbackResponse(
+          { status: 'error', message: t('errors.osm.authorizationExpired') },
+          wantsJson,
+        )
       }
 
       // Clean up the state token
@@ -181,7 +204,10 @@ publicApi.get(
 
       const osmUser = userResponse.data?.user
       if (!osmUser) {
-        return oauthCallbackPage({ status: 'error', message: t('errors.osm.userDetailsFailed') })
+        return oauthCallbackResponse(
+          { status: 'error', message: t('errors.osm.userDetailsFailed') },
+          wantsJson,
+        )
       }
 
       // Clear any previous connection before writing the new one. This goes
@@ -203,14 +229,14 @@ publicApi.get(
 
       await createIntegration(userId, IntegrationId.OPENSTREETMAP_ACCOUNT, config)
 
-      return oauthCallbackPage({ status: 'connected' })
+      return oauthCallbackResponse({ status: 'connected' }, wantsJson)
     } catch (error: any) {
       logError('OSM OAuth2 callback error', error)
       const message =
         error instanceof arctic.OAuth2RequestError
           ? `OAuth2 error: ${error.code}`
           : error.message || 'OAuth2 callback failed'
-      return oauthCallbackPage({ status: 'error', message })
+      return oauthCallbackResponse({ status: 'error', message }, wantsJson)
     }
   },
   {

--- a/server/src/services/integration.service.db.test.ts
+++ b/server/src/services/integration.service.db.test.ts
@@ -1,0 +1,82 @@
+/**
+ * DB-backed test for removing an integration whose config no longer decrypts.
+ *
+ * The unit tests are pure, so they can't show the trap that broke OSM
+ * reconnects: a row encrypted under a retired key is filtered out of
+ * `getConfiguredIntegrations`, while the unique index still sees it.
+ */
+
+import { describe, test, expect, beforeAll, afterAll } from 'bun:test'
+import { eq } from 'drizzle-orm'
+import { db } from '../db'
+import { users } from '../schema/users.schema'
+import { integrations } from '../schema/integrations.schema'
+import { generateId } from '../util'
+import {
+  deleteUserIntegrations,
+  getConfiguredIntegrations,
+} from './integration.service'
+import { IntegrationId } from '../types/integration.enums'
+
+const RUN_SUFFIX = Math.random().toString(36).slice(2, 8)
+let userId = ''
+
+beforeAll(async () => {
+  userId = generateId()
+  await db.insert(users).values({
+    id: userId,
+    email: `integrations-${RUN_SUFFIX}@parchment.test`,
+    alias: `integrations_${RUN_SUFFIX}`,
+    signingKey: 'sig',
+    encryptionKey: 'enc',
+  })
+})
+
+afterAll(async () => {
+  if (userId) await db.delete(users).where(eq(users.id, userId))
+})
+
+/** A row whose ciphertext was written under a key this server doesn't hold. */
+async function insertUndecryptableRow() {
+  const id = generateId()
+  await db.insert(integrations).values({
+    id,
+    userId,
+    integrationId: IntegrationId.OPENSTREETMAP_ACCOUNT,
+    scheme: 'server-key',
+    capabilities: JSON.stringify([]),
+    configCiphertext: Buffer.from('not-a-real-ciphertext').toString('base64'),
+    configNonce: Buffer.alloc(12).toString('base64'),
+    configKeyVersion: 1,
+  })
+  return id
+}
+
+describe('deleteUserIntegrations', () => {
+  test('removes a row the readable listing cannot see', async () => {
+    const id = await insertUndecryptableRow()
+
+    const listed = await getConfiguredIntegrations(userId)
+    expect(listed.find((i) => i.id === id)).toBeUndefined()
+
+    const removed = await deleteUserIntegrations(
+      userId,
+      IntegrationId.OPENSTREETMAP_ACCOUNT,
+    )
+    expect(removed).toBe(1)
+
+    const rows = await db
+      .select()
+      .from(integrations)
+      .where(eq(integrations.userId, userId))
+    expect(rows).toHaveLength(0)
+  })
+
+  test('reports nothing removed when the user has no such integration', async () => {
+    const removed = await deleteUserIntegrations(
+      userId,
+      IntegrationId.OPENSTREETMAP_ACCOUNT,
+    )
+    expect(removed).toBe(0)
+  })
+})

--- a/server/src/services/integration.service.ts
+++ b/server/src/services/integration.service.ts
@@ -1096,6 +1096,32 @@ export async function deleteIntegration(
   integrationManager.removeIntegration(userId, id)
 }
 
+/**
+ * Remove every row this user holds for one integration, readable or not.
+ *
+ * Reconnecting an OAuth account has to clear the old row to satisfy the
+ * (user, integration, scheme) unique index, and a row encrypted under a
+ * retired key never reaches `getConfiguredIntegrations` — so a caller that
+ * looks there sees nothing to delete and then collides on insert.
+ */
+export async function deleteUserIntegrations(
+  userId: string,
+  integrationId: IntegrationId,
+): Promise<number> {
+  const rows = await db
+    .select({ id: integrations.id })
+    .from(integrations)
+    .where(
+      and(
+        eq(integrations.userId, userId),
+        eq(integrations.integrationId, integrationId),
+      ),
+    )
+
+  for (const row of rows) await deleteIntegration(row.id, userId)
+  return rows.length
+}
+
 export async function testIntegrationConfig(
   integrationId: IntegrationId,
   config: Record<string, any>,

--- a/web/public/oauth/osm.html
+++ b/web/public/oauth/osm.html
@@ -1,0 +1,70 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Parchment</title>
+    <style>
+      body {
+        margin: 0;
+        min-height: 100vh;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font: 15px/1.5 system-ui, -apple-system, sans-serif;
+        color: #57534e;
+        background: #faf9f7;
+      }
+      main {
+        text-align: center;
+        padding: 1.5rem;
+      }
+      a {
+        color: inherit;
+      }
+      @media (prefers-color-scheme: dark) {
+        body {
+          color: #a8a29e;
+          background: #1c1917;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <p id="message">Connecting…</p>
+      <p><a id="back" href="/settings/integrations">Back to Parchment</a></p>
+    </main>
+    <script>
+      // OpenStreetMap serves Cross-Origin-Opener-Policy: same-origin, so by the
+      // time the OAuth popup lands back here its `window.opener` is severed and
+      // postMessage is impossible. This page is same-origin with the app, so it
+      // can hand the result over a BroadcastChannel instead.
+      var params = new URLSearchParams(location.search)
+      var status = params.get('status') === 'connected' ? 'connected' : 'error'
+      var message = params.get('message') || undefined
+
+      try {
+        var channel = new BroadcastChannel('osm-oauth')
+        channel.postMessage({ type: 'osm-oauth-callback', status: status, message: message })
+        channel.close()
+      } catch (error) {
+        // No channel: the app tab picks the result up when it regains focus.
+      }
+
+      document.getElementById('back').href =
+        '/settings/integrations?osm=' + encodeURIComponent(status) +
+        (message ? '&message=' + encodeURIComponent(message) : '')
+
+      window.close()
+
+      // A popup can only close itself in some browsers; say so if it's still here.
+      setTimeout(function () {
+        document.getElementById('message').textContent =
+          status === 'connected'
+            ? 'Your OpenStreetMap account is connected. You can close this window.'
+            : message || 'Something went wrong connecting your account.'
+      }, 300)
+    </script>
+  </body>
+</html>

--- a/web/src/components/integration/IntegrationTile.vue
+++ b/web/src/components/integration/IntegrationTile.vue
@@ -17,7 +17,7 @@ import {
   IntegrationScheme,
   IntegrationScope,
 } from '@/types/integrations.types'
-import { computed, h } from 'vue'
+import { computed, h, onUnmounted } from 'vue'
 import { useRouter } from 'vue-router'
 import { storeToRefs } from 'pinia'
 import { Button } from '@/components/ui/button'
@@ -78,6 +78,46 @@ const requiresSetup = computed(
 )
 
 const tileDisabled = computed(() => props.disabled || requiresSetup.value)
+
+/** Open while an OAuth popup is in flight; closed as soon as it reports back. */
+let oauthChannel: BroadcastChannel | null = null
+let oauthPoll: ReturnType<typeof setInterval> | undefined
+
+function stopListeningForOauthResult() {
+  oauthChannel?.close()
+  oauthChannel = null
+  clearInterval(oauthPoll)
+}
+
+onUnmounted(stopListeningForOauthResult)
+
+function listenForOauthResult(popup: Window | null) {
+  stopListeningForOauthResult()
+
+  oauthChannel = new BroadcastChannel('osm-oauth')
+  oauthChannel.onmessage = async ({ data }) => {
+    if (data?.type !== 'osm-oauth-callback') return
+    stopListeningForOauthResult()
+    popup?.close()
+
+    if (data.status === 'connected') {
+      toast.success(t('settings.integrations.osm.connected'))
+      await integrationService.fetchConfiguredIntegrations()
+      await integrationService.fetchAvailableIntegrations()
+    } else {
+      toast.error(data.message || t('settings.integrations.osm.authError'))
+    }
+  }
+
+  // Severing the opener also detaches our handle, so `closed` can read true
+  // while the popup is very much open. Treat it as "the flow may be over" —
+  // refresh once, quietly, and leave the channel listening for the real word.
+  oauthPoll = setInterval(() => {
+    if (!popup?.closed) return
+    clearInterval(oauthPoll)
+    integrationService.fetchConfiguredIntegrations()
+  }, 1000)
+}
 
 async function handleOAuthClick() {
   const integration = props.integration
@@ -169,33 +209,10 @@ async function handleOAuthClick() {
           'width=600,height=700,popup=yes',
         )
 
-        // Listen for the callback postMessage from the popup
-        const expectedOrigin = new URL(api.defaults.baseURL as string).origin
-        const onMessage = async (event: MessageEvent) => {
-          if (event.data?.type !== 'osm-oauth-callback') return
-          if (event.origin !== expectedOrigin) return
-          window.removeEventListener('message', onMessage)
-
-          if (event.data.status === 'connected') {
-            toast.success(t('settings.integrations.osm.connected'))
-            await integrationService.fetchConfiguredIntegrations()
-            await integrationService.fetchAvailableIntegrations()
-          } else {
-            toast.error(
-              event.data.message || t('settings.integrations.osm.authError'),
-            )
-          }
-        }
-
-        window.addEventListener('message', onMessage)
-
-        // Clean up listener if popup is closed without completing
-        const checkClosed = setInterval(() => {
-          if (popup?.closed) {
-            clearInterval(checkClosed)
-            window.removeEventListener('message', onMessage)
-          }
-        }, 500)
+        // The popup can't postMessage back: OSM's COOP header severs its
+        // opener. It ends on `/oauth/osm.html`, same-origin with us, which
+        // broadcasts the result here.
+        listenForOauthResult(popup)
       }
     } catch (error) {
       console.error('Failed to initiate OAuth flow:', error)

--- a/web/src/components/integration/IntegrationTile.vue
+++ b/web/src/components/integration/IntegrationTile.vue
@@ -119,6 +119,61 @@ function listenForOauthResult(popup: Window | null) {
   }, 1000)
 }
 
+/**
+ * Finish an OAuth flow whose redirect never made it back, by pasting the URL
+ * OpenStreetMap landed on into the console.
+ */
+function offerManualCallback() {
+  const finish = async (redirectUrl: string) => {
+    const params = new URL(redirectUrl).searchParams
+    const code = params.get('code')
+    const state = params.get('state')
+
+    if (!code || !state) {
+      toast.error(t('settings.integrations.osm.manualCallbackNoCode'))
+      return
+    }
+
+    try {
+      const { data } = await api.get('/integrations/osm/callback', {
+        params: { code, state },
+        headers: { Accept: 'application/json' },
+      })
+
+      if (data.status !== 'connected') {
+        toast.error(data.message || t('settings.integrations.osm.authError'))
+        return
+      }
+
+      delete (window as any).__osmDevCallback
+      toast.success(t('settings.integrations.osm.connected'))
+      await integrationService.fetchConfiguredIntegrations()
+      await integrationService.fetchAvailableIntegrations()
+    } catch (error: any) {
+      toast.error(
+        error.response?.data?.message ||
+          error.message ||
+          t('settings.integrations.osm.authError'),
+      )
+    }
+  }
+
+  ;(window as any).__osmDevCallback = finish
+
+  console.log(
+    '%cConnecting an OpenStreetMap account',
+    'font-weight: bold; font-size: 14px;',
+  )
+  console.log(
+    "After you authorize, OpenStreetMap sends you to this app's registered\n" +
+      'redirect URI, which this deployment does not answer on — the page will\n' +
+      'fail to load. Copy its full URL (it carries ?code=...&state=...) and run:\n\n' +
+      "  window.__osmDevCallback('PASTE_FULL_URL_HERE')\n",
+  )
+
+  toast.info(t('settings.integrations.osm.devCallbackInstructions'))
+}
+
 async function handleOAuthClick() {
   const integration = props.integration
   const config = props.configuration
@@ -128,80 +183,14 @@ async function handleOAuthClick() {
     // Open OAuth authorization in a popup/new tab
     try {
       const response = await api.get('/integrations/osm/authorize')
-      const { url } = response.data
+      const { url, manualCallback } = response.data
 
-      const isDevMode = window.location.protocol === 'http:'
-
-      if (isDevMode) {
-        // Dev mode: OSM doesn't allow HTTP redirect URIs, so provide a console-based workaround.
-        // Open the auth URL - the redirect will fail, but the user can copy the URL from the browser.
+      // Some setups can't be redirected back to — the OAuth app's registered
+      // redirect URI points somewhere this deployment isn't. The server says
+      // so; the user finishes the exchange by hand.
+      if (manualCallback) {
         window.open(url, '_blank')
-
-        // Register a global callback for the dev workaround
-        ;(window as any).__osmDevCallback = async (redirectUrl: string) => {
-          try {
-            const parsedUrl = new URL(redirectUrl)
-            const code = parsedUrl.searchParams.get('code')
-            const state = parsedUrl.searchParams.get('state')
-
-            if (!code || !state) {
-              console.error(
-                'Missing code or state in URL. Make sure you copied the full URL.',
-              )
-              return
-            }
-
-            // Call the callback endpoint directly - it returns HTML but the server-side
-            // still performs the token exchange and creates the integration record
-            const response = await api.get('/integrations/osm/callback', {
-              params: { code, state },
-              // Accept any response type since it returns HTML
-              transformResponse: [(data: any) => data],
-            })
-
-            // Parse the HTML response to check for success/error
-            const html = response.data as string
-            if (html.includes('"status":"error"')) {
-              const msgMatch = html.match(/"message":"([^"]*)"/)
-              const errorMsg = msgMatch?.[1] || 'OAuth callback failed'
-              console.error(
-                `%c❌ ${errorMsg}`,
-                'color: red; font-weight: bold;',
-              )
-              toast.error(errorMsg)
-              return
-            }
-
-            toast.success(t('settings.integrations.osm.connected'))
-            await integrationService.fetchConfiguredIntegrations()
-            await integrationService.fetchAvailableIntegrations()
-
-            delete (window as any).__osmDevCallback
-            console.log(
-              '%c✅ OSM account connected successfully!',
-              'color: green; font-weight: bold;',
-            )
-          } catch (error: any) {
-            console.error('Dev OAuth callback failed:', error)
-            toast.error(
-              error.message || t('settings.integrations.osm.authError'),
-            )
-          }
-        }
-
-        console.log(
-          '%c🔑 OSM OAuth Dev Mode',
-          'font-weight: bold; font-size: 14px;',
-        )
-        console.log(
-          'After authorizing on OSM, the redirect will fail because the\n' +
-            'redirect URI uses HTTPS but your local server runs on HTTP.\n\n' +
-            'Copy the full URL from the browser address bar (it will contain\n' +
-            '?code=...&state=... parameters) and run:\n\n' +
-            "  window.__osmDevCallback('PASTE_FULL_URL_HERE')\n",
-        )
-
-        toast.info(t('settings.integrations.osm.devCallbackInstructions'))
+        offerManualCallback()
       } else {
         const popup = window.open(
           url,

--- a/web/src/components/quick-edit/ConnectPrompt.vue
+++ b/web/src/components/quick-edit/ConnectPrompt.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+import { useRouter } from 'vue-router'
+import { useI18n } from 'vue-i18n'
+import { LinkIcon } from 'lucide-vue-next'
+import { Button } from '@/components/ui/button'
+import { EmptyState } from '@/components/ui/empty-state'
+import { AppRoute } from '@/router'
+import { IntegrationId } from '@/types/integrations.types'
+
+const router = useRouter()
+const { t } = useI18n()
+
+function openIntegration() {
+  router.push({
+    name: AppRoute.INTEGRATIONS,
+    query: { integration: IntegrationId.OPENSTREETMAP_ACCOUNT },
+  })
+}
+</script>
+
+<template>
+  <EmptyState
+    :icon="LinkIcon"
+    :title="t('quickEdit.connectTitle')"
+    :description="t('quickEdit.connectDescription')"
+  >
+    <Button size="sm" @click="openIntegration">
+      {{ t('quickEdit.connectAction') }}
+    </Button>
+  </EmptyState>
+</template>

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -2076,7 +2076,8 @@
         "disconnect": "Disconnect",
         "viewProfile": "View OSM profile",
         "configureOAuthApp": "Configure OAuth application on OSM server",
-        "devCallbackInstructions": "Dev mode: After authorizing in the browser, copy the full redirect URL and run window.__osmDevCallback('URL') in the console"
+        "devCallbackInstructions": "This deployment can't be redirected back to. After authorizing, copy the URL OpenStreetMap lands on and run window.__osmDevCallback('URL') in the console",
+        "manualCallbackNoCode": "That URL has no authorization code in it — copy the whole address, including everything after the ?"
       },
       "viewDocs": "View documentation",
       "degraded": {

--- a/web/src/lib/i18n/en-US.json
+++ b/web/src/lib/i18n/en-US.json
@@ -2687,7 +2687,7 @@
     "defaultEditComment": "Update {name}",
     "connectTitle": "Connect your OpenStreetMap account",
     "connectDescription": "Quick edits are published under your own OpenStreetMap account. Connect it once in settings to start editing the map.",
-    "connectAction": "Open integrations",
+    "connectAction": "Connect account",
     "rawKey": "key",
     "rawValue": "value",
     "address": {

--- a/web/src/service-worker.ts
+++ b/web/src/service-worker.ts
@@ -39,8 +39,14 @@ cleanupOutdatedCaches()
 precacheAndRoute(self.__WB_MANIFEST)
 
 // Every navigation serves the app shell — this is what makes a cold offline
-// launch render at all.
-registerRoute(new NavigationRoute(createHandlerBoundToURL('index.html')))
+// launch render at all. Except `/oauth/`: those are real static pages that
+// close themselves, and serving the shell there boots a second copy of the app
+// inside the OAuth popup.
+registerRoute(
+  new NavigationRoute(createHandlerBoundToURL('index.html'), {
+    denylist: [/^\/oauth\//],
+  }),
+)
 
 const DAY = 24 * 60 * 60
 

--- a/web/src/views/quick-edit/QuickEditElement.vue
+++ b/web/src/views/quick-edit/QuickEditElement.vue
@@ -3,12 +3,10 @@ import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import PanelLayout from '@/components/sheet/layouts/PanelLayout.vue'
-import { Button } from '@/components/ui/button'
 import { EmptyState } from '@/components/ui/empty-state'
 import { Spinner } from '@/components/ui/spinner'
 import {
   PencilIcon,
-  LinkIcon,
   ClockIcon,
   InfoIcon,
   TriangleAlertIcon,
@@ -19,8 +17,8 @@ import { useAppService } from '@/services/app.service'
 import { useExternalLink } from '@/composables/useExternalLink'
 import { useIntegrationsStore } from '@/stores/integrations.store'
 import { IntegrationId } from '@/types/integrations.types'
-import { AppRoute } from '@/router'
 import { LngLat } from '@/types/map.types'
+import ConnectPrompt from '@/components/quick-edit/ConnectPrompt.vue'
 import QuickEditMarker from '@/components/quick-edit/QuickEditMarker.vue'
 import PresetIcon from '@/components/quick-edit/PresetIcon.vue'
 import QuickEditForm from '@/components/quick-edit/QuickEditForm.vue'
@@ -225,18 +223,7 @@ async function handleSubmit(comment: string) {
 
 <template>
   <PanelLayout>
-    <EmptyState
-      v-if="!osmConnected"
-      :icon="LinkIcon"
-      :title="t('quickEdit.connectTitle')"
-      :description="t('quickEdit.connectDescription')"
-    >
-      <template #action>
-        <Button @click="router.push({ name: AppRoute.INTEGRATIONS })">
-          {{ t('quickEdit.connectAction') }}
-        </Button>
-      </template>
-    </EmptyState>
+    <ConnectPrompt v-if="!osmConnected" />
 
     <div v-else-if="loading" class="flex justify-center py-12">
       <Spinner size="sm" />

--- a/web/src/views/quick-edit/QuickEditNew.vue
+++ b/web/src/views/quick-edit/QuickEditNew.vue
@@ -3,9 +3,7 @@ import { computed, onMounted, onUnmounted, reactive, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
 import { useI18n } from 'vue-i18n'
 import PanelLayout from '@/components/sheet/layouts/PanelLayout.vue'
-import { Button } from '@/components/ui/button'
-import { EmptyState } from '@/components/ui/empty-state'
-import { PencilIcon, LinkIcon } from 'lucide-vue-next'
+import { PencilIcon } from 'lucide-vue-next'
 import { useQuickEditService } from '@/services/quick-edit.service'
 import { useMapService } from '@/services/map/map.service'
 import { useAppService } from '@/services/app.service'
@@ -14,6 +12,7 @@ import { useIntegrationsStore } from '@/stores/integrations.store'
 import { IntegrationId } from '@/types/integrations.types'
 import { AppRoute } from '@/router'
 import { LngLat } from '@/types/map.types'
+import ConnectPrompt from '@/components/quick-edit/ConnectPrompt.vue'
 import QuickEditMarker from '@/components/quick-edit/QuickEditMarker.vue'
 import PresetPicker from '@/components/quick-edit/PresetPicker.vue'
 import PresetIcon from '@/components/quick-edit/PresetIcon.vue'
@@ -222,18 +221,7 @@ async function handleSubmit(comment: string) {
 
 <template>
   <PanelLayout>
-    <EmptyState
-      v-if="!osmConnected"
-      :icon="LinkIcon"
-      :title="t('quickEdit.connectTitle')"
-      :description="t('quickEdit.connectDescription')"
-    >
-      <template #action>
-        <Button @click="router.push({ name: AppRoute.INTEGRATIONS })">
-          {{ t('quickEdit.connectAction') }}
-        </Button>
-      </template>
-    </EmptyState>
+    <ConnectPrompt v-if="!osmConnected" />
 
     <template v-else>
       <div class="mb-4 flex items-start gap-2">

--- a/web/src/views/settings/pages/Integrations.vue
+++ b/web/src/views/settings/pages/Integrations.vue
@@ -113,6 +113,24 @@ function handleOAuthCallback() {
   router.replace({ query: {} })
 }
 
+/**
+ * `?integration=<id>` deep-links one tile — quick edit sends people here to
+ * connect their OSM account. Seeding the search rather than filtering leaves
+ * a state the existing clear button can undo.
+ */
+function focusQueriedIntegration() {
+  const id = route.query.integration
+  if (typeof id !== 'string') return
+
+  const match = integrationStore.allIntegrations.find(
+    ({ integration }) => integration.id === id,
+  )
+  if (match) searchQuery.value = match.integration.name
+
+  const { integration: _removed, ...rest } = route.query
+  router.replace({ query: rest })
+}
+
 onMounted(async () => {
   handleOAuthCallback()
 
@@ -122,6 +140,8 @@ onMounted(async () => {
   } catch (error) {
     console.error('Failed to load integrations:', error)
   }
+
+  focusQueriedIntegration()
 })
 </script>
 


### PR DESCRIPTION
## What

Three things broke connecting an OpenStreetMap account:

1. Reconnecting failed with `Integration openstreetmap-account is already configured with scheme server-key`, and the account couldn't be disconnected either.
2. Quick edit's "connect your account" screen had no button.
3. After a successful connect, the OAuth popup stayed open showing a second copy of the whole app, with the success toast inside it.

## Why

**(1)** `getConfiguredIntegrations` drops rows whose config can't be decrypted, so an account stored under a retired `PARCHMENT_INTEGRATION_ENCRYPTION_KEY` is invisible to the OAuth callback. The callback saw nothing to remove, inserted a fresh row, and collided with the stale one on the `(user, integration, scheme)` unique index. Disconnect failed the same way, with a 404 — leaving no route out of the state from the UI. Live on production: every integration row written before the key changed on 2026-07-17 is unreadable there.

**(2)** The action was passed through `EmptyState`'s `#action` slot, which doesn't exist — actions go in the default slot — so it rendered nothing.

**(3)** openstreetmap.org serves `Cross-Origin-Opener-Policy: same-origin`, so the popup loses `window.opener` the moment it navigates there. The callback page's `postMessage` could never arrive, and it fell through to its "no opener" branch: redirect the popup to `/settings/integrations`. The service worker then served the app shell for that navigation — hence a whole second app inside the popup.

## Changes

* `deleteUserIntegrations(userId, integrationId)` removes a user's rows for an integration straight from the table, readable or not. The OAuth callback and disconnect both use it.
* The callback now hands its result to `/oauth/osm.html`, a static page on the *client* origin. Being same-origin with the app it broadcasts the result over a `BroadcastChannel` and closes itself; the tile listens on that channel instead of `message`.
* `/oauth/` is excluded from the service worker's navigation fallback, so that page is served as itself rather than as the app shell.
* Both quick edit views share one `ConnectPrompt`, whose button deep-links to `/settings/integrations?integration=openstreetmap-account` — that seeds the search so only that tile shows.

## Verified

* `deleteUserIntegrations` removes an undecryptable row a listing can't see — new DB-backed test.
* With the OSM row's ciphertext corrupted, `POST /integrations/osm/disconnect` returns 200 and clears the row (it 404'd before).
* Driving the real flow on the preview: `opener after OSM: false`, `POPUP SELF-CLOSED: true`, `TOAST IN APP WINDOW: true`.
* Screenshots in the comments.

## Notes

* Rows that don't decrypt are still invisible everywhere else in settings, so the stale system-integration rows on production can't be cleaned up from the UI. Not fixed here.
* `/oauth/osm.html` is a plain static file, so its two lines of copy aren't run through i18n.