### PR TITLE
Trip line stops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Added
 
+* Trip maps now draw the stops, station names and line bullets along each transit leg, instead of a bare coloured line.
+
 ### Changed
 
 ### Fixed

--- a/web/src/lib/geo/geo-line.test.ts
+++ b/web/src/lib/geo/geo-line.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { haversineMeters, projectAlong, sliceAlong } from './geo-line'
+import { distanceToLine, haversineMeters, projectAlong, sliceAlong } from './geo-line'
 
 // A straight west→east line at NYC's latitude, ~842 m per 0.01° of
 // longitude. Four vertices, three equal segments.
@@ -58,5 +58,28 @@ describe('sliceAlong', () => {
     const s = sliceAlong(LINE, SEG * 2, SEG * 99)
     expect(s[s.length - 1][0]).toBeCloseTo(LINE[3][0], 9)
     expect(sliceAlong(LINE, SEG, SEG)).toEqual([])
+  })
+})
+
+describe('distanceToLine', () => {
+  it('is 0 on the line and the perpendicular distance beside it', () => {
+    expect(distanceToLine(LINE, [-73.985, 40.70])).toBeCloseTo(0, 6)
+    // 0.001° of latitude ≈ 111 m, whatever the longitude
+    expect(distanceToLine(LINE, [-73.985, 40.701])).toBeCloseTo(110.5, 0)
+  })
+
+  it('measures a point past an end to that end, not to the line through it', () => {
+    // Straight off the west end: the perpendicular to the infinite line
+    // would be 0, but the line stops here.
+    // Equirectangular against haversine: metres apart over a 1.7 km gap.
+    expect(distanceToLine(LINE, [-74.02, 40.70])).toBeCloseTo(
+      haversineMeters(40.70, -74.02, 40.70, -74.00),
+      -1,
+    )
+  })
+
+  it('falls back to the lone vertex of a degenerate line', () => {
+    expect(distanceToLine([[-74.0, 40.70]], [-74.0, 40.701])).toBeCloseTo(111, 0)
+    expect(distanceToLine([], [-74.0, 40.70])).toBe(Infinity)
   })
 })

--- a/web/src/lib/geo/geo-line.ts
+++ b/web/src/lib/geo/geo-line.ts
@@ -60,6 +60,40 @@ export function projectAlong(
 }
 
 /**
+ * Metres from `pt` to the nearest point ON `coords` — clamped to each
+ * segment, so a point past either end measures to that end rather than to
+ * the infinite line through it.
+ */
+export function distanceToLine(
+  coords: [number, number][],
+  [plng, plat]: [number, number],
+): number {
+  let best = Infinity
+  for (let i = 1; i < coords.length; i++) {
+    const [alng, alat] = coords[i - 1]
+    const [blng, blat] = coords[i]
+    const kx = 111_320 * Math.cos((alat * Math.PI) / 180)
+    const ky = 110_540
+    const dx = (blng - alng) * kx
+    const dy = (blat - alat) * ky
+    const px = (plng - alng) * kx
+    const py = (plat - alat) * ky
+    const len2 = dx * dx + dy * dy
+    const t = len2 ? Math.max(0, Math.min(1, (px * dx + py * dy) / len2)) : 0
+    const ddx = px - t * dx
+    const ddy = py - t * dy
+    const d2 = ddx * ddx + ddy * ddy
+    if (d2 < best) best = d2
+  }
+  if (best === Infinity) {
+    const only = coords[0]
+    if (!only) return Infinity
+    return haversineMeters(plat, plng, only[1], only[0])
+  }
+  return Math.sqrt(best)
+}
+
+/**
  * The sub-polyline between two distances (metres) along `coords`, with both
  * cut ends interpolated exactly. Out-of-range bounds clamp to the line's
  * ends; an empty or inverted span returns an empty array.

--- a/web/src/lib/transit/transit-focus.test.ts
+++ b/web/src/lib/transit/transit-focus.test.ts
@@ -31,8 +31,8 @@ const transitSegment = (over: Record<string, unknown> = {}) => ({
     route: { id: 'f1_A' },
     trip: { id: 'f1_trip-7' },
     stops: [
-      { id: 'f1_s1', location: { lat: 1, lng: 2 } },
-      { id: 'f1_s2', location: { lat: 3, lng: 4 } },
+      { id: 'f1_s1', name: 'First St', location: { lat: 1, lng: 2 } },
+      { id: 'f1_s2', name: 'Second St', location: { lat: 3, lng: 4 } },
     ],
     ...(over as Record<string, unknown>),
   },
@@ -45,9 +45,18 @@ describe('focusedLegs', () => {
     expect(leg.routeIds).toEqual(['A'])
     expect(leg.tripId).toBe('trip-7')
     expect(leg.stops).toEqual([
-      { stopId: 's1', lat: 1, lng: 2 },
-      { stopId: 's2', lat: 3, lng: 4 },
+      { stopId: 's1', name: 'First St', lat: 1, lng: 2 },
+      { stopId: 's2', name: 'Second St', lat: 3, lng: 4 },
     ])
+  })
+
+  it('takes the line\'s colour, with the # a GTFS feed leaves off', () => {
+    const [bare] = focusedLegs({
+      segments: [transitSegment({ route: { id: 'f1_A', color: '2850AD' } })],
+    })
+    expect(bare.color).toBe('#2850AD')
+    const [none] = focusedLegs({ segments: [transitSegment()] })
+    expect(none.color).toBeNull()
   })
 
   it('keeps interchangeable lines, which are one leg to the rider', () => {
@@ -87,11 +96,14 @@ describe('focusedLegs', () => {
     const [leg] = focusedLegs({
       segments: [
         transitSegment({
-          stops: [{ id: 'f1_s1' }, { id: 'f1_s2', location: { lat: 3, lng: 4 } }],
+          stops: [
+            { id: 'f1_s1', name: 'First St' },
+            { id: 'f1_s2', name: 'Second St', location: { lat: 3, lng: 4 } },
+          ],
         }),
       ],
     })
-    expect(leg.stops).toEqual([{ stopId: 's2', lat: 3, lng: 4 }])
+    expect(leg.stops).toEqual([{ stopId: 's2', name: 'Second St', lat: 3, lng: 4 }])
   })
 })
 

--- a/web/src/lib/transit/transit-focus.ts
+++ b/web/src/lib/transit/transit-focus.ts
@@ -14,6 +14,7 @@ import type { TransitVehiclePosition } from '@/types/multimodal.types'
  *  list and a leg's stop list reduce to. */
 export interface FocusedStop {
   stopId: string
+  name: string
   lat: number
   lng: number
 }
