### PR TITLE
Fix the OSM OAuth controller tests

### DIFF
--- a/server/src/controllers/osm-oauth.controller.test.ts
+++ b/server/src/controllers/osm-oauth.controller.test.ts
@@ -54,11 +54,12 @@ mock.module('../config/origins.config', () => ({
   clientOrigin: 'https://app.parchment.test',
 }))
 
+let osmRedirectUri = ''
 mock.module('../config/osm.config', () => ({
   getOsmConfig: () => ({
     clientId: 'osm-client',
     clientSecret: 'osm-secret',
-    redirectUri: '',
+    redirectUri: osmRedirectUri,
     authEndpoint: 'https://osm.test/oauth2/authorize',
     tokenEndpoint: 'https://osm.test/oauth2/token',
     apiBase: 'https://osm.test/api/0.6',
@@ -71,6 +72,10 @@ const createIntegration = mock(
   async (_userId: string, _id: string, _config: unknown) => ({ id: 'int-1' }),
 )
 const deleteIntegration = mock(async (_id: string, _userId: string) => true)
+let removedIntegrations = 0
+const deleteUserIntegrations = mock(
+  async (_userId: string, _integrationId: string) => removedIntegrations,
+)
 const updateIntegration = mock(
   async (_id: string, _userId: string, _patch: unknown) => ({ id: 'int-1' }),
 )
@@ -79,6 +84,7 @@ mock.module('../services/integration.service', () => ({
   getConfiguredIntegrations,
   createIntegration,
   deleteIntegration,
+  deleteUserIntegrations,
   updateIntegration,
 }))
 
@@ -122,11 +128,14 @@ beforeEach(() => {
   dbMock.reset()
   tokenExchangeError = null
   userIntegrations = []
+  removedIntegrations = 0
+  osmRedirectUri = ''
   validateAuthorizationCode.mockClear()
   createAuthorizationURL.mockClear()
   getConfiguredIntegrations.mockClear()
   createIntegration.mockClear()
   deleteIntegration.mockClear()
+  deleteUserIntegrations.mockClear()
   updateIntegration.mockClear()
 })
 
@@ -172,6 +181,24 @@ describe('GET /integrations/osm/authorize', () => {
     expect(dbMock.deleteCount).toBe(1)
   })
 
+  test('expects the browser back when the redirect URI is this server', async () => {
+    osmRedirectUri = 'https://api.parchment.test/integrations/osm/callback'
+
+    const res = await req(app).get('/integrations/osm/authorize')
+
+    expect(res.body.manualCallback).toBe(false)
+  })
+
+  test('asks for a manual handover when the redirect URI is elsewhere', async () => {
+    // A branch preview: OSM will send the browser to the one host registered on
+    // the OAuth app, which isn't this one, so the popup can never report back.
+    osmRedirectUri = 'https://localhost:5000/integrations/osm/callback'
+
+    const res = await req(app).get('/integrations/osm/authorize')
+
+    expect(res.body.manualCallback).toBe(true)
+  })
+
   test('gives the state a one-hour lifetime', async () => {
     await req(app).get('/integrations/osm/authorize')
 
@@ -183,25 +210,25 @@ describe('GET /integrations/osm/authorize', () => {
 })
 
 describe('GET /integrations/osm/callback — state validation', () => {
-  test('renders an error page when the code is missing', async () => {
+  test('sends the browser on with the error when the code is missing', async () => {
     const res = await req(app).get('/integrations/osm/callback', {
       query: { state: 'generated-state' },
     })
 
-    expect(res.status).toBe(200)
-    expect(res.headers.get('content-type')).toContain('text/html')
-    expect(String(res.body)).toContain('Missing authorization code or state')
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toContain('status=error')
+    expect(res.headers.get('location')).toContain('Missing+authorization+code')
     expect(validateAuthorizationCode).not.toHaveBeenCalled()
   })
 
-  test('renders an error page when the state is unknown', async () => {
+  test('sends the browser on with the error when the state is unknown', async () => {
     dbMock.queueSelect([])
 
     const res = await req(app).get('/integrations/osm/callback', {
       query: { code: 'auth-code', state: 'forged-state' },
     })
 
-    expect(String(res.body)).toContain('Invalid or expired state parameter')
+    expect(res.headers.get('location')).toContain('Invalid+or+expired+state')
     expect(validateAuthorizationCode).not.toHaveBeenCalled()
   })
 
@@ -214,7 +241,7 @@ describe('GET /integrations/osm/callback — state validation', () => {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    expect(String(res.body)).toContain('Authorization request expired')
+    expect(res.headers.get('location')).toContain('Authorization+request+expired')
     expect(dbMock.deleteCount).toBe(1)
     expect(validateAuthorizationCode).not.toHaveBeenCalled()
   })
@@ -244,7 +271,7 @@ describe('GET /integrations/osm/callback — success path', () => {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    expect(String(res.body)).toContain('"status":"connected"')
+    expect(res.headers.get('location')).toContain('status=connected')
     expect(createIntegration.mock.calls[0][0]).toBe(TEST_USER.id)
     expect(createIntegration.mock.calls[0][2]).toMatchObject({
       accessToken: 'osm-access-token',
@@ -268,15 +295,21 @@ describe('GET /integrations/osm/callback — success path', () => {
     )
   })
 
-  test('replaces an existing OSM integration rather than duplicating it', async () => {
-    userIntegrations = [osmIntegration]
+  test('clears any previous connection before writing the new one', async () => {
+    // Not through the readable listing: a row encrypted under a retired key is
+    // absent from it, and leaving that row in place collides on the unique
+    // index — which is what made reconnecting impossible.
+    userIntegrations = []
     http.get.mockResolvedValueOnce({ data: { user: OSM_USER } })
 
     await req(app).get('/integrations/osm/callback', {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    expect(deleteIntegration).toHaveBeenCalledWith('int-1', TEST_USER.id)
+    expect(deleteUserIntegrations).toHaveBeenCalledWith(
+      TEST_USER.id,
+      'openstreetmap-account',
+    )
     expect(createIntegration).toHaveBeenCalled()
   })
 
@@ -302,7 +335,7 @@ describe('GET /integrations/osm/callback — success path', () => {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    expect(String(res.body)).toContain('Failed to fetch OSM user details')
+    expect(res.headers.get('location')).toContain('Failed+to+fetch+OSM+user')
     expect(createIntegration).not.toHaveBeenCalled()
   })
 
@@ -313,13 +346,13 @@ describe('GET /integrations/osm/callback — success path', () => {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    expect(String(res.body)).toContain('OAuth2 error: invalid_grant')
+    expect(res.headers.get('location')).toContain('OAuth2+error%3A+invalid_grant')
     expect(createIntegration).not.toHaveBeenCalled()
   })
 })
 
-describe('GET /integrations/osm/callback — callback page safety', () => {
-  test('targets the postMessage at our client origin, not a wildcard', async () => {
+describe('GET /integrations/osm/callback — handing the result back', () => {
+  test('sends the browser to the handoff page on our client origin', async () => {
     dbMock.queueSelect([futureStateToken()])
     http.get.mockResolvedValueOnce({ data: { user: OSM_USER } })
 
@@ -327,11 +360,14 @@ describe('GET /integrations/osm/callback — callback page safety', () => {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    expect(String(res.body)).toContain("'https://app.parchment.test'")
-    expect(String(res.body)).not.toContain("postMessage(, '*')")
+    // OSM's COOP header severs the popup's opener on the way through, so the
+    // result can only be handed over from a page sharing the app's origin.
+    expect(res.headers.get('location')).toBe(
+      'https://app.parchment.test/oauth/osm.html?status=connected',
+    )
   })
 
-  test('escapes </script> in an error message so it cannot break out', async () => {
+  test('encodes an error message rather than passing it through', async () => {
     dbMock.queueSelect([futureStateToken()])
     tokenExchangeError = new Error('boom </script><script>alert(1)</script>')
 
@@ -339,23 +375,39 @@ describe('GET /integrations/osm/callback — callback page safety', () => {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    const html = String(res.body)
-    // The raw closing tag must never appear inside the inline script payload.
-    expect(html).not.toContain('</script><script>alert(1)')
-    expect(html).toContain('\\u003c/script')
+    const location = res.headers.get('location') ?? ''
+    expect(location).not.toContain('<script>')
+    expect(location).toContain('%3Cscript%3E')
   })
 
-  test('falls back to a redirect when there is no opener', async () => {
+  test('answers with JSON when the app asks for it', async () => {
+    // The manual handover: the app calls this itself with the pasted code, so
+    // it wants the result, not a page to look at.
     dbMock.queueSelect([futureStateToken()])
     http.get.mockResolvedValueOnce({ data: { user: OSM_USER } })
 
     const res = await req(app).get('/integrations/osm/callback', {
       query: { code: 'auth-code', state: 'generated-state' },
+      headers: { accept: 'application/json' },
     })
 
-    expect(String(res.body)).toContain(
-      'https://app.parchment.test/settings/integrations?osm=connected',
-    )
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ status: 'connected' })
+  })
+
+  test('reports a failure as JSON too', async () => {
+    dbMock.queueSelect([futureStateToken()])
+    tokenExchangeError = new OAuth2RequestError('invalid_grant')
+
+    const res = await req(app).get('/integrations/osm/callback', {
+      query: { code: 'auth-code', state: 'generated-state' },
+      headers: { accept: 'application/json' },
+    })
+
+    expect(res.body).toMatchObject({
+      status: 'error',
+      message: 'OAuth2 error: invalid_grant',
+    })
   })
 
   test('completes without a session, authenticated by the state token', async () => {
@@ -371,8 +423,8 @@ describe('GET /integrations/osm/callback — callback page safety', () => {
       query: { code: 'auth-code', state: 'generated-state' },
     })
 
-    expect(res.status).toBe(200)
-    expect(String(res.body)).toContain('osm-oauth-callback')
+    expect(res.status).toBe(302)
+    expect(res.headers.get('location')).toContain('status=connected')
   })
 
   test('creates the integration for the state token’s owner, not the session', async () => {
@@ -476,31 +528,43 @@ describe('POST /integrations/osm/disconnect', () => {
     const res = await req(app).post('/integrations/osm/disconnect')
 
     expect(res.status).toBe(401)
-    expect(deleteIntegration).not.toHaveBeenCalled()
+    expect(deleteUserIntegrations).not.toHaveBeenCalled()
   })
 
   test('removes the caller’s OSM integration', async () => {
-    userIntegrations = [osmIntegration]
+    removedIntegrations = 1
 
     const res = await req(app).post('/integrations/osm/disconnect')
 
     expect(res.status).toBe(200)
     expect(res.body).toEqual({ success: true })
-    expect(deleteIntegration).toHaveBeenCalledWith('int-1', TEST_USER.id)
+    expect(deleteUserIntegrations).toHaveBeenCalledWith(
+      TEST_USER.id,
+      'openstreetmap-account',
+    )
+  })
+
+  test('removes a row the readable listing can’t see', async () => {
+    // Undecryptable config: the listing drops the row, but it is still there
+    // and still blocks reconnecting, so disconnect must clear it.
+    userIntegrations = []
+    removedIntegrations = 1
+
+    const res = await req(app).post('/integrations/osm/disconnect')
+
+    expect(res.status).toBe(200)
   })
 
   test('404s when there is nothing connected', async () => {
-    userIntegrations = []
+    removedIntegrations = 0
 
     const res = await req(app).post('/integrations/osm/disconnect')
 
     expect(res.status).toBe(404)
-    expect(deleteIntegration).not.toHaveBeenCalled()
   })
 
   test('500s when the delete fails', async () => {
-    userIntegrations = [osmIntegration]
-    deleteIntegration.mockRejectedValueOnce(new Error('db down'))
+    deleteUserIntegrations.mockRejectedValueOnce(new Error('db down'))
 
     const res = await req(app).post('/integrations/osm/disconnect')
 


### PR DESCRIPTION
#509 changed the OAuth callback's shape without updating its controller tests, so `osm-oauth.controller.test.ts` failed to load at all: the test's `integration.service` mock didn't export `deleteUserIntegrations`.

Brings the tests up to what the controller now does:

* mocks `deleteUserIntegrations`, and asserts the callback clears a previous connection through it rather than through the readable listing — the reconnect bug
* the callback redirects now, so the error and success cases assert on `Location` instead of an HTML body
* the postMessage/`</script>`-escaping cases are gone with the inline script they tested; in their place, the handoff page target, URL-encoding of error text, and the JSON negotiation the manual flow uses
* disconnect is driven by the removed-row count, including the case where the listing can't see the row

37 pass. No production code changes.