### PR TITLE
Unblock the release build

### DIFF
--- a/server/src/controllers/osm-edit.controller.ts
+++ b/server/src/controllers/osm-edit.controller.ts
@@ -17,8 +17,8 @@ import {
   submitEdit,
   getPendingEdits,
   OsmEditError,
-  type OsmElementType,
 } from '../services/osm-edit.service'
+import type { OsmElementType } from '../types/osm-edit.types'
 import { integrationManager } from '../services/integrations'
 import { IntegrationId } from '../types/integration.enums'
 import type { OverpassIntegration } from '../services/integrations/overpass-integration'

--- a/server/src/services/osm-edit.service.ts
+++ b/server/src/services/osm-edit.service.ts
@@ -10,42 +10,12 @@ import { generateId } from '../util'
 import { logError } from '../lib/logger'
 import { version as appVersion } from '../../package.json'
 import { APP_USER_AGENT } from '../lib/constants'
-
-export type OsmElementType = 'node' | 'way' | 'relation'
-
-export interface OsmLiveElement {
-  type: OsmElementType
-  id: number
-  version: number
-  lat?: number
-  lon?: number
-  tags: Record<string, string>
-  /** Node refs for ways — echoed back verbatim on modify. */
-  nodeRefs?: number[]
-  /** Members for relations — echoed back verbatim on modify. */
-  members?: Array<{ type: OsmElementType; ref: number; role: string }>
-}
-
-export interface SubmitEditInput {
-  comment: string
-  action: 'create' | 'modify'
-  element: {
-    type: OsmElementType
-    id?: number
-    /** Version the client prefilled from — a mismatch at submit time is a conflict. */
-    version?: number
-    lat?: number
-    lon?: number
-    tags: Record<string, string>
-  }
-}
-
-export interface SubmitEditResult {
-  changesetId: number
-  osmType: OsmElementType
-  osmId: number
-  version: number
-}
+import type {
+  OsmElementType,
+  OsmLiveElement,
+  SubmitEditInput,
+  SubmitEditResult,
+} from '../types/osm-edit.types'
 
 export class OsmEditError extends Error {
   constructor(

--- a/server/src/types/osm-edit.types.ts
+++ b/server/src/types/osm-edit.types.ts
@@ -1,0 +1,44 @@
+/**
+ * The shapes quick edit exchanges with the client.
+ *
+ * These live apart from `osm-edit.service` because the web app imports them:
+ * reaching into the service would pull the whole integrations graph into the
+ * frontend's typecheck, and with it every type error in code the browser never
+ * runs. A leaf module keeps that graph the size of the types themselves.
+ */
+
+export type OsmElementType = 'node' | 'way' | 'relation'
+
+export interface OsmLiveElement {
+  type: OsmElementType
+  id: number
+  version: number
+  lat?: number
+  lon?: number
+  tags: Record<string, string>
+  /** Node refs for ways — echoed back verbatim on modify. */
+  nodeRefs?: number[]
+  /** Members for relations — echoed back verbatim on modify. */
+  members?: Array<{ type: OsmElementType; ref: number; role: string }>
+}
+
+export interface SubmitEditInput {
+  comment: string
+  action: 'create' | 'modify'
+  element: {
+    type: OsmElementType
+    id?: number
+    /** Version the client prefilled from — a mismatch at submit time is a conflict. */
+    version?: number
+    lat?: number
+    lon?: number
+    tags: Record<string, string>
+  }
+}
+
+export interface SubmitEditResult {
+  changesetId: number
+  osmType: OsmElementType
+  osmId: number
+  version: number
+}

--- a/web/src/types/quick-edit.types.ts
+++ b/web/src/types/quick-edit.types.ts
@@ -4,7 +4,7 @@ import type {
   OsmLiveElement,
   SubmitEditInput,
   SubmitEditResult,
-} from '@server/services/osm-edit.service'
+} from '@server/types/osm-edit.types'
 import type { FieldDefinition, GeometryType } from '@server/lib/osm-presets'
 import type { OsmEdit } from '@server/schema/osm-edits.schema'
 import type { NsiBrand } from '@server/lib/nsi'


### PR DESCRIPTION
## What

`vue-tsc` fails, so `bun run build` and `bun run build:ci` can't complete. That took the v0.12.0 release down: Android, iOS and desktop all failed, so **Create GitHub Release**, **Upload to App Store** and **Upload to Google Play** were skipped ([run 34654918384](https://github.com/alexwohlbruck/parchment/actions/runs/34654918384)). The tag and the server shipped; nothing else did.

## Why

`web/src/types/quick-edit.types.ts` imported its types from `@server/services/osm-edit.service`. That service imports `integration.service` → `services/integrations` → every adapter, so a type-only import pulled the server's whole integration graph into the frontend's typecheck and surfaced 37 pre-existing type errors in code the browser never runs (valhalla, overpass, wikipedia, geoapify, graphhopper…).

Those errors aren't new — `tsc` in `server/` reports 266 of them, and has for a long time, because nothing gates it. What was new in 0.12.0 was the web build being made to look at a slice of them.

## Change

The four shared shapes move to `server/src/types/osm-edit.types.ts`, a leaf module with no runtime imports. The service and the controller import them from there; the web app does too.

## Verified

* `bunx vue-tsc --noEmit` — 0 errors (was 37).
* `bun run build:ci` — completes.
* `bun run test` — 2452 passed.
* `tsc` in `server/` — still 266 errors, unchanged. This PR doesn't fix them, it stops the web build depending on them.

## Follow-up

The server's own typecheck being red is worth its own pass — some of those errors look real (`valhalla-integration` reads `avoidHills` off a type that only has `avoidTolls`). Nothing runs `tsc` over `server/` in CI, so they'll keep accumulating.