@@ -30,6 +31,9 @@ export interface FocusedLeg {
   tripId: string | null
   /** Every stop the leg calls at, ends included. */
   stops: FocusedStop[]
+  /** The line's own colour, as the trip's polyline draws it (`#rrggbb`), or
+   *  null for a feed that publishes none. */
+  color: string | null
 }
 
 /** Feed-local id, or null when there is nothing to strip. */
@@ -68,10 +72,13 @@ export function focusedLegs(trip: { segments?: unknown[] } | null | undefined): 
     const stops: FocusedStop[] = ((td?.stops ?? []) as Array<Record<string, any>>)
       .map((s) => ({
         stopId: local(s?.id) ?? '',
+        name: s?.name ?? '',
         lat: s?.location?.lat,
         lng: s?.location?.lng,
       }))
       .filter((s) => s.stopId && Number.isFinite(s.lat) && Number.isFinite(s.lng))
+
+    const color = td?.route?.color ?? td?.color ?? null
 
     out.push({
       segmentIndex,
@@ -79,6 +86,7 @@ export function focusedLegs(trip: { segments?: unknown[] } | null | undefined): 
       routeIds: [...new Set(routeIds)],
       tripId: local(td?.trip?.id),
       stops,
+      color: color ? (color.startsWith('#') ? color : `#${color}`) : null,
     })
   })
 

--- a/web/src/services/layers/features/portolan/portolan-transit.service.ts
+++ b/web/src/services/layers/features/portolan/portolan-transit.service.ts
@@ -48,6 +48,7 @@ import { proxyBase, ensureRegions } from './portolan-client'
 import router, { AppRoute } from '@/router'
 import { api } from '@/lib/api'
 import { densifyLine } from '@/lib/geo/geo-densify'
+import { distanceToLine } from '@/lib/geo/geo-line'
 import { useLayersStore } from '@/stores/layers.store'
 import { useThemeStore } from '@/stores/theme.store'
 import { MapStrategy } from '@/services/map/providers/map.strategy'
@@ -320,6 +321,7 @@ export function usePortolanTransitService() {
     setNetworkHidden,
     setIsolatedRouteStops,
     setIsolatedRouteGeometry,
+    setTripLegs,
     setStopService,
     portolanRouteToken,
     portolanTransitActive,
@@ -408,6 +410,84 @@ function setIsolatedRouteStops(points: [number, number][] | null) {
   isolatedStopsSig = sig
   isolatedStops = next
   if (isolatedRoute) applyStations()
+}
+
+/** One leg of an open itinerary, in the terms the tiles are keyed by. */
+export interface PortolanTripLeg {
+  /** Portolan's own tokens for the line the leg rides — resolved, never a
+   *  bare GTFS id, for the reason portolanRouteToken exists. Several when
+   *  the leg is one ride to the rider and two lines to the feed (the 4 and
+   *  the 5). */
+  routes: string[]
+  /** Every stop the leg calls at, in order, [lng, lat]. */
+  stops: [number, number][]
+}
+
+/**
+ * The legs of the itinerary on the map, or null for none.
+ *
+ * A trip is NOT an isolation: its own polyline is the subject and the
+ * ribbons only step back behind it (see the trip isolation service). But
+ * a line drawn with nothing on it is a coloured stripe — the stations it
+ * calls at, their names and the bullets that say which line this is are
+ * what make it a journey. So the stops narrow exactly as they do under
+ * isolation, to the legs' own, and keep full strength while the ribbons
+ * dim.
+ */
+let tripLegs: PortolanTripLeg[] | null = null
+let tripLegsSig = ''
+
+function setTripLegs(legs: PortolanTripLeg[] | null) {
+  const next = legs?.length ? legs : null
+  const sig = next
+    ? next.map(l => `${l.routes.join('+')}@${l.stops.length}`).join(';')
+    : ''
+  if (sig === tripLegsSig) return
+  tripLegsSig = sig
+  tripLegs = next
+  applyStations()
+  applyStationZoomRelax()
+  applyStationScale()
+  applyStationDim()
+}
+
+/** Whether the symbols on the map have been narrowed to one line or one
+ *  itinerary — in which case they are the subject of the view, not the
+ *  network's own thinning-by-zoom crowd. */
+function stopsNarrowed(): boolean {
+  return !!isolatedRoute || !!tripLegs
+}
+
+/** A cat rides the line rather than sitting at a stop, so its span is
+ *  measured against the chain of stops, not against any one of them.
+ *  Loose enough for track that curves between two stops, tight enough to
+ *  leave the line's un-ridden tail behind. */
+const LEG_PATH_M = 400
+
+/**
+ * The leg this symbol belongs to, and which of that leg's lines it is,
+ * or null when it belongs to none.
+ *
+ * Structure decides the line, and the leg's own stop list decides the
+ * span: the planner already said which stops the ride calls at, so no
+ * activity mask is consulted — a trip planned for tomorrow morning draws
+ * exactly the stops it will call at then.
+ */
+function tripLegFor(f: any): { routes: string[]; route: string } | null {
+  const p = f?.properties
+  if (!p || !tripLegs) return null
+  const [lng, lat] = f.geometry?.coordinates ?? []
+  if (lng == null) return null
+  const isCat = p.ftype === 'cat'
+  for (const leg of tripLegs) {
+    const route = leg.routes.find(r => stationServesRoute(p, r, NO_MASKS, null))
+    if (!route) continue
+    const onLeg = isCat
+      ? leg.stops.length > 1 && distanceToLine(leg.stops, [lng, lat]) <= LEG_PATH_M
+      : nearAnyStop([lng, lat], leg.stops)
+    if (onLeg) return { routes: leg.routes, route }
+  }
+  return null
 }
 
 /** The running span's geometry, when it differs from the tiles', plus a
@@ -667,11 +747,7 @@ function serviceDimmedBullets(f: any, at: Date | null): any {
  *  enough not to bleed into the next station. */
 const PATH_MATCH_M = 160
 
-function onIsolatedPath(f: any): boolean {
-  const pts = isolatedStops
-  if (!pts) return true
-  const [lng, lat] = f.geometry?.coordinates ?? []
-  if (lng == null) return false
+function nearAnyStop([lng, lat]: [number, number], pts: [number, number][]): boolean {
   const kx = 111_320 * Math.cos((lat * Math.PI) / 180)
   const ky = 110_540
   for (const [plng, plat] of pts) {
@@ -680,6 +756,14 @@ function onIsolatedPath(f: any): boolean {
     if (dx * dx + dy * dy <= PATH_MATCH_M * PATH_MATCH_M) return true
   }
   return false
+}
+
+function onIsolatedPath(f: any): boolean {
+  const pts = isolatedStops
+  if (!pts) return true
+  const [lng, lat] = f.geometry?.coordinates ?? []
+  if (lng == null) return false
+  return nearAnyStop([lng, lat], pts)
 }
 
 /**
@@ -725,7 +809,7 @@ function applyStationScale() {
   for (let i = 3; i < MARKER_SIZE.length; i += 2) {
     out.push(
       MARKER_SIZE[i],
-      isolatedRoute ? MARKER_SIZE[i + 1] * ISOLATION_WIDTH : MARKER_SIZE[i + 1],
+      stopsNarrowed() ? MARKER_SIZE[i + 1] * ISOLATION_WIDTH : MARKER_SIZE[i + 1],
     )
   }
   map.setLayoutProperty('portolan-station-markers', 'icon-size', out)
@@ -735,7 +819,7 @@ function applyStationZoomRelax() {
   if (!map?.getStyle()) return
   for (const [id, z] of Object.entries(STATION_ZOOM)) {
     if (!map.getLayer(id)) continue
-    map.setLayerZoomRange(id, isolatedRoute ? z.isolated : z.usual, 24)
+    map.setLayerZoomRange(id, stopsNarrowed() ? z.isolated : z.usual, 24)
   }
   // the connection bullets under each name follow the same relaxation
   if (map.getLayer('portolan-station-labels')) {
@@ -743,7 +827,7 @@ function applyStationZoomRelax() {
       'step',
       ['zoom'],
       '',
-      isolatedRoute ? BULLET_ROW_STEP.isolated : BULLET_ROW_STEP.usual,
+      stopsNarrowed() ? BULLET_ROW_STEP.isolated : BULLET_ROW_STEP.usual,
       ['coalesce', ['get', 'brow'], ''],
     ])
   }
@@ -921,6 +1005,8 @@ function teardownPortolanTransit() {
   map = null
   activeStrategy = null
   isolatedRoute = null
+  tripLegs = null
+  tripLegsSig = ''
   clearHydration()
   clearMounts()
   inkDark = null
@@ -2191,7 +2277,7 @@ function applyRibbonDim() {
  */
 function applyStationDim() {
   if (!map) return
-  const o = networkDimmed && !isolatedRoute ? isolationDim() : 1
+  const o = networkDimmed && !stopsNarrowed() ? isolationDim() : 1
   let layers: any[] = []
   try {
     layers = map.getStyle()?.layers ?? []
@@ -2496,6 +2582,19 @@ function applyStations() {
       )
       .map((f: any) => serviceDimmedBullets(f, at))
       .map((f: any) => isolatedMarkerFeature(f, isolatedRoute!))
+    src.setData({ type: 'FeatureCollection', features: feats })
+    return
+  }
+  // Same narrowing for an itinerary, over several lines at once: each leg
+  // keeps the stops it calls at and the bullets riding the span it rides.
+  if (tripLegs) {
+    const at = isolationTime()
+    const feats: any[] = []
+    for (const f of stationsRaw.features) {
+      const hit = tripLegFor(f)
+      if (!hit) continue
+      feats.push(isolatedMarkerFeature(serviceDimmedBullets(f, at), hit.route))
+    }
     src.setData({ type: 'FeatureCollection', features: feats })
     return
   }

--- a/web/src/services/layers/features/portolan/portolan-trip-legs.test.ts
+++ b/web/src/services/layers/features/portolan/portolan-trip-legs.test.ts
@@ -1,0 +1,214 @@
+/**
+ * An open itinerary narrows the symbols on the map to its own legs.
+ *
+ * The rule has three parts, and the interesting failures are all in the
+ * third: the right LINE (a leg riding the A must not light up the C that
+ * shares its stations), the right SPAN (the A runs to Inwood whether or
+ * not the rider does), and the right kind of span test for the kind of
+ * symbol — a station sits AT a stop, a caterpillar bullet rides between
+ * two of them.
+ */
+
+import { describe, test, expect, vi, beforeEach, afterEach } from 'vitest'
+
+vi.mock('maplibre-gl', () => ({ getVersion: () => '6.4.1-transit.3' }))
+vi.mock('@/router', () => ({ default: {}, AppRoute: {} }))
+vi.mock('@/lib/api', () => ({ api: { defaults: { baseURL: 'http://test' } } }))
+
+import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
+import { MapEngine, MapTheme } from '@/types/map.types'
+
+const FLAG_KEY = 'parchment.portolan-transit'
+
+/** Four stops down one avenue, ~1.1 km apart, and the A/C run all four. */
+const STOPS: [number, number][] = [
+  [-73.99, 40.75],
+  [-73.99, 40.76],
+  [-73.99, 40.77],
+  [-73.99, 40.78],
+]
+
+const station = (name: string, at: [number, number], routes: string) => ({
+  type: 'Feature',
+  properties: { ftype: 'station', name, routes, route_colors: '2850AD' },
+  geometry: { type: 'Point', coordinates: at },
+})
+
+const cat = (label: string, at: [number, number], route: string) => ({
+  type: 'Feature',
+  properties: { ftype: 'cat', label, route, band: 14, vec: '[0,0]', veclo: '[0,0]' },
+  geometry: { type: 'Point', coordinates: at },
+})
+
+function fakeMap(features: Record<string, unknown[]>) {
+  const layers: Array<{ id: string }> = [{ id: 'background' }]
+  const sources: Record<string, unknown> = { basemap: {}, 'portolan-tiles-nyc': {} }
+  const handlers: Record<string, (e?: unknown) => void> = {}
+  const stationData: unknown[] = []
+
+  const map = {
+    style: {},
+    isStyleLoaded: () => true,
+    getStyle: () => ({ layers: [...layers], sources: { ...sources } }),
+    getLayer: (id: string) => layers.find(l => l.id === id),
+    getSource: (id: string) =>
+      id === 'portolan-stations'
+        ? { setData: (d: any) => stationData.push(d) }
+        : sources[id],
+    addLayer: (l: { id: string }) => layers.push(l),
+    addSource: (id: string, def: unknown) => {
+      sources[id] = def
+    },
+    removeLayer: (id: string) => {
+      const i = layers.findIndex(l => l.id === id)
+      if (i >= 0) layers.splice(i, 1)
+    },
+    removeSource: (id: string) => {
+      delete sources[id]
+    },
+    querySourceFeatures: (_sid: string, opts: { sourceLayer: string }) =>
+      features[opts.sourceLayer] ?? [],
+    setFilter: () => {},
+    setPaintProperty: () => {},
+    setLayoutProperty: () => {},
+    setLayerZoomRange: () => {},
+    getBounds: () => ({
+      getWest: () => -74.3,
+      getEast: () => -73.6,
+      getSouth: () => 40.5,
+      getNorth: () => 41,
+    }),
+    hasImage: () => true,
+    addImage: () => {},
+    on: (ev: string, fn: (e?: unknown) => void) => {
+      handlers[ev] = fn
+    },
+    off: () => {},
+    once: vi.fn(),
+    fire: (ev: string) => handlers[ev]?.(),
+    /** The features the last setData put on the map. */
+    symbols: () => (stationData.at(-1) as any)?.features ?? [],
+  }
+  return map
+}
+
+const strategyFor = (map: unknown) =>
+  ({
+    mapInstance: map,
+    options: { engine: MapEngine.MAPLIBRE, theme: MapTheme.LIGHT },
+  }) as any
+
+const names = (map: ReturnType<typeof fakeMap>) =>
+  map.symbols().map((f: any) => f.properties.name ?? f.properties.label)
+
+/** Hydrate the tiles into the symbol source, the way an idle does. */
+async function hydrate(map: ReturnType<typeof fakeMap>) {
+  map.fire('idle')
+  await new Promise(r => requestAnimationFrame(() => r(null)))
+}
+
+describe('trip legs narrow the symbols to the itinerary', () => {
+  let service: ReturnType<typeof usePortolanTransitService>
+
+  beforeEach(() => {
+    // Station names are measured on a canvas to predict their wrap count,
+    // and happy-dom has no 2d context to measure on.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      font: '',
+      measureText: (t: string) => ({ width: t.length * 50 }),
+    } as unknown as CanvasRenderingContext2D)
+    localStorage.setItem(FLAG_KEY, '1')
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve([]) })),
+    )
+    service = usePortolanTransitService()
+  })
+
+  afterEach(() => {
+    service.teardownPortolanTransit()
+    localStorage.removeItem(FLAG_KEY)
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  test('keeps the legitimate stops and drops everything else', async () => {
+    const map = fakeMap({
+      stations: [
+        station('Ridden', STOPS[1], 'A,C'),
+        station('Off the line', STOPS[1], 'L'),
+        station('Past the last stop', [-73.99, 40.83], 'A,C'),
+      ],
+      markers: [],
+      cat: [],
+    })
+    service.initializePortolanTransit(strategyFor(map))
+    await hydrate(map)
+
+    service.setTripLegs([{ routes: ['A'], stops: STOPS }])
+
+    expect(names(map)).toEqual(['Ridden'])
+  })
+
+  test('bullets ride the span between stops, not only the stops', async () => {
+    const map = fakeMap({
+      stations: [],
+      markers: [],
+      cat: [
+        cat('A', [-73.99, 40.755], 'A'),
+        cat('A', [-73.99, 40.81], 'A'),
+        cat('L', [-73.99, 40.755], 'L'),
+      ],
+    })
+    service.initializePortolanTransit(strategyFor(map))
+    await hydrate(map)
+
+    service.setTripLegs([{ routes: ['A'], stops: STOPS }])
+
+    // Between two ridden stops, and only for the line being ridden. The
+    // one at 40.81 is past the leg's last stop.
+    expect(map.symbols()).toHaveLength(1)
+    expect(map.symbols()[0].geometry.coordinates).toEqual([-73.99, 40.755])
+  })
+
+  test('each leg contributes its own line and its own span', async () => {
+    const far: [number, number][] = [
+      [-73.95, 40.68],
+      [-73.95, 40.69],
+    ]
+    const map = fakeMap({
+      stations: [
+        station('First leg', STOPS[2], 'A,C'),
+        station('Second leg', far[0], 'Q'),
+        station('Second line, first span', STOPS[2], 'Q'),
+      ],
+      markers: [],
+      cat: [],
+    })
+    service.initializePortolanTransit(strategyFor(map))
+    await hydrate(map)
+
+    service.setTripLegs([
+      { routes: ['A'], stops: STOPS },
+      { routes: ['Q'], stops: far },
+    ])
+
+    expect(names(map)).toEqual(['First leg', 'Second leg'])
+  })
+
+  test('putting the trip away puts the whole network back', async () => {
+    const map = fakeMap({
+      stations: [station('Ridden', STOPS[1], 'A'), station('Elsewhere', [0, 0], 'L')],
+      markers: [],
+      cat: [],
+    })
+    service.initializePortolanTransit(strategyFor(map))
+    await hydrate(map)
+
+    service.setTripLegs([{ routes: ['A'], stops: STOPS }])
+    expect(names(map)).toEqual(['Ridden'])
+
+    service.setTripLegs(null)
+    expect(names(map)).toEqual(['Ridden', 'Elsewhere'])
+  })
+})

--- a/web/src/services/layers/features/route-isolation.service.ts
+++ b/web/src/services/layers/features/route-isolation.service.ts
@@ -21,13 +21,18 @@ import {
   fadeTransitNetwork,
   networkDimOpacity,
 } from '@/services/layers/features/transit-network-dim'
+import {
+  addStopOverlay,
+  removeLayerIfExists,
+  removeSourceIfExists,
+  removeStopOverlay,
+  stopOverlayIds,
+} from '@/services/layers/features/transit-stop-overlay'
 import type { FitBoundsFn } from '@/types/map.types'
 
 const ROUTE_SOURCE_ID = 'route-detail-shape'
 const ROUTE_LAYER_ID = 'route-detail-line'
-const STOPS_SOURCE_ID = 'route-detail-stops'
-const STOPS_LAYER_ID = 'route-detail-stops-circles'
-const STOPS_LABELS_LAYER_ID = 'route-detail-stops-labels'
+const STOPS = stopOverlayIds('route-detail-stops')
 
 export function useRouteIsolationService() {
   const routeDetailStore = useRouteDetailStore()
@@ -117,11 +122,9 @@ export function useRouteIsolationService() {
    * ours. Only one of them may be on the map at a time.
    */
   function removeRouteOverlay() {
-    removeLayerIfExists(STOPS_LABELS_LAYER_ID)
-    removeLayerIfExists(STOPS_LAYER_ID)
-    removeSourceIfExists(STOPS_SOURCE_ID)
-    removeLayerIfExists(ROUTE_LAYER_ID)
-    removeSourceIfExists(ROUTE_SOURCE_ID)
+    removeStopOverlay(mapInstance, STOPS)
+    removeLayerIfExists(mapInstance, ROUTE_LAYER_ID)
+    removeSourceIfExists(mapInstance, ROUTE_SOURCE_ID)
   }
 
   type IsolatableRoute = {
@@ -238,9 +241,12 @@ export function useRouteIsolationService() {
       const stops = routeDetailStore.servedStops.length
         ? routeDetailStore.servedStops
         : route.stops
-      if (stops.length > 0) {
-        addStationMarkers(stops, route.routeColor)
-      }
+      addStopOverlay(
+        mapInstance,
+        STOPS,
+        stops.map(s => ({ name: s.stopName, lng: s.lng, lat: s.lat })),
+        route.routeColor,
+      )
     }
 
     // A confirmed break does not change WHO renders — portolan keeps the
@@ -422,8 +428,8 @@ export function useRouteIsolationService() {
   function addRouteShape(coordinates: [number, number][], color: string | null) {
     if (!mapInstance) return
 
-    removeLayerIfExists(ROUTE_LAYER_ID)
-    removeSourceIfExists(ROUTE_SOURCE_ID)
+    removeLayerIfExists(mapInstance, ROUTE_LAYER_ID)
+    removeSourceIfExists(mapInstance, ROUTE_SOURCE_ID)
 
     const lineColor = color ? `#${color}` : '#007cbf'
 
@@ -463,97 +469,6 @@ export function useRouteIsolationService() {
         'line-opacity': 1,
       },
     })
-  }
-
-  function addStationMarkers(
-    stops: RouteDetailStop[],
-    color: string | null,
-  ) {
-    if (!mapInstance) return
-
-    removeLayerIfExists(STOPS_LABELS_LAYER_ID)
-    removeLayerIfExists(STOPS_LAYER_ID)
-    removeSourceIfExists(STOPS_SOURCE_ID)
-
-    const features = stops.map((stop, i) => ({
-      type: 'Feature' as const,
-      properties: {
-        name: stop.stopName,
-        isTerminus: i === 0 || i === stops.length - 1,
-      },
-      geometry: {
-        type: 'Point' as const,
-        coordinates: [stop.lng, stop.lat],
-      },
-    }))
-
-    mapInstance.addSource(STOPS_SOURCE_ID, {
-      type: 'geojson',
-      data: {
-        type: 'FeatureCollection',
-        features,
-      },
-    })
-
-    const stationColor = color ? `#${color}` : '#007cbf'
-
-    // Station circles
-    mapInstance.addLayer({
-      id: STOPS_LAYER_ID,
-      type: 'circle',
-      source: STOPS_SOURCE_ID,
-      paint: {
-        'circle-radius': [
-          'case',
-          ['get', 'isTerminus'], 6,
-          4,
-        ],
-        'circle-color': '#ffffff',
-        'circle-stroke-width': [
-          'case',
-          ['get', 'isTerminus'], 3,
-          2.5,
-        ],
-        'circle-stroke-color': stationColor,
-      },
-    })
-
-    // Station labels
-    mapInstance.addLayer({
-      id: STOPS_LABELS_LAYER_ID,
-      type: 'symbol',
-      source: STOPS_SOURCE_ID,
-      layout: {
-        'text-field': ['get', 'name'],
-        'text-font': ['DIN Pro Medium', 'Arial Unicode MS Bold'],
-        'text-size': 11,
-        'text-offset': [1, 0],
-        'text-anchor': 'left',
-        'text-allow-overlap': false,
-        'text-max-width': 12,
-      },
-      paint: {
-        'text-color': '#333333',
-        'text-halo-width': 1.5,
-        'text-halo-color': '#ffffff',
-      },
-    })
-  }
-
-  function removeLayerIfExists(id: string) {
-    try {
-      if (mapInstance?.getLayer(id)) {
-        mapInstance.removeLayer(id)
-      }
-    } catch { /* layer doesn't exist */ }
-  }
-
-  function removeSourceIfExists(id: string) {
-    try {
-      if (mapInstance?.getSource(id)) {
-        mapInstance.removeSource(id)
-      }
-    } catch { /* source doesn't exist */ }
   }
 
   function destroy() {

--- a/web/src/services/layers/features/transit-stop-overlay.ts
+++ b/web/src/services/layers/features/transit-stop-overlay.ts
@@ -1,0 +1,119 @@
+/**
+ * Stations drawn as circles and names, for the transit portolan does not
+ * draw.
+ *
+ * The pyramids cover the rail-ish feeds portolan has built; a bus route in
+ * a city with none still has stops, and this is the only view they have.
+ * One renderer for both callers that need it — a route detail lifting its
+ * line out of the network, and an itinerary's transit legs — so the two
+ * views agree on what a stop looks like.
+ */
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const DEFAULT_COLOR = '#007cbf'
+
+export interface OverlayStop {
+  name: string
+  lng: number
+  lat: number
+}
+
+/** The three ids one overlay owns; distinct per caller so several can be
+ *  on the map at once (one per leg of a trip). */
+export interface StopOverlayIds {
+  source: string
+  circles: string
+  labels: string
+}
+
+export function stopOverlayIds(prefix: string): StopOverlayIds {
+  return {
+    source: prefix,
+    circles: `${prefix}-circles`,
+    labels: `${prefix}-labels`,
+  }
+}
+
+export function removeLayerIfExists(map: any, id: string) {
+  try {
+    if (map?.getLayer(id)) map.removeLayer(id)
+  } catch { /* layer doesn't exist */ }
+}
+
+export function removeSourceIfExists(map: any, id: string) {
+  try {
+    if (map?.getSource(id)) map.removeSource(id)
+  } catch { /* source doesn't exist */ }
+}
+
+export function removeStopOverlay(map: any, ids: StopOverlayIds) {
+  removeLayerIfExists(map, ids.labels)
+  removeLayerIfExists(map, ids.circles)
+  removeSourceIfExists(map, ids.source)
+}
+
+export function addStopOverlay(
+  map: any,
+  ids: StopOverlayIds,
+  stops: OverlayStop[],
+  color: string | null,
+) {
+  if (!map || !stops.length) return
+
+  removeStopOverlay(map, ids)
+
+  const stationColor = color
+    ? color.startsWith('#') ? color : `#${color}`
+    : DEFAULT_COLOR
+
+  map.addSource(ids.source, {
+    type: 'geojson',
+    data: {
+      type: 'FeatureCollection',
+      features: stops.map((stop, i) => ({
+        type: 'Feature' as const,
+        properties: {
+          name: stop.name,
+          isTerminus: i === 0 || i === stops.length - 1,
+        },
+        geometry: {
+          type: 'Point' as const,
+          coordinates: [stop.lng, stop.lat],
+        },
+      })),
+    },
+  })
+
+  map.addLayer({
+    id: ids.circles,
+    type: 'circle',
+    source: ids.source,
+    paint: {
+      'circle-radius': ['case', ['get', 'isTerminus'], 6, 4],
+      'circle-color': '#ffffff',
+      'circle-stroke-width': ['case', ['get', 'isTerminus'], 3, 2.5],
+      'circle-stroke-color': stationColor,
+    },
+  })
+
+  map.addLayer({
+    id: ids.labels,
+    type: 'symbol',
+    source: ids.source,
+    layout: {
+      'text-field': ['get', 'name'],
+      'text-font': ['DIN Pro Medium', 'Arial Unicode MS Bold'],
+      'text-size': 11,
+      'text-offset': [1, 0],
+      'text-anchor': 'left',
+      'text-allow-overlap': false,
+      'text-max-width': 12,
+    },
+    paint: {
+      'text-color': '#333333',
+      'text-halo-width': 1.5,
+      'text-halo-color': '#ffffff',
+    },
+  })
+}

--- a/web/src/services/layers/features/trip-isolation.service.ts
+++ b/web/src/services/layers/features/trip-isolation.service.ts
@@ -2,7 +2,8 @@
  * Trip Isolation Service
  *
  * Decides what the transit network does while an itinerary is on the map,
- * hovered in the list or opened.
+ * hovered in the list or opened, and puts the itinerary's own stops back
+ * on top of it.
  *
  * A trip that rides transit steps the network back, so the trip's own
  * polyline reads as the subject instead of competing with every line it
@@ -10,11 +11,18 @@
  * the ribbons are not context for a walking or driving line, just clutter
  * beside it.
  *
- * That is all it does. The route panel lifts its line out of portolan's
- * ribbons; a trip must not, because portolan draws bundled routes at
- * parallel slot offsets — an isolated A would land beside the trip line
- * rather than under it, the same line drawn twice in two styles. The trip
- * line is already the highlight; the dim is the other half of it.
+ * The route panel lifts its line out of portolan's ribbons; a trip must
+ * not, because portolan draws bundled routes at parallel slot offsets —
+ * an isolated A would land beside the trip line rather than under it, the
+ * same line drawn twice in two styles. The trip line is already the
+ * highlight; the dim is the other half of it.
+ *
+ * What the dim alone leaves is a coloured stripe across a city. So the
+ * SYMBOLS are narrowed the way an isolation narrows them — each leg's own
+ * stations, their names, and the bullets riding the span it rides — and
+ * kept at full strength over the dimmed ribbons. Where portolan draws the
+ * line that is portolan's own lettering; where it does not, the stops fall
+ * back to the same circles-and-names overlay the route panel uses.
  *
  * Stands down entirely when the route panel is the focus: that view owns
  * the dim, and two owners would fight over the paint they restore.
@@ -25,24 +33,70 @@
  * retired transitland layers, which are static when they are there at all.
  */
 
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
 import { watch, type WatchStopHandle } from 'vue'
 import {
   useTransitFocusStore,
   type TransitNetworkMode,
 } from '@/stores/transit-focus.store'
+import { useTripFocusStore } from '@/stores/trip-focus.store'
 import { usePortolanTransitService } from '@/services/layers/features/portolan/portolan-transit.service'
+import type { PortolanTripLeg } from '@/services/layers/features/portolan/portolan-transit.service'
 import {
   fadeTransitNetwork,
   networkDimOpacity,
 } from '@/services/layers/features/transit-network-dim'
+import {
+  addStopOverlay,
+  removeStopOverlay,
+  stopOverlayIds,
+  type StopOverlayIds,
+} from '@/services/layers/features/transit-stop-overlay'
+import type { FocusedLeg } from '@/lib/transit/transit-focus'
+
+/** Points spread along a leg pin a route token to THIS line's geometry:
+ *  several feeds can share a bare id, and one shared terminal cannot tell
+ *  them apart (see portolanRouteToken). */
+const TOKEN_PROBES = 8
+
+/** Idles to wait for portolan to hydrate before giving up on it, and
+ *  idles to keep asking once it has — the tiles a leg runs through arrive
+ *  over the fit's ease, so one answer is never the answer. */
+const HYDRATION_IDLES = 6
+const MISS_IDLES = 3
+
+const overlayIds = (segmentIndex: number): StopOverlayIds =>
+  stopOverlayIds(`trip-leg-stops-${segmentIndex}`)
+
+function probesAlong(leg: FocusedLeg): [number, number][] {
+  const stops = leg.stops
+  if (!stops.length) return []
+  const want = Math.min(TOKEN_PROBES, stops.length)
+  const step = (stops.length - 1) / Math.max(1, want - 1)
+  const out: [number, number][] = []
+  for (let i = 0; i < want; i++) {
+    const s = stops[Math.round(i * step)]
+    if (s) out.push([s.lng, s.lat])
+  }
+  return out
+}
 
 export function useTripIsolationService() {
   const focus = useTransitFocusStore()
+  const tripFocus = useTripFocusStore()
   const portolan = usePortolanTransitService()
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   let mapInstance: any = null
   let watchStop: WatchStopHandle | null = null
+  let legsWatchStop: WatchStopHandle | null = null
   let mode: TransitNetworkMode = 'normal'
+
+  /** Bumps on every leg change, so a deferred answer for an itinerary the
+   *  rider has already left does nothing at all. */
+  let generation = 0
+  let reconciler: (() => void) | null = null
+  /** Segment indices whose stops are currently drawn as the overlay. */
+  let overlaid = new Set<number>()
 
   function apply(next: TransitNetworkMode) {
     if (!mapInstance || next === mode) return
@@ -54,18 +108,155 @@ export function useTripIsolationService() {
     const opacity =
       next === 'dimmed' ? networkDimOpacity() : next === 'hidden' ? 0 : null
     fadeTransitNetwork(mapInstance, opacity, { skipPortolan: true })
+    renderStops()
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  /** The legs whose stops this service is responsible for: none at all
+   *  unless the trip is what the map is showing. */
+  function focusedLegs(): FocusedLeg[] {
+    return mode === 'dimmed' ? tripFocus.legs : []
+  }
+
+  function clearStops() {
+    detachReconciler()
+    portolan.setTripLegs(null)
+    for (const segmentIndex of overlaid) {
+      removeStopOverlay(mapInstance, overlayIds(segmentIndex))
+    }
+    overlaid = new Set()
+  }
+
+  function drawOverlay(legs: FocusedLeg[]) {
+    const next = new Set<number>()
+    for (const leg of legs) {
+      if (leg.stops.length < 2) continue
+      addStopOverlay(
+        mapInstance,
+        overlayIds(leg.segmentIndex),
+        leg.stops.map(s => ({ name: s.name, lng: s.lng, lat: s.lat })),
+        leg.color,
+      )
+      next.add(leg.segmentIndex)
+    }
+    for (const segmentIndex of overlaid) {
+      if (!next.has(segmentIndex)) {
+        removeStopOverlay(mapInstance, overlayIds(segmentIndex))
+      }
+    }
+    overlaid = next
+  }
+
+  /** Portolan's token for each of a leg's lines, empty when it draws none
+   *  of them. */
+  function tokensFor(leg: FocusedLeg): string[] {
+    const along = probesAlong(leg)
+    return leg.routeIds
+      .map(id => portolan.portolanRouteToken(id, along))
+      .filter((t): t is string => !!t)
+  }
+
+  /**
+   * Split the legs between the two renderers and draw both.
+   *
+   * Returns whether every leg has an answer — until then the caller keeps
+   * asking, because a leg portolan has simply not loaded the tiles for yet
+   * is indistinguishable from one it does not draw.
+   */
+  function drawResolved(legs: FocusedLeg[]): boolean {
+    const drawn: PortolanTripLeg[] = []
+    const rest: FocusedLeg[] = []
+    for (const leg of legs) {
+      const routes = tokensFor(leg)
+      if (routes.length) {
+        drawn.push({
+          routes,
+          stops: leg.stops.map(s => [s.lng, s.lat] as [number, number]),
+        })
+      } else {
+        rest.push(leg)
+      }
+    }
+    portolan.setTripLegs(drawn)
+    drawOverlay(rest)
+    return rest.length === 0
+  }
+
+  /**
+   * Ask portolan first, and keep asking.
+   *
+   * Drawing the overlay before portolan has had its chance puts plain
+   * circles and labels on screen only to replace them with portolan's
+   * bulleted ones a moment later; nothing at all is the better first
+   * frame. The reconciler fills it in as soon as the tiles can answer, and
+   * the overlay is still what a feed portolan does not draw gets.
+   */
+  function renderStops() {
+    if (!mapInstance) return
+    const legs = focusedLegs()
+    generation++
+    detachReconciler()
+    if (!legs.length) {
+      clearStops()
+      return
+    }
+
+    if (!portolan.isPortolanTransitEnabled()) {
+      portolan.setTripLegs(null)
+      drawOverlay(legs)
+      return
+    }
+
+    const mine = generation
+    if (portolan.portolanTransitActive() && drawResolved(legs)) return
+
+    let waitsForHydration = 0
+    let missesWhileReady = 0
+    const reconcile = () => {
+      if (mine !== generation) return detachReconciler()
+      if (!portolan.portolanTransitActive()) {
+        if (++waitsForHydration >= HYDRATION_IDLES) {
+          portolan.setTripLegs(null)
+          drawOverlay(legs)
+          detachReconciler()
+        }
+        return
+      }
+      if (drawResolved(legs)) return detachReconciler()
+      // Ready, tiles idle, some leg still unknown: once the fit has landed
+      // and the tiles under it have answered a few times, that IS the
+      // answer, and the overlay drawResolved already left there stands.
+      if (++missesWhileReady >= MISS_IDLES) detachReconciler()
+    }
+    reconciler = reconcile
+    mapInstance.on('idle', reconcile)
+  }
+
+  function detachReconciler() {
+    if (reconciler && mapInstance) mapInstance.off('idle', reconciler)
+    reconciler = null
+  }
+
   function initialize(map: any) {
     mapInstance = map
     watchStop = watch(() => focus.networkMode, apply, { immediate: true })
+    // The legs themselves change without the mode doing: a rebooking, a
+    // board naming the run, the rider picking a different itinerary.
+    legsWatchStop = watch(
+      () =>
+        tripFocus.legs
+          .map(l => `${l.segmentIndex}:${l.routeIds.join('+')}:${l.stops.length}`)
+          .join('|'),
+      renderStops,
+    )
   }
 
   function destroy() {
+    clearStops()
     apply('normal')
     watchStop?.()
     watchStop = null
+    legsWatchStop?.()
+    legsWatchStop = null
     mapInstance = null
   }
 

--- a/web/src/services/layers/markers/marker-layers.service.ts
+++ b/web/src/services/layers/markers/marker-layers.service.ts
@@ -127,6 +127,7 @@ export function useMarkerLayersService() {
     routeIsolation.initialize(mapStrategy.mapInstance, fitBounds)
 
     // Trip isolation: dims the network behind an open itinerary's line
+    // and draws that line's own stops on top of it
     tripIsolation = useTripIsolationService()
     tripIsolation.initialize(mapStrategy.mapInstance)
 

--- a/web/src/stores/transit-focus.store.ts
+++ b/web/src/stores/transit-focus.store.ts
@@ -95,6 +95,7 @@ export const useTransitFocusStore = defineStore('transit-focus', () => {
     if (source.value === 'route') {
       return (routeDetail.activeRoute?.stops ?? []).map((s) => ({
         stopId: s.stopId,
+        name: s.stopName,
         lat: s.lat,
         lng: s.lng,
       }))


### PR DESCRIPTION
An itinerary's transit legs were drawn as bare coloured lines: no stations, no
names, no bullets. The network behind them dims, so what a leg calls at was
harder to read on a trip than on the route panel.

The symbols now narrow to the trip the same way they narrow under a route
isolation, over several lines at once. Each leg keeps its own stations at full
strength while the ribbons stay dimmed, their names and connection bullets come
with them, and the caterpillar bullets ride the span the leg actually rides —
not the rest of the line. Where portolan draws the leg that is portolan's own
lettering; where it does not, the stops fall back to the same
circles-and-names overlay the route panel already uses for a feed with no
pyramid.

### Notes

* `portolan-transit.service` gets `setTripLegs`, the multi-route sibling of
  `setIsolatedRoute` — it narrows the symbols only, never the ribbons, because
  portolan draws bundled routes at parallel slot offsets and lifting the leg's
  ribbon would land it beside the trip line rather than under it.
* Stations match a leg by its own stop list; bullets, which ride between stops,
  match the chain of them (`distanceToLine`, new in `lib/geo/geo-line`).
* The route panel's circles-and-names overlay moves to
  `transit-stop-overlay.ts` so both callers draw a stop the same way